### PR TITLE
Error when Audio Input is in use by another app

### DIFF
--- a/ios/CameraError.swift
+++ b/ios/CameraError.swift
@@ -176,7 +176,7 @@ enum SessionError {
     case let .audioSessionSetupFailed(reason):
       return "The audio session failed to setup! \(reason)"
     case .audioInUseByOtherApp:
-      return "The audio session is already in use by another app!"
+      return "The audio session is already in use by another app with higher priority!"
     }
   }
 }

--- a/ios/CameraError.swift
+++ b/ios/CameraError.swift
@@ -154,6 +154,7 @@ enum FormatError {
 enum SessionError {
   case cameraNotReady
   case audioSessionSetupFailed(reason: String)
+  case audioInUseByOtherApp
 
   // MARK: Internal
 
@@ -163,6 +164,8 @@ enum SessionError {
       return "camera-not-ready"
     case .audioSessionSetupFailed:
       return "audio-session-setup-failed"
+    case .audioInUseByOtherApp:
+      return "audio-in-use-by-other-app"
     }
   }
 
@@ -172,6 +175,8 @@ enum SessionError {
       return "The Camera is not ready yet! Wait for the onInitialized() callback!"
     case let .audioSessionSetupFailed(reason):
       return "The audio session failed to setup! \(reason)"
+    case .audioInUseByOtherApp:
+      return "The audio session is already in use by another app!"
     }
   }
 }

--- a/ios/CameraView+AVAudioSession.swift
+++ b/ios/CameraView+AVAudioSession.swift
@@ -19,7 +19,7 @@ extension CameraView {
   final func configureAudioSession() {
     let start = DispatchTime.now()
     do {
-      try self.addAudioInput()
+      try addAudioInput()
       let audioSession = AVAudioSession.sharedInstance()
       if audioSession.category != .playAndRecord {
         // allow background music playback
@@ -31,7 +31,7 @@ extension CameraView {
       try audioSession.setActive(true)
     } catch let error as NSError {
       switch error.code {
-      case 561017449:
+      case 561_017_449:
         self.invokeOnError(.session(.audioInUseByOtherApp), cause: error)
       default:
         self.invokeOnError(.session(.audioSessionSetupFailed(reason: error.description)), cause: error)
@@ -42,16 +42,16 @@ extension CameraView {
     let nanoTime = end.uptimeNanoseconds - start.uptimeNanoseconds
     ReactLogger.log(level: .info, message: "Configured Audio session in \(Double(nanoTime) / 1_000_000)ms!")
   }
-  
+
   /**
    Configures the CaptureSession and adds the audio device if it has not already been added yet.
    */
   private final func addAudioInput() throws {
-    if self.audioDeviceInput != nil {
+    if audioDeviceInput != nil {
       // we already added the audio device, don't add it again
       return
     }
-    self.removeAudioInput()
+    removeAudioInput()
     captureSession.beginConfiguration()
     guard let audioDevice = AVCaptureDevice.default(for: .audio) else {
       throw CameraError.device(.microphoneUnavailable)
@@ -64,17 +64,17 @@ extension CameraView {
     captureSession.automaticallyConfiguresApplicationAudioSession = true
     captureSession.commitConfiguration()
   }
-  
+
   /**
    Configures the CaptureSession and removes the audio device if it has been added before.
    */
   private final func removeAudioInput() {
-    guard let audioInput = self.audioDeviceInput else {
+    guard let audioInput = audioDeviceInput else {
       return
     }
     captureSession.beginConfiguration()
     captureSession.removeInput(audioInput)
-    self.audioDeviceInput = nil
+    audioDeviceInput = nil
     captureSession.commitConfiguration()
   }
 
@@ -90,7 +90,7 @@ extension CameraView {
     case .began:
       // Something interrupted our Audio Session, stop recording audio.
       ReactLogger.log(level: .error, message: "The Audio Session was interrupted!")
-      self.removeAudioInput()
+      removeAudioInput()
     case .ended:
       ReactLogger.log(level: .error, message: "The Audio Session interruption has ended.")
       guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else { return }

--- a/ios/CameraView+AVAudioSession.swift
+++ b/ios/CameraView+AVAudioSession.swift
@@ -80,7 +80,7 @@ extension CameraView {
 
   @objc
   func audioSessionInterrupted(notification: Notification) {
-    ReactLogger.log(level: .error, message: "The Audio Session was interrupted!")
+    ReactLogger.log(level: .error, message: "Audio Session Interruption Notification!")
     guard let userInfo = notification.userInfo,
           let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
           let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
@@ -88,13 +88,15 @@ extension CameraView {
     }
     switch type {
     case .began:
-      // TODO: Should we also disable the camera here? I think it will throw a runtime error
-      // disable audio session
-      try? AVAudioSession.sharedInstance().setActive(false)
+      // Something interrupted our Audio Session, stop recording audio.
+      ReactLogger.log(level: .error, message: "The Audio Session was interrupted!")
+      self.removeAudioInput()
     case .ended:
+      ReactLogger.log(level: .error, message: "The Audio Session interruption has ended.")
       guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else { return }
       let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
       if options.contains(.shouldResume) {
+        ReactLogger.log(level: .error, message: "Resuming interrupted Audio Session...")
         // restart audio session because interruption is over
         configureAudioSession()
       } else {

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -73,24 +73,6 @@ extension CameraView {
       return invokeOnError(.device(.invalid))
     }
 
-    // Microphone (Audio Input)
-    do {
-      if let audioDeviceInput = self.audioDeviceInput {
-        captureSession.removeInput(audioDeviceInput)
-      }
-      guard let audioDevice = AVCaptureDevice.default(for: .audio) else {
-        return invokeOnError(.device(.microphoneUnavailable))
-      }
-
-      audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice)
-      guard captureSession.canAddInput(audioDeviceInput!) else {
-        return invokeOnError(.parameter(.unsupportedInput(inputDescriptor: "audio-input")))
-      }
-      captureSession.addInput(audioDeviceInput!)
-    } catch {
-      return invokeOnError(.device(.invalid))
-    }
-
     // OUTPUTS
     if let photoOutput = self.photoOutput {
       captureSession.removeOutput(photoOutput)

--- a/src/CameraError.ts
+++ b/src/CameraError.ts
@@ -20,7 +20,7 @@ export type FormatError =
   | 'format/invalid-low-light-boost'
   | 'format/invalid-format'
   | 'format/invalid-preset';
-export type SessionError = 'session/camera-not-ready' | 'session/audio-session-setup-failed';
+export type SessionError = 'session/camera-not-ready' | 'session/audio-session-setup-failed' | 'session/audio-in-use-by-other-app';
 export type CaptureError =
   | 'capture/invalid-photo-format'
   | 'capture/encoder-error'


### PR DESCRIPTION
## What

Throw an explicit error event when audio is in use by another app with higher priority (e.g. phone call): `audio-in-use-by-other-app`