### PR TITLE
Set `scaleType=FIT_CENTER` to avoid expensive takePhoto cropping

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -107,6 +107,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   init {
     previewView = PreviewView(context)
     previewView.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+    previewView.scaleType = PreviewView.ScaleType.FIT_CENTER // avoids cropping on takePhoto
     previewView.installHierarchyFitter() // If this is not called correctly, view finder will be black/blank
     addView(previewView)
 


### PR DESCRIPTION
<!-- ❤️ Thank you for your contribution! ❤️ -->

## What

By default, the `PreviewView` uses a scale type of `FILL_CENTER`. To make the photo look like the preview, CameraX automatically crops the image when `takePhoto()` gets called, which is a quite expensive operation. This can be skipped if the scaleType is either `FIT_START`, `FIT_CENTER` or `FIT_END`, and `FIT_CENTER` seems to be the best fit here.

Note; this actually visually changes the `PreviewView`, so I _probably_ need to manually calculate layout size to extend past the bounds, effectively simulating `FILL_CENTER` but by working around the post-photo cropping.

I'll have to evaluate if that's worth it.

## Changes

* Make PreviewView's scaleType `FIT_CENTER` instead of `FILL_CENTER`

## Side-effects

* [ ] This PR does not introduce any known side-effects.
* [x] This PR introduces the following side-effects: PreviewView looks different.

## Tested on

/

