### PR TITLE
Upgrade CameraX to 1.1.0-alpha04

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,10 +135,10 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.4.3"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3"
 
-  implementation "androidx.camera:camera-core:1.1.0-alpha03"
-  implementation "androidx.camera:camera-camera2:1.1.0-alpha03"
-  implementation "androidx.camera:camera-lifecycle:1.1.0-alpha03"
-  implementation "androidx.camera:camera-extensions:1.0.0-alpha23"
-  implementation "androidx.camera:camera-view:1.0.0-alpha23"
+  implementation "androidx.camera:camera-core:1.1.0-alpha04"
+  implementation "androidx.camera:camera-camera2:1.1.0-alpha04"
+  implementation "androidx.camera:camera-lifecycle:1.1.0-alpha04"
+  implementation "androidx.camera:camera-extensions:1.0.0-alpha24"
+  implementation "androidx.camera:camera-view:1.0.0-alpha24"
   implementation "androidx.exifinterface:exifinterface:1.3.2"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,7 +13,7 @@
 #Fri Feb 19 20:46:14 CET 2021
 VisionCamera_buildToolsVersion=30.0.0
 VisionCamera_compileSdkVersion=30
-VisionCamera_kotlinVersion=1.4.31
+VisionCamera_kotlinVersion=1.4.32
 VisionCamera_targetSdkVersion=30
 android.enableJetifier=true
 android.useAndroidX=true

--- a/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
@@ -1,7 +1,10 @@
 package com.mrousavy.camera
 
+import android.Manifest
 import android.annotation.SuppressLint
+import android.content.pm.PackageManager
 import androidx.camera.core.VideoCapture
+import androidx.core.content.ContextCompat
 import com.facebook.react.bridge.*
 import com.mrousavy.camera.utils.makeErrorMap
 import kotlinx.coroutines.*
@@ -9,11 +12,15 @@ import java.io.File
 
 data class TemporaryFile(val path: String)
 
-@SuppressLint("RestrictedApi")
+@SuppressLint("RestrictedApi", "MissingPermission")
 suspend fun CameraView.startRecording(options: ReadableMap, onRecordCallback: Callback): TemporaryFile {
   if (videoCapture == null) {
     throw CameraNotReadyError()
   }
+  if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+    throw MicrophonePermissionError()
+  }
+
   if (options.hasKey("flash")) {
     val enableFlash = options.getString("flash") == "on"
     // overrides current torch mode value to enable flash while recording

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -16,7 +16,7 @@ import java.io.File
 
 private const val TAG = "CameraView.performance"
 
-@SuppressLint("UnsafeExperimentalUsageError", "UnsafeOptInUsageError")
+@SuppressLint("UnsafeOptInUsageError")
 suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineScope {
   val startFunc = System.nanoTime()
   Log.d(CameraView.REACT_CLASS, "takePhoto() called")

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -16,7 +16,7 @@ import java.io.File
 
 private const val TAG = "CameraView.performance"
 
-@SuppressLint("UnsafeExperimentalUsageError")
+@SuppressLint("UnsafeExperimentalUsageError", "UnsafeOptInUsageError")
 suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineScope {
   val startFunc = System.nanoTime()
   Log.d(CameraView.REACT_CLASS, "takePhoto() called")

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -212,7 +212,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   /**
    * Configures the camera capture session. This should only be called when the camera device changes.
    */
-  @SuppressLint("UnsafeExperimentalUsageError", "RestrictedApi")
+  @SuppressLint("RestrictedApi")
   private suspend fun configureSession() {
     try {
       val startTime = System.currentTimeMillis()

--- a/android/src/main/java/com/mrousavy/camera/utils/CameraSelector+byID.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/CameraSelector+byID.kt
@@ -8,7 +8,7 @@ import java.lang.IllegalArgumentException
 /**
  * Create a new [CameraSelector] which selects the camera with the given [cameraId]
  */
-@SuppressLint("UnsafeExperimentalUsageError")
+@SuppressLint("UnsafeExperimentalUsageError", "UnsafeOptInUsageError")
 fun CameraSelector.Builder.byID(cameraId: String): CameraSelector.Builder {
   return this.addCameraFilter { cameras ->
     cameras.filter { cameraInfoX ->

--- a/android/src/main/java/com/mrousavy/camera/utils/CameraSelector+byID.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/CameraSelector+byID.kt
@@ -8,7 +8,7 @@ import java.lang.IllegalArgumentException
 /**
  * Create a new [CameraSelector] which selects the camera with the given [cameraId]
  */
-@SuppressLint("UnsafeExperimentalUsageError", "UnsafeOptInUsageError")
+@SuppressLint("UnsafeOptInUsageError")
 fun CameraSelector.Builder.byID(cameraId: String): CameraSelector.Builder {
   return this.addCameraFilter { cameras ->
     cameras.filter { cameraInfoX ->

--- a/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
@@ -33,7 +33,6 @@ fun flip(imageBytes: ByteArray, imageWidth: Int): ByteArray {
   return holder + subArray
 }
 
-@SuppressLint("UnsafeExperimentalUsageError")
 fun ImageProxy.save(file: File, flipHorizontally: Boolean) {
   when (format) {
     // TODO: ImageFormat.RAW_SENSOR


### PR DESCRIPTION
## Release Notes

* Fixed a memory leak caused by multiple threads concurrently accessing the same collection. The memory leak may cause the Activity or Fragment to be retained by a Preview instance. (I7b4b8)
* Replaced annotation @Experimental with @RequiresOptIn to experimental APIs. For calling experimental APIs, use androidx.annotation.OptIn instead of deprecated androidx.annotation.experimental.UseExperimental. (Iff226)
* Fixed ImageCapture with flash On/Auto takes washed out images on Samsung Galaxy S7. (I30001)
* Added a CameraState API that will be exposed through CameraInfo. (I75392)

> See [release notes](https://developer.android.com/jetpack/androidx/releases/camera#1.1.0-alpha04)

## Related PRs

* closes #122 
* closes #123 
* closes #124 
* closes #125 
* closes #126 