### PR TITLE
fix: Mirror selfies on Android

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -64,7 +64,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
       val startCapture = System.nanoTime()
       val pic = imageCapture.takePicture(takePhotoExecutor)
       val endCapture = System.nanoTime()
-      Log.d(CameraView.TAG_PERF, "Finished image capture in ${(endCapture - startCapture) / 1_000_000}ms")
+      Log.i(CameraView.TAG_PERF, "Finished image capture in ${(endCapture - startCapture) / 1_000_000}ms")
       pic
     },
     async(Dispatchers.IO) {
@@ -82,7 +82,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
     val milliseconds = measureTimeMillis {
       photo.save(file, lensFacing == CameraCharacteristics.LENS_FACING_FRONT)
     }
-    Log.d(CameraView.TAG_PERF, "Finished image saving in ${milliseconds}ms")
+    Log.i(CameraView.TAG_PERF, "Finished image saving in ${milliseconds}ms")
     // TODO: Read Exif from existing in-memory photo buffer instead of file?
     exif = if (skipMetadata) null else ExifInterface(file)
   }
@@ -101,6 +101,6 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   Log.d(CameraView.TAG, "Finished taking photo!")
 
   val endFunc = System.nanoTime()
-  Log.d(CameraView.TAG_PERF, "Finished function execution in ${(endFunc - startFunc) / 1_000_000}ms")
+  Log.i(CameraView.TAG_PERF, "Finished function execution in ${(endFunc - startFunc) / 1_000_000}ms")
   return@coroutineScope map
 }

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -18,7 +18,7 @@ import kotlin.system.measureTimeMillis
 @SuppressLint("UnsafeOptInUsageError")
 suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineScope {
   val startFunc = System.nanoTime()
-  Log.d(CameraView.REACT_CLASS, "takePhoto() called")
+  Log.d(CameraView.TAG, "takePhoto() called")
   val imageCapture = imageCapture ?: throw CameraNotReadyError()
 
   if (options.hasKey("flash")) {
@@ -60,15 +60,15 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
 
   val results = awaitAll(
     async(coroutineContext) {
-      Log.d(CameraView.REACT_CLASS, "Taking picture...")
+      Log.d(CameraView.TAG, "Taking picture...")
       val startCapture = System.nanoTime()
       val pic = imageCapture.takePicture(takePhotoExecutor)
       val endCapture = System.nanoTime()
-      Log.d(CameraView.REACT_CLASS_PERFORMANCE, "Finished image capture in ${(endCapture - startCapture) / 1_000_000}ms")
+      Log.d(CameraView.TAG_PERF, "Finished image capture in ${(endCapture - startCapture) / 1_000_000}ms")
       pic
     },
     async(Dispatchers.IO) {
-      Log.d(CameraView.REACT_CLASS, "Creating temp file...")
+      Log.d(CameraView.TAG, "Creating temp file...")
       File.createTempFile("mrousavy", ".jpg", context.cacheDir).apply { deleteOnExit() }
     }
   )
@@ -78,11 +78,11 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   val exif: ExifInterface?
   @Suppress("BlockingMethodInNonBlockingContext")
   withContext(Dispatchers.IO) {
-    Log.d(CameraView.REACT_CLASS, "Saving picture to ${file.absolutePath}...")
+    Log.d(CameraView.TAG, "Saving picture to ${file.absolutePath}...")
     val milliseconds = measureTimeMillis {
       photo.save(file, lensFacing == CameraCharacteristics.LENS_FACING_FRONT)
     }
-    Log.d(CameraView.REACT_CLASS_PERFORMANCE, "Finished image saving in ${milliseconds}ms")
+    Log.d(CameraView.TAG_PERF, "Finished image saving in ${milliseconds}ms")
     // TODO: Read Exif from existing in-memory photo buffer instead of file?
     exif = if (skipMetadata) null else ExifInterface(file)
   }
@@ -98,9 +98,9 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
 
   photo.close()
 
-  Log.d(CameraView.REACT_CLASS, "Finished taking photo!")
+  Log.d(CameraView.TAG, "Finished taking photo!")
 
   val endFunc = System.nanoTime()
-  Log.d(CameraView.REACT_CLASS_PERFORMANCE, "Finished function execution in ${(endFunc - startFunc) / 1_000_000}ms")
+  Log.d(CameraView.TAG_PERF, "Finished function execution in ${(endFunc - startFunc) / 1_000_000}ms")
   return@coroutineScope map
 }

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -56,7 +56,6 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
 
   val camera2Info = Camera2CameraInfo.from(camera!!.cameraInfo)
   val lensFacing = camera2Info.getCameraCharacteristic(CameraCharacteristics.LENS_FACING)
-  // TODO: Flip image if lens is front side - see https://github.com/cuvent/react-native-vision-camera/issues/74
 
   val results = awaitAll(
     async(coroutineContext) {
@@ -80,7 +79,8 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   withContext(Dispatchers.IO) {
     Log.d(CameraView.TAG, "Saving picture to ${file.absolutePath}...")
     val milliseconds = measureTimeMillis {
-      photo.save(file, lensFacing == CameraCharacteristics.LENS_FACING_FRONT)
+      val flipHorizontally = lensFacing == CameraCharacteristics.LENS_FACING_FRONT
+      photo.save(file, flipHorizontally)
     }
     Log.i(CameraView.TAG_PERF, "Finished image saving in ${milliseconds}ms")
     // TODO: Read Exif from existing in-memory photo buffer instead of file?

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -15,8 +15,6 @@ import kotlinx.coroutines.*
 import java.io.File
 import kotlin.system.measureTimeMillis
 
-private const val TAG = "CameraView.performance"
-
 @SuppressLint("UnsafeOptInUsageError")
 suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineScope {
   val startFunc = System.nanoTime()
@@ -66,7 +64,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
       val startCapture = System.nanoTime()
       val pic = imageCapture.takePicture(takePhotoExecutor)
       val endCapture = System.nanoTime()
-      Log.d(TAG, "Finished image capture in ${(endCapture - startCapture) / 1_000_000}ms")
+      Log.d(CameraView.REACT_CLASS_PERFORMANCE, "Finished image capture in ${(endCapture - startCapture) / 1_000_000}ms")
       pic
     },
     async(Dispatchers.IO) {
@@ -84,7 +82,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
     val milliseconds = measureTimeMillis {
       photo.save(file, lensFacing == CameraCharacteristics.LENS_FACING_FRONT)
     }
-    Log.d(TAG, "Finished image saving in ${milliseconds}ms")
+    Log.d(CameraView.REACT_CLASS_PERFORMANCE, "Finished image saving in ${milliseconds}ms")
     // TODO: Read Exif from existing in-memory photo buffer instead of file?
     exif = if (skipMetadata) null else ExifInterface(file)
   }
@@ -103,6 +101,6 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   Log.d(CameraView.REACT_CLASS, "Finished taking photo!")
 
   val endFunc = System.nanoTime()
-  Log.d(TAG, "Finished function execution in ${(endFunc - startFunc) / 1_000_000}ms")
+  Log.d(CameraView.REACT_CLASS_PERFORMANCE, "Finished function execution in ${(endFunc - startFunc) / 1_000_000}ms")
   return@coroutineScope map
 }

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.WritableMap
 import com.mrousavy.camera.utils.*
 import kotlinx.coroutines.*
 import java.io.File
+import kotlin.system.measureTimeMillis
 
 private const val TAG = "CameraView.performance"
 
@@ -80,10 +81,10 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   @Suppress("BlockingMethodInNonBlockingContext")
   withContext(Dispatchers.IO) {
     Log.d(CameraView.REACT_CLASS, "Saving picture to ${file.absolutePath}...")
-    val startSave = System.nanoTime()
-    photo.save(file, lensFacing == CameraCharacteristics.LENS_FACING_FRONT)
-    val endSave = System.nanoTime()
-    Log.d(TAG, "Finished image saving in ${(endSave - startSave) / 1_000_000}ms")
+    val milliseconds = measureTimeMillis {
+      photo.save(file, lensFacing == CameraCharacteristics.LENS_FACING_FRONT)
+    }
+    Log.d(TAG, "Finished image saving in ${milliseconds}ms")
     // TODO: Read Exif from existing in-memory photo buffer instead of file?
     exif = if (skipMetadata) null else ExifInterface(file)
   }

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -379,6 +379,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
 
   companion object {
     const val REACT_CLASS = "CameraView"
+    const val REACT_CLASS_PERFORMANCE = "CameraView.performance"
 
     private val propsThatRequireSessionReconfiguration = arrayListOf("cameraId", "format", "fps", "hdr", "lowLightBoost")
 

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -161,7 +161,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
       // Host Lifecycle (Activity) is currently inactive (STARTED or DESTROYED), so that overrules our view's lifecycle
       lifecycleRegistry.currentState = hostLifecycleState
     }
-    Log.d(REACT_CLASS, "Lifecycle went from ${lifecycleBefore.name} -> ${lifecycleRegistry.currentState.name} (isActive: $isActive | isAttachedToWindow: $isAttachedToWindow)")
+    Log.d(TAG, "Lifecycle went from ${lifecycleBefore.name} -> ${lifecycleRegistry.currentState.name} (isActive: $isActive | isAttachedToWindow: $isAttachedToWindow)")
   }
 
   override fun onAttachedToWindow() {
@@ -216,7 +216,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   private suspend fun configureSession() {
     try {
       val startTime = System.currentTimeMillis()
-      Log.i(REACT_CLASS, "Configuring session...")
+      Log.i(TAG, "Configuring session...")
       if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
         throw MicrophonePermissionError()
       }
@@ -227,9 +227,9 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
         throw NoCameraDeviceError()
       }
       if (format != null)
-        Log.i(REACT_CLASS, "Configuring session with Camera ID $cameraId and custom format...")
+        Log.i(TAG, "Configuring session with Camera ID $cameraId and custom format...")
       else
-        Log.i(REACT_CLASS, "Configuring session with Camera ID $cameraId and default format options...")
+        Log.i(TAG, "Configuring session with Camera ID $cameraId and default format options...")
 
       // Used to bind the lifecycle of cameras to the lifecycle owner
       val cameraProvider = ProcessCameraProvider.getInstance(reactContext).await()
@@ -248,7 +248,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
 
       if (format == null) {
         // let CameraX automatically find best resolution for the target aspect ratio
-        Log.i(REACT_CLASS, "No custom format has been set, CameraX will automatically determine best configuration...")
+        Log.i(TAG, "No custom format has been set, CameraX will automatically determine best configuration...")
         val aspectRatio = aspectRatio(previewView.width, previewView.height)
         previewBuilder.setTargetAspectRatio(aspectRatio)
         imageCaptureBuilder.setTargetAspectRatio(aspectRatio)
@@ -256,7 +256,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
       } else {
         // User has selected a custom format={}. Use that
         val format = DeviceFormat(format!!)
-        Log.i(REACT_CLASS, "Using custom format - photo: ${format.photoSize}, video: ${format.videoSize} @ $fps FPS")
+        Log.i(TAG, "Using custom format - photo: ${format.photoSize}, video: ${format.videoSize} @ $fps FPS")
         previewBuilder.setDefaultResolution(format.photoSize)
         imageCaptureBuilder.setDefaultResolution(format.photoSize)
         videoCaptureBuilder.setDefaultResolution(format.photoSize)
@@ -266,7 +266,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
             // Camera supports the given FPS (frame rate range)
             val frameDuration = (1.0 / fps.toDouble()).toLong() * 1_000_000_000
 
-            Log.i(REACT_CLASS, "Setting AE_TARGET_FPS_RANGE to $fps-$fps, and SENSOR_FRAME_DURATION to $frameDuration")
+            Log.i(TAG, "Setting AE_TARGET_FPS_RANGE to $fps-$fps, and SENSOR_FRAME_DURATION to $frameDuration")
             Camera2Interop.Extender(previewBuilder)
               .setCaptureRequestOption(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Range(fps, fps))
               .setCaptureRequestOption(CaptureRequest.SENSOR_FRAME_DURATION, frameDuration)
@@ -283,11 +283,11 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
             val isExtensionAvailable = imageExtension.isExtensionAvailable(cameraSelector) &&
               previewExtension.isExtensionAvailable(cameraSelector)
             if (isExtensionAvailable) {
-              Log.i(REACT_CLASS, "Enabling native HDR extension...")
+              Log.i(TAG, "Enabling native HDR extension...")
               imageExtension.enableExtension(cameraSelector)
               previewExtension.enableExtension(cameraSelector)
             } else {
-              Log.e(REACT_CLASS, "Native HDR vendor extension not available!")
+              Log.e(TAG, "Native HDR vendor extension not available!")
               throw HdrNotContainedInFormatError()
             }
           }
@@ -299,11 +299,11 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
             val isExtensionAvailable = imageExtension.isExtensionAvailable(cameraSelector) &&
               previewExtension.isExtensionAvailable(cameraSelector)
             if (isExtensionAvailable) {
-              Log.i(REACT_CLASS, "Enabling native night-mode extension...")
+              Log.i(TAG, "Enabling native night-mode extension...")
               imageExtension.enableExtension(cameraSelector)
               previewExtension.enableExtension(cameraSelector)
             } else {
-              Log.e(REACT_CLASS, "Native night-mode vendor extension not available!")
+              Log.e(TAG, "Native night-mode vendor extension not available!")
               throw LowLightBoostNotContainedInFormatError()
             }
           }
@@ -325,7 +325,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
       maxZoom = camera!!.cameraInfo.zoomState.value?.maxZoomRatio ?: 1f
 
       val duration = System.currentTimeMillis() - startTime
-      Log.i(REACT_CLASS, "Session configured in $duration ms! Camera: ${camera!!}")
+      Log.i(TAG_PERF, "Session configured in $duration ms! Camera: ${camera!!}")
       invokeOnInitialized()
     } catch (exc: Throwable) {
       throw when (exc) {
@@ -348,7 +348,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
 
   override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
     super.onLayout(changed, left, top, right, bottom)
-    Log.i(REACT_CLASS, "onLayout($changed, $left, $top, $right, $bottom) was called! (Width: $width, Height: $height)")
+    Log.i(TAG, "onLayout($changed, $left, $top, $right, $bottom) was called! (Width: $width, Height: $height)")
   }
 
   private fun invokeOnInitialized() {
@@ -378,8 +378,8 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   }
 
   companion object {
-    const val REACT_CLASS = "CameraView"
-    const val REACT_CLASS_PERFORMANCE = "CameraView.performance"
+    const val TAG = "CameraView"
+    const val TAG_PERF = "CameraView.performance"
 
     private val propsThatRequireSessionReconfiguration = arrayListOf("cameraId", "format", "fps", "hdr", "lowLightBoost")
 

--- a/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
@@ -6,6 +6,7 @@ import android.graphics.ImageFormat
 import android.graphics.Matrix
 import android.util.Log
 import androidx.camera.core.ImageProxy
+import com.mrousavy.camera.CameraView
 import com.mrousavy.camera.InvalidFormatError
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -61,12 +62,12 @@ fun ImageProxy.save(file: File, flipHorizontally: Boolean) {
       // copy image from buffer to byte array
       buffer.get(bytes)
 
-      val milliseconds = measureTimeMillis {
-        if (flipHorizontally) {
+      if (flipHorizontally) {
+        val milliseconds = measureTimeMillis {
           bytes = flipImage(bytes)
         }
+        Log.i(CameraView.REACT_CLASS_PERFORMANCE, "Flipping Image took $milliseconds ms.")
       }
-      Log.i("VISION_CAMERA", "Flipping Image took $milliseconds ms.")
 
       val output = FileOutputStream(file)
       output.write(bytes)

--- a/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
@@ -66,7 +66,7 @@ fun ImageProxy.save(file: File, flipHorizontally: Boolean) {
         val milliseconds = measureTimeMillis {
           bytes = flipImage(bytes)
         }
-        Log.i(CameraView.REACT_CLASS_PERFORMANCE, "Flipping Image took $milliseconds ms.")
+        Log.i(CameraView.TAG_PERF, "Flipping Image took $milliseconds ms.")
       }
 
       val output = FileOutputStream(file)

--- a/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
@@ -1,12 +1,18 @@
 package com.mrousavy.camera.utils
 
-import android.annotation.SuppressLint
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.ImageFormat
+import android.graphics.Matrix
+import android.util.Log
 import androidx.camera.core.ImageProxy
 import com.mrousavy.camera.InvalidFormatError
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.nio.ByteBuffer
+import kotlin.system.measureTimeMillis
+
 
 // TODO: Fix this flip() function (this outputs a black image)
 fun flip(imageBytes: ByteArray, imageWidth: Int): ByteArray {
@@ -33,16 +39,34 @@ fun flip(imageBytes: ByteArray, imageWidth: Int): ByteArray {
   return holder + subArray
 }
 
+// TODO: This function is slow. Figure out a faster way to flip images, preferably via directly manipulating the byte[] Exif flags
+fun flipImage(imageBytes: ByteArray): ByteArray {
+  val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+  val matrix = Matrix()
+  matrix.preScale(-1f, 1f)
+  val newBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+  val stream = ByteArrayOutputStream()
+  newBitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+  return stream.toByteArray()
+}
+
 fun ImageProxy.save(file: File, flipHorizontally: Boolean) {
   when (format) {
     // TODO: ImageFormat.RAW_SENSOR
     // TODO: ImageFormat.DEPTH_JPEG
     ImageFormat.JPEG -> {
       val buffer = planes[0].buffer
-      val bytes = ByteArray(buffer.remaining())
+      var bytes = ByteArray(buffer.remaining())
 
       // copy image from buffer to byte array
       buffer.get(bytes)
+
+      val milliseconds = measureTimeMillis {
+        if (flipHorizontally) {
+          bytes = flipImage(bytes)
+        }
+      }
+      Log.i("VISION_CAMERA", "Flipping Image took $milliseconds ms.")
 
       val output = FileOutputStream(file)
       output.write(bytes)


### PR DESCRIPTION
<!-- ❤️ Thank you for your contribution! ❤️ -->

## What

This PR automatically horizontally flips (= mirrors) images taken from the front camera.

It is achieved by decoding the received `byte[]` to a `Bitmap`, applying a Matrix with a scaleX of `-1`, then converting it back to a `byte[]`. I am not fully happy with that approach, as I'd like to avoid the `byte[]` -> `Bitmap` -> `byte[]` approach if possible.

Benchmarks show that horizontally flipping an image takes ~24ms on my Huawai P10.

Back camera (no flipping):

```
2021-05-03 18:57:54.478 31448-31448/com.mrousavy.camera.example I/CameraView.performance: Session configured in 200 ms! Camera: androidx.camera.lifecycle.LifecycleCamera@c475d4
2021-05-03 18:58:17.609 31448-31729/com.mrousavy.camera.example I/CameraView.performance: Finished creating temp file in 1ms
2021-05-03 18:58:18.028 31448-31448/com.mrousavy.camera.example I/CameraView.performance: Finished image capture in 413ms
2021-05-03 18:58:18.033 31448-31729/com.mrousavy.camera.example I/CameraView.performance: Finished image saving in 3ms
2021-05-03 18:58:18.035 31448-31448/com.mrousavy.camera.example I/CameraView.performance: Finished function execution in 444ms
```

Front camera (flipping):

```
2021-05-03 18:58:50.155 31448-31448/com.mrousavy.camera.example I/CameraView.performance: Session configured in 129 ms! Camera: androidx.camera.lifecycle.LifecycleCamera@4e5ccc6
2021-05-03 18:58:52.032 31448-31729/com.mrousavy.camera.example I/CameraView.performance: Finished creating temp file in 2ms
2021-05-03 18:58:52.345 31448-31448/com.mrousavy.camera.example I/CameraView.performance: Finished image capture in 314ms
2021-05-03 18:58:52.379 31448-31729/com.mrousavy.camera.example I/CameraView.performance: Flipping Image took 31 ms.
2021-05-03 18:58:52.380 31448-31729/com.mrousavy.camera.example I/CameraView.performance: Finished image saving in 33ms
2021-05-03 18:58:52.381 31448-31448/com.mrousavy.camera.example I/CameraView.performance: Finished function execution in 353ms
```

## Changes

- Add `flipImage` to ImageProxy+save - a function that flips the given byte[].
- Call `flipImage` in ImageProxy+save when `flipHorizontally` ist true

## Side-effects

- Taking selfies takes a few milliseconds longer (~24ms on my Huawai P10)

## Tested on

- Huawai P10

## Related issues

Closes #74 