### PR TITLE
feat: Support LEGACY camera devices

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -113,17 +113,6 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
           val imageCaptureBuilder = ImageCapture.Builder()
 
           val characteristics = manager.getCameraCharacteristics(id)
-          val hardwareLevel = characteristics.get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL)!!
-
-          // Filters out cameras that are LEGACY hardware level. Those don't support Preview + Photo Capture + Video Capture at the same time.
-          if (hardwareLevel == CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
-            Log.i(
-              REACT_CLASS,
-              "Skipping Camera #$id because it does not meet the minimum requirements for react-native-vision-camera. " +
-                "See the tables at https://developer.android.com/reference/android/hardware/camera2/CameraDevice#regular-capture for more information."
-            )
-            return@loop
-          }
 
           val capabilities = characteristics.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES)!!
           val isMultiCam = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&


### PR DESCRIPTION
<!-- ❤️ Thank you for your contribution! ❤️ -->

## What

Cameras that report the "LEGACY" hardware level technically also support up to three use-cases:

![Screenshot 2021-05-10 at 09 52 23](https://user-images.githubusercontent.com/15199031/117624659-6e045600-b175-11eb-8e32-b19d23a28dbd.png)

So that's "preview", "photo-capture" and "video-capture", even though "video-capture" will be in low-resolution (= "preview" resolution).

This PR adds support for LEGACY camera devices.

## Changes

* Also return LEGACY devices in `getAvailableCameraDevices`

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

Fixes #127 
