### PR TITLE
Resolve missing permission errors confusion

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -218,10 +218,10 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
       val startTime = System.currentTimeMillis()
       Log.i(TAG, "Configuring session...")
       if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-        throw MicrophonePermissionError()
+        throw CameraPermissionError()
       }
       if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-        throw CameraPermissionError()
+        throw MicrophonePermissionError()
       }
       if (cameraId == null) {
         throw NoCameraDeviceError()


### PR DESCRIPTION
## What

Currently the library reports camera permission denied error if mic permission was not granted and vice versa.
So this PR fixes a typo in a CameraView.kt

## Changes

* Swapped permission errors to throw.

## Tested on

* iPhone 11 , iOS 14.3
* Nokia 5.3, Android 10

## Related issues

 * Resolves #162