### PR TITLE
feat: Separate usecases (decouple microphone, video, photo)

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
@@ -15,10 +15,18 @@ data class TemporaryFile(val path: String)
 @SuppressLint("RestrictedApi", "MissingPermission")
 suspend fun CameraView.startRecording(options: ReadableMap, onRecordCallback: Callback): TemporaryFile {
   if (videoCapture == null) {
-    throw CameraNotReadyError()
+    if (video == true) {
+      throw CameraNotReadyError()
+    } else {
+      throw VideoNotEnabledError()
+    }
   }
-  if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-    throw MicrophonePermissionError()
+
+  // check audio permission
+  if (audio == true) {
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+      throw MicrophonePermissionError()
+    }
   }
 
   if (options.hasKey("flash")) {

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -19,11 +19,17 @@ import kotlin.system.measureTimeMillis
 suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineScope {
   val startFunc = System.nanoTime()
   Log.d(CameraView.TAG, "takePhoto() called")
-  val imageCapture = imageCapture ?: throw CameraNotReadyError()
+  if (imageCapture == null) {
+    if (photo == true) {
+      throw CameraNotReadyError()
+    } else {
+      throw PhotoNotEnabledError()
+    }
+  }
 
   if (options.hasKey("flash")) {
     val flashMode = options.getString("flash")
-    imageCapture.flashMode = when (flashMode) {
+    imageCapture!!.flashMode = when (flashMode) {
       "on" -> ImageCapture.FLASH_MODE_ON
       "off" -> ImageCapture.FLASH_MODE_OFF
       "auto" -> ImageCapture.FLASH_MODE_AUTO
@@ -61,7 +67,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
     async(coroutineContext) {
       Log.d(CameraView.TAG, "Taking picture...")
       val startCapture = System.nanoTime()
-      val pic = imageCapture.takePicture(takePhotoExecutor)
+      val pic = imageCapture!!.takePicture(takePhotoExecutor)
       val endCapture = System.nanoTime()
       Log.i(CameraView.TAG_PERF, "Finished image capture in ${(endCapture - startCapture) / 1_000_000}ms")
       pic

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -23,6 +23,27 @@ class CameraViewManager : SimpleViewManager<CameraView>() {
     view.cameraId = cameraId
   }
 
+  @ReactProp(name = "photo")
+  fun setPhoto(view: CameraView, photo: Boolean?) {
+    if (view.photo != photo)
+      addChangedPropToTransaction(view, "photo")
+    view.photo = photo
+  }
+
+  @ReactProp(name = "video")
+  fun setVideo(view: CameraView, video: Boolean?) {
+    if (view.video != video)
+      addChangedPropToTransaction(view, "video")
+    view.video = video
+  }
+
+  @ReactProp(name = "audio")
+  fun setAudio(view: CameraView, audio: Boolean?) {
+    if (view.audio != audio)
+      addChangedPropToTransaction(view, "audio")
+    view.audio = audio
+  }
+
   @ReactProp(name = "enableDepthData")
   fun setEnableDepthData(view: CameraView, enableDepthData: Boolean) {
     if (view.enableDepthData != enableDepthData)

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -63,11 +63,16 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
   }
 
   // TODO: startRecording() cannot be awaited, because I can't have a Promise and a onRecordedCallback in the same function. Hopefully TurboModules allows that
-  @ReactMethod(isBlockingSynchronousMethod = true)
+  @ReactMethod
   fun startRecording(viewTag: Int, options: ReadableMap, onRecordCallback: Callback) {
     GlobalScope.launch(Dispatchers.Main) {
       val view = findCameraView(viewTag)
-      view.startRecording(options, onRecordCallback)
+      try {
+        view.startRecording(options, onRecordCallback)
+      } catch (error: CameraError) {
+        val map = makeErrorMap("${error.domain}/${error.id}", error.message, error)
+        onRecordCallback(null, map)
+      }
     }
   }
 

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -72,6 +72,9 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
       } catch (error: CameraError) {
         val map = makeErrorMap("${error.domain}/${error.id}", error.message, error)
         onRecordCallback(null, map)
+      } catch (error: Throwable) {
+        val map = makeErrorMap("capture/unknown", "An unknown error occured while trying to start a video recording!", error)
+        onRecordCallback(null, map)
       }
     }
   }

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -115,16 +115,6 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
           val characteristics = manager.getCameraCharacteristics(id)
           val hardwareLevel = characteristics.get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL)!!
 
-          // Filters out cameras that are LEGACY hardware level. Those don't support Preview + Photo Capture + Video Capture at the same time.
-          if (hardwareLevel == CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
-            Log.i(
-              REACT_CLASS,
-              "Skipping Camera #$id because it does not meet the minimum requirements for react-native-vision-camera. " +
-                "See the tables at https://developer.android.com/reference/android/hardware/camera2/CameraDevice#regular-capture for more information."
-            )
-            return@loop
-          }
-
           val capabilities = characteristics.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES)!!
           val isMultiCam = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
             capabilities.contains(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES_LOGICAL_MULTI_CAMERA)
@@ -162,6 +152,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
           map.putBoolean("hasFlash", hasFlash)
           map.putBoolean("hasTorch", hasFlash)
           map.putBoolean("isMultiCam", isMultiCam)
+          map.putBoolean("supportsPhotoAndVideoCapture", hardwareLevel != CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY)
           map.putBoolean("supportsRawCapture", supportsRawCapture)
           map.putBoolean("supportsDepthCapture", supportsDepthCapture)
           map.putBoolean("supportsLowLightBoost", supportsLowLightBoost)

--- a/android/src/main/java/com/mrousavy/camera/Errors.kt
+++ b/android/src/main/java/com/mrousavy/camera/Errors.kt
@@ -30,7 +30,7 @@ abstract class CameraError(
 val CameraError.code: String
   get() = "$domain/$id"
 
-class MicrophonePermissionError : CameraError("permission", "microphone-permission-denied", "The Microphone permission was denied!")
+class MicrophonePermissionError : CameraError("permission", "microphone-permission-denied", "The Microphone permission was denied! If you want to record Video without sound, pass `audio={false}`.")
 class CameraPermissionError : CameraError("permission", "camera-permission-denied", "The Camera permission was denied!")
 
 class InvalidTypeScriptUnionError(unionName: String, unionValue: String) : CameraError("parameter", "invalid-parameter", "The given value for $unionName could not be parsed! (Received: $unionValue)")
@@ -51,6 +51,9 @@ class LowLightBoostNotContainedInFormatError() : CameraError(
 )
 
 class CameraNotReadyError : CameraError("session", "camera-not-ready", "The Camera is not ready yet! Wait for the onInitialized() callback!")
+
+class VideoNotEnabledError : CameraError("capture", "video-not-enabled", "Video capture is disabled! Pass `video={true}` to enable video recordings.")
+class PhotoNotEnabledError : CameraError("capture", "photo-not-enabled", "Photo capture is disabled! Pass `photo={true}` to enable photo capture.")
 
 class InvalidFormatError(format: Int) : CameraError("capture", "invalid-photo-format", "The Photo has an invalid format! Expected ${ImageFormat.YUV_420_888}, actual: $format")
 class VideoEncoderError(message: String, cause: Throwable? = null) : CameraError("capture", "encoder-error", message, cause)

--- a/docs/docs/guides/CAPTURING.mdx
+++ b/docs/docs/guides/CAPTURING.mdx
@@ -40,7 +40,13 @@ The most important actions are:
 
 ## Taking Photos
 
-To take a photo, simply use the Camera's [`takePhoto(...)`](../api/classes/camera.camera-1#takephoto) function:
+To take a photo you first have to enable photo capture:
+
+```tsx
+<Camera {...props} photo={true} />
+```
+
+Then, simply use the Camera's [`takePhoto(...)`](../api/classes/camera.camera-1#takephoto) function:
 
 ```ts
 const photo = await camera.current.takePhoto({
@@ -71,9 +77,23 @@ const snapshot = await camera.current.takeSnapshot({
 While taking snapshots is faster than taking photos, the resulting image has way lower quality. You can combine both functions to create a snapshot to present to the user at first, then deliver the actual high-res photo afterwards.
 :::
 
+:::note
+The `takeSnapshot` function also works with `photo={false}`. For this reason, devices that do not support photo and video capture at the same time can use `video={true}` and fall back to snapshot capture for photos.
+:::
+
 ## Recording Videos
 
-To start a video recording, use the Camera's [`startRecording(...)`](../api/classes/camera.camera-1#startrecording) function:
+To start a video recording you first have to enable video capture:
+
+```tsx
+<Camera
+  {...props}
+  video={true}
+  audio={true} // <-- optional
+  />
+```
+
+Then, simply use the Camera's [`startRecording(...)`](../api/classes/camera.camera-1#startrecording) function:
 
 ```ts
 camera.current.startRecording({

--- a/docs/docs/guides/CAPTURING.mdx
+++ b/docs/docs/guides/CAPTURING.mdx
@@ -105,10 +105,6 @@ camera.current.startRecording({
 
 For any error that occured _while recording the video_, the `onRecordingError` callback will be invoked with a [`CaptureError`](../api/classes/cameraerror.cameracaptureerror) and the recording is therefore cancelled.
 
-:::note
-Due to limitations of the React Native Bridge, this function can not be awaited. This means, any errors thrown while trying to start the recording (e.g. `capture/recording-in-progress`) can only be caught synchronously (`isBlockingSynchronousMethod`). This will change with the upcoming React Native Re-Architecture.
-:::
-
 To stop the video recording, you can call [`stopRecording(...)`](../api/classes/camera.camera-1#stoprecording):
 
 ```ts

--- a/docs/docs/guides/DEVICES.mdx
+++ b/docs/docs/guides/DEVICES.mdx
@@ -60,7 +60,7 @@ The `CameraDevice` type also contains other useful information describing a came
 Make sure to be careful when filtering out unneeded camera devices, since not every phone supports all camera device types. Some phones don't even have front-cameras. You always want to have a camera device, even when it's not the one that has the best features.
 :::
 
-### `useCameraDevices` hook
+### The `useCameraDevices` hook
 
 The react-native-vision-camera library provides a hook to make camera device selection a lot easier.
 
@@ -99,6 +99,14 @@ function App() {
   )
 }
 ```
+
+### The `supportsPhotoAndVideoCapture` prop
+
+Camera devices provide the `supportsPhotoAndVideoCapture` property which determines whether the device allows enabling photo- and video-capture at the same time. While every iOS device supports this feature, there are some older Android devices which only allow enabling one of each - either photo capture or video capture. (Those are `LEGACY` devices, see [this table](https://developer.android.com/reference/android/hardware/camera2/CameraDevice#regular-capture).)
+
+:::note
+If you need photo- and video-capture for devices where `supportsPhotoAndVideoCapture` is `false`, you can fall back to snapshot capture (see [**"Taking Snapshots"**](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing#taking-snapshots)) instead.
+:::
 
 ### The `isActive` prop
 

--- a/example/src/CameraPage.tsx
+++ b/example/src/CameraPage.tsx
@@ -209,6 +209,9 @@ export const CameraPage: NavigationFunctionComponent = ({ componentId }) => {
                 onError={onError}
                 enableZoomGesture={false}
                 animatedProps={cameraAnimatedProps}
+                photo={true}
+                video={true}
+                audio={true}
                 // frameProcessor={frameProcessor}
                 // frameProcessorFps={1}
               />

--- a/example/src/Splash.tsx
+++ b/example/src/Splash.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import type { ImageRequireSource } from 'react-native';
+import { ImageRequireSource, Linking } from 'react-native';
 
 import { StyleSheet, View, Text, Image } from 'react-native';
 import { Navigation, NavigationFunctionComponent } from 'react-native-navigation';
@@ -17,6 +17,8 @@ export const Splash: NavigationFunctionComponent = ({ componentId }) => {
     console.log('Requesting microphone permission...');
     const permission = await Camera.requestMicrophonePermission();
     console.log(`Microphone permission status: ${permission}`);
+
+    if (permission === 'denied') Linking.openSettings();
     setMicrophonePermissionStatus(permission);
   }, []);
 
@@ -24,6 +26,8 @@ export const Splash: NavigationFunctionComponent = ({ componentId }) => {
     console.log('Requesting camera permission...');
     const permission = await Camera.requestCameraPermission();
     console.log(`Camera permission status: ${permission}`);
+
+    if (permission === 'denied') Linking.openSettings();
     setCameraPermissionStatus(permission);
   }, []);
 
@@ -43,14 +47,14 @@ export const Splash: NavigationFunctionComponent = ({ componentId }) => {
   }, []);
 
   useEffect(() => {
-    if (cameraPermissionStatus === 'authorized' && microphonePermissionStatus === 'authorized') {
+    if (cameraPermissionStatus === 'authorized' && microphonePermissionStatus !== 'not-determined') {
       Navigation.setRoot({
         root: {
           stack: {
             children: [
               {
                 component: {
-                  name: 'Home',
+                  name: 'CameraPage',
                 },
               },
             ],
@@ -73,7 +77,7 @@ export const Splash: NavigationFunctionComponent = ({ componentId }) => {
             </Text>
           </Text>
         )}
-        {microphonePermissionStatus !== 'authorized' && (
+        {microphonePermissionStatus === 'not-determined' && (
           <Text style={styles.permissionText}>
             Vision Camera needs <Text style={styles.bold}>Microphone permission</Text>.
             <Text style={styles.hyperlink} onPress={requestMicrophonePermission}>

--- a/ios/CameraError.swift
+++ b/ios/CameraError.swift
@@ -21,7 +21,7 @@ enum PermissionError: String {
   var message: String {
     switch self {
     case .microphone:
-      return "The Microphone permission was denied!"
+      return "The Microphone permission was denied! If you want to record Videos without sound, pass `audio={false}`."
     case .camera:
       return "The Camera permission was denied!"
     }

--- a/ios/CameraError.swift
+++ b/ios/CameraError.swift
@@ -186,6 +186,8 @@ enum CaptureError {
   case createTempFileError
   case createRecorderError(message: String? = nil)
   case invalidPhotoCodec
+  case videoNotEnabled
+  case photoNotEnabled
   case unknown(message: String? = nil)
 
   var code: String {
@@ -204,6 +206,10 @@ enum CaptureError {
       return "create-recorder-error"
     case .invalidPhotoCodec:
       return "invalid-photo-codec"
+    case .videoNotEnabled:
+      return "video-not-enabled"
+    case .photoNotEnabled:
+      return "photo-not-enabled"
     case .unknown:
       return "unknown"
     }
@@ -225,6 +231,10 @@ enum CaptureError {
       return "Failed to create a temporary file!"
     case let .createRecorderError(message: message):
       return "Failed to create the AVAssetWriter (Recorder)! \(message ?? "(no additional message)")"
+    case .videoNotEnabled:
+      return "Video capture is disabled! Pass `video={true}` to enable video recordings."
+    case .photoNotEnabled:
+      return "Photo capture is disabled! Pass `photo={true}` to enable photo capture."
     case let .unknown(message: message):
       return message ?? "An unknown error occured while capturing a video/photo."
     }

--- a/ios/CameraQueues.swift
+++ b/ios/CameraQueues.swift
@@ -23,7 +23,6 @@ public class CameraQueues: NSObject {
                                                      autoreleaseFrequency: .inherit,
                                                      target: nil)
 
-  // TODO: Is it a good idea to use a separate queue for audio output processing?
   /// The serial execution queue for output processing of audio buffers.
   @objc public static let audioQueue = DispatchQueue(label: "com.mrousavy.vision.audio-queue",
                                                      qos: .userInteractive,

--- a/ios/CameraView+AVAudioSession.swift
+++ b/ios/CameraView+AVAudioSession.swift
@@ -25,6 +25,15 @@ extension CameraView {
     }
 
     audioCaptureSession.automaticallyConfiguresApplicationAudioSession = false
+    let enableAudio = self.audio?.boolValue == true
+    
+    // check microphone permission
+    if enableAudio {
+      let audioPermissionStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+      if audioPermissionStatus != .authorized {
+        return invokeOnError(.permission(.microphone))
+      }
+    }
 
     // Audio Input
     do {
@@ -32,15 +41,17 @@ extension CameraView {
         audioCaptureSession.removeInput(audioDeviceInput)
         self.audioDeviceInput = nil
       }
-      ReactLogger.log(level: .info, message: "Adding Audio input...")
-      guard let audioDevice = AVCaptureDevice.default(for: .audio) else {
-        return invokeOnError(.device(.microphoneUnavailable))
+      if enableAudio {
+        ReactLogger.log(level: .info, message: "Adding Audio input...")
+        guard let audioDevice = AVCaptureDevice.default(for: .audio) else {
+          return invokeOnError(.device(.microphoneUnavailable))
+        }
+        audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice)
+        guard audioCaptureSession.canAddInput(audioDeviceInput!) else {
+          return invokeOnError(.parameter(.unsupportedInput(inputDescriptor: "audio-input")))
+        }
+        audioCaptureSession.addInput(audioDeviceInput!)
       }
-      audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice)
-      guard audioCaptureSession.canAddInput(audioDeviceInput!) else {
-        return invokeOnError(.parameter(.unsupportedInput(inputDescriptor: "audio-input")))
-      }
-      audioCaptureSession.addInput(audioDeviceInput!)
     } catch let error as NSError {
       return invokeOnError(.device(.microphoneUnavailable), cause: error)
     }
@@ -50,13 +61,15 @@ extension CameraView {
       audioCaptureSession.removeOutput(audioOutput)
       self.audioOutput = nil
     }
-    ReactLogger.log(level: .info, message: "Adding Audio Data output...")
-    audioOutput = AVCaptureAudioDataOutput()
-    guard audioCaptureSession.canAddOutput(audioOutput!) else {
-      return invokeOnError(.parameter(.unsupportedOutput(outputDescriptor: "audio-output")))
+    if enableAudio {
+      ReactLogger.log(level: .info, message: "Adding Audio Data output...")
+      audioOutput = AVCaptureAudioDataOutput()
+      guard audioCaptureSession.canAddOutput(audioOutput!) else {
+        return invokeOnError(.parameter(.unsupportedOutput(outputDescriptor: "audio-output")))
+      }
+      audioOutput!.setSampleBufferDelegate(self, queue: audioQueue)
+      audioCaptureSession.addOutput(audioOutput!)
     }
-    audioOutput!.setSampleBufferDelegate(self, queue: audioQueue)
-    audioCaptureSession.addOutput(audioOutput!)
   }
 
   /**

--- a/ios/CameraView+AVAudioSession.swift
+++ b/ios/CameraView+AVAudioSession.swift
@@ -25,8 +25,8 @@ extension CameraView {
     }
 
     audioCaptureSession.automaticallyConfiguresApplicationAudioSession = false
-    let enableAudio = self.audio?.boolValue == true
-    
+    let enableAudio = audio?.boolValue == true
+
     // check microphone permission
     if enableAudio {
       let audioPermissionStatus = AVCaptureDevice.authorizationStatus(for: .audio)

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -85,21 +85,23 @@ extension CameraView {
       captureSession.removeOutput(photoOutput)
       self.photoOutput = nil
     }
-    ReactLogger.log(level: .info, message: "Adding Photo output...")
-    photoOutput = AVCapturePhotoOutput()
-    photoOutput!.isDepthDataDeliveryEnabled = photoOutput!.isDepthDataDeliverySupported && enableDepthData
-    if let enableHighResolutionCapture = self.enableHighResolutionCapture?.boolValue {
-      photoOutput!.isHighResolutionCaptureEnabled = enableHighResolutionCapture
-    }
-    if #available(iOS 12.0, *) {
-      photoOutput!.isPortraitEffectsMatteDeliveryEnabled = photoOutput!.isPortraitEffectsMatteDeliverySupported && self.enablePortraitEffectsMatteDelivery
-    }
-    guard captureSession.canAddOutput(photoOutput!) else {
-      return invokeOnError(.parameter(.unsupportedOutput(outputDescriptor: "photo-output")))
-    }
-    captureSession.addOutput(photoOutput!)
-    if videoDeviceInput!.device.position == .front {
-      photoOutput!.mirror()
+    if photo?.boolValue == true {
+      ReactLogger.log(level: .info, message: "Adding Photo output...")
+      photoOutput = AVCapturePhotoOutput()
+      photoOutput!.isDepthDataDeliveryEnabled = photoOutput!.isDepthDataDeliverySupported && enableDepthData
+      if let enableHighResolutionCapture = self.enableHighResolutionCapture?.boolValue {
+        photoOutput!.isHighResolutionCaptureEnabled = enableHighResolutionCapture
+      }
+      if #available(iOS 12.0, *) {
+        photoOutput!.isPortraitEffectsMatteDeliveryEnabled = photoOutput!.isPortraitEffectsMatteDeliverySupported && self.enablePortraitEffectsMatteDelivery
+      }
+      guard captureSession.canAddOutput(photoOutput!) else {
+        return invokeOnError(.parameter(.unsupportedOutput(outputDescriptor: "photo-output")))
+      }
+      captureSession.addOutput(photoOutput!)
+      if videoDeviceInput!.device.position == .front {
+        photoOutput!.mirror()
+      }
     }
 
     // Video Output + Frame Processor
@@ -107,16 +109,18 @@ extension CameraView {
       captureSession.removeOutput(videoOutput)
       self.videoOutput = nil
     }
-    ReactLogger.log(level: .info, message: "Adding Video Data output...")
-    videoOutput = AVCaptureVideoDataOutput()
-    guard captureSession.canAddOutput(videoOutput!) else {
-      return invokeOnError(.parameter(.unsupportedOutput(outputDescriptor: "video-output")))
-    }
-    videoOutput!.setSampleBufferDelegate(self, queue: videoQueue)
-    videoOutput!.alwaysDiscardsLateVideoFrames = true
-    captureSession.addOutput(videoOutput!)
-    if videoDeviceInput!.device.position == .front {
-      videoOutput!.mirror()
+    if video?.boolValue == true {
+      ReactLogger.log(level: .info, message: "Adding Video Data output...")
+      videoOutput = AVCaptureVideoDataOutput()
+      guard captureSession.canAddOutput(videoOutput!) else {
+        return invokeOnError(.parameter(.unsupportedOutput(outputDescriptor: "video-output")))
+      }
+      videoOutput!.setSampleBufferDelegate(self, queue: videoQueue)
+      videoOutput!.alwaysDiscardsLateVideoFrames = true
+      captureSession.addOutput(videoOutput!)
+      if videoDeviceInput!.device.position == .front {
+        videoOutput!.mirror()
+      }
     }
 
     invokeOnInitialized()

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -228,7 +228,7 @@ extension CameraView {
 
     if isActive {
       // restart capture session after an error occured
-      queue.async {
+      cameraQueue.async {
         self.captureSession.startRunning()
       }
     }

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -43,6 +43,14 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         //       the callback, but I'd prefer for them to throw for the original function instead.
 
         let enableAudio = self.audio?.boolValue == true
+        
+        if enableAudio {
+          let audioPermissionStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+          if audioPermissionStatus != .authorized {
+            return callback([NSNull(), CameraError.permission(.microphone)])
+          }
+        }
+        
         let onFinish = { (status: AVAssetWriter.Status, error: Error?) -> Void in
           defer {
             self.recordingSession = nil

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -58,13 +58,6 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
 
       let enableAudio = self.audio?.boolValue == true
 
-      if enableAudio {
-        let audioPermissionStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-        if audioPermissionStatus != .authorized {
-          return callback.reject(error: .permission(.microphone))
-        }
-      }
-
       let onFinish = { (status: AVAssetWriter.Status, error: Error?) -> Void in
         defer {
           self.recordingSession = nil

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -101,7 +101,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
           }
         } else {
           // start recording session without audio.
-          recordingSession.start()
+          self.recordingSession!.start()
           self.isRecording = true
         }
       } catch EnumParserError.invalidValue {

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -23,11 +23,11 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       do {
         var fileType = AVFileType.mov
         if let fileTypeOption = options["fileType"] as? String {
-          fileType = AVFileType(withString: fileTypeOption)
+          fileType = try AVFileType(withString: fileTypeOption)
         }
         
         let errorPointer = ErrorPointer(nilLiteral: ())
-        let fileExtension = fileType.rawValue
+        let fileExtension = fileType.descriptor ?? "mov"
         guard let tempFilePath = RCTTempFilePath(fileExtension, errorPointer) else {
           return callback([NSNull(), makeReactError(.capture(.createTempFileError), cause: errorPointer?.pointee)])
         }

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -36,6 +36,14 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         if let fileTypeOption = options["fileType"] as? String {
           fileType = AVFileType(withString: fileTypeOption)
         }
+        
+        guard let videoOutput = self.videoOutput else {
+          if self.video?.boolValue == true {
+            return callback([NSNull(), CameraError.session(.cameraNotReady)])
+          } else {
+            return callback([NSNull(), CameraError.capture(.videoNotEnabled)])
+          }
+        }
 
         // TODO: The startRecording() func cannot be async because RN doesn't allow
         //       both a callback and a Promise in a single function. Wait for TurboModules?
@@ -81,8 +89,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
                                                      completion: onFinish)
 
         // Init Video
-        guard let videoOutput = self.videoOutput,
-              let videoSettings = videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType),
+        guard let videoSettings = videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType),
               !videoSettings.isEmpty else {
           throw CameraError.capture(.createRecorderError(message: "Failed to get video settings!"))
         }

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -43,14 +43,14 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         //       the callback, but I'd prefer for them to throw for the original function instead.
 
         let enableAudio = self.audio?.boolValue == true
-        
+
         if enableAudio {
           let audioPermissionStatus = AVCaptureDevice.authorizationStatus(for: .audio)
           if audioPermissionStatus != .authorized {
             return callback([NSNull(), CameraError.permission(.microphone)])
           }
         }
-        
+
         let onFinish = { (status: AVAssetWriter.Status, error: Error?) -> Void in
           defer {
             self.recordingSession = nil
@@ -192,8 +192,8 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
     }
   }
 
-  public final func captureOutput(_ captureOutput: AVCaptureOutput, didDrop buffer: CMSampleBuffer, from _: AVCaptureConnection) {
-    #if DEBUG
+  #if DEBUG
+    public final func captureOutput(_ captureOutput: AVCaptureOutput, didDrop buffer: CMSampleBuffer, from _: AVCaptureConnection) {
       if frameProcessorCallback != nil && !hasLoggedFrameDropWarning && captureOutput is AVCaptureVideoDataOutput {
         let reason = findFrameDropReason(inBuffer: buffer)
         ReactLogger.log(level: .warning,
@@ -202,16 +202,16 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
                         alsoLogToJS: true)
         hasLoggedFrameDropWarning = true
       }
-    #endif
-  }
-
-  private final func findFrameDropReason(inBuffer buffer: CMSampleBuffer) -> String {
-    var mode: CMAttachmentMode = 0
-    guard let reason = CMGetAttachment(buffer,
-                                       key: kCMSampleBufferAttachmentKey_DroppedFrameReason,
-                                       attachmentModeOut: &mode) else {
-      return "unknown"
     }
-    return String(describing: reason)
-  }
+
+    private final func findFrameDropReason(inBuffer buffer: CMSampleBuffer) -> String {
+      var mode: CMAttachmentMode = 0
+      guard let reason = CMGetAttachment(buffer,
+                                         key: kCMSampleBufferAttachmentKey_DroppedFrameReason,
+                                         attachmentModeOut: &mode) else {
+        return "unknown"
+      }
+      return String(describing: reason)
+    }
+  #endif
 }

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -28,16 +28,16 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         }
         fileType = parsed
       }
-      
+
       let errorPointer = ErrorPointer(nilLiteral: ())
       let fileExtension = fileType.descriptor ?? "mov"
       guard let tempFilePath = RCTTempFilePath(fileExtension, errorPointer) else {
         return callback.reject(error: .capture(.createTempFileError), cause: errorPointer?.pointee)
       }
-      
+
       ReactLogger.log(level: .info, message: "File path: \(tempFilePath)")
       let tempURL = URL(string: "file://\(tempFilePath)")!
-      
+
       if let flashMode = options["flash"] as? String {
         // use the torch as the video's flash
         self.setTorchMode(flashMode)
@@ -104,7 +104,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         self.audioQueue.async {
           // Activate Audio Session (blocking)
           self.activateAudioSession()
-          
+
           guard let recordingSession = self.recordingSession else {
             // recording has already been cancelled
             return

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -36,7 +36,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         if let fileTypeOption = options["fileType"] as? String {
           fileType = AVFileType(withString: fileTypeOption)
         }
-        
+
         guard let videoOutput = self.videoOutput else {
           if self.video?.boolValue == true {
             return callback([NSNull(), CameraError.session(.cameraNotReady)])

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -21,20 +21,23 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       ReactLogger.log(level: .info, message: "Starting Video recording...")
 
       do {
-        let errorPointer = ErrorPointer(nilLiteral: ())
-        guard let tempFilePath = RCTTempFilePath("mov", errorPointer) else {
-          return callback([NSNull(), makeReactError(.capture(.createTempFileError), cause: errorPointer?.pointee)])
-        }
-
-        let tempURL = URL(string: "file://\(tempFilePath)")!
-        if let flashMode = options["flash"] as? String {
-          // use the torch as the video's flash
-          self.setTorchMode(flashMode)
-        }
-
         var fileType = AVFileType.mov
         if let fileTypeOption = options["fileType"] as? String {
           fileType = AVFileType(withString: fileTypeOption)
+        }
+        
+        let errorPointer = ErrorPointer(nilLiteral: ())
+        let fileExtension = fileType.rawValue
+        guard let tempFilePath = RCTTempFilePath(fileExtension, errorPointer) else {
+          return callback([NSNull(), makeReactError(.capture(.createTempFileError), cause: errorPointer?.pointee)])
+        }
+        
+        ReactLogger.log(level: .info, message: "File path: \(tempFilePath)")
+        let tempURL = URL(string: "file://\(tempFilePath)")!
+        
+        if let flashMode = options["flash"] as? String {
+          // use the torch as the video's flash
+          self.setTorchMode(flashMode)
         }
 
         guard let videoOutput = self.videoOutput else {

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -25,8 +25,13 @@ struct TakePhotoOptions {
 extension CameraView {
   func takePhoto(options: NSDictionary, promise: Promise) {
     cameraQueue.async {
-      guard let photoOutput = self.photoOutput, let videoDeviceInput = self.videoDeviceInput else {
-        return promise.reject(error: .session(.cameraNotReady))
+      guard let photoOutput = self.photoOutput,
+            let videoDeviceInput = self.videoDeviceInput else {
+        if self.photo?.boolValue == true {
+          return promise.reject(error: .session(.cameraNotReady))
+        } else {
+          return promise.reject(error: .capture(.photoNotEnabled))
+        }
       }
 
       var photoSettings = AVCapturePhotoSettings()

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -135,10 +135,6 @@ public final class CameraView: UIView {
                                            selector: #selector(audioSessionInterrupted),
                                            name: AVAudioSession.interruptionNotification,
                                            object: AVAudioSession.sharedInstance)
-
-    audioQueue.async {
-      self.configureAudioSession()
-    }
   }
 
   @available(*, unavailable)
@@ -164,6 +160,7 @@ public final class CameraView: UIView {
     let shouldReconfigure = changedProps.contains { propsThatRequireReconfiguration.contains($0) }
     let shouldReconfigureFormat = shouldReconfigure || changedProps.contains("format")
     let shouldReconfigureDevice = shouldReconfigureFormat || changedProps.contains { propsThatRequireDeviceReconfiguration.contains($0) }
+    let shouldReconfigureAudioSession = changedProps.contains("audio")
 
     let willReconfigure = shouldReconfigure || shouldReconfigureFormat || shouldReconfigureDevice
 
@@ -173,6 +170,7 @@ public final class CameraView: UIView {
     let shouldUpdateVideoStabilization = willReconfigure || changedProps.contains("videoStabilizationMode")
 
     if shouldReconfigure ||
+      shouldReconfigureAudioSession ||
       shouldCheckActive ||
       shouldUpdateTorch ||
       shouldUpdateZoom ||
@@ -217,6 +215,13 @@ public final class CameraView: UIView {
           self.cameraQueue.asyncAfter(deadline: .now() + 0.1) {
             self.setTorchMode(self.torch)
           }
+        }
+      }
+      
+      // Audio Configuration
+      if shouldReconfigureAudioSession {
+        audioQueue.async {
+          self.configureAudioSession()
         }
       }
     }

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -15,7 +15,6 @@ import UIKit
 //
 // CameraView+RecordVideo
 // TODO: Better startRecording()/stopRecording() (promise + callback, wait for TurboModules/JSI)
-// TODO: videoStabilizationMode
 
 // CameraView+TakePhoto
 // TODO: Photo HDR
@@ -42,6 +41,10 @@ public final class CameraView: UIView {
   @objc var enableHighResolutionCapture: NSNumber? // nullable bool
   @objc var enablePortraitEffectsMatteDelivery = false
   @objc var preset: String?
+  // use cases
+  @objc var photo: NSNumber? // nullable bool
+  @objc var video: NSNumber? // nullable bool
+  @objc var audio: NSNumber? // nullable bool
   // props that require format reconfiguring
   @objc var format: NSDictionary?
   @objc var fps: NSNumber?

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -23,7 +23,9 @@ private let propsThatRequireReconfiguration = ["cameraId",
                                                "enableDepthData",
                                                "enableHighResolutionCapture",
                                                "enablePortraitEffectsMatteDelivery",
-                                               "preset"]
+                                               "preset",
+                                               "photo",
+                                               "video"]
 private let propsThatRequireDeviceReconfiguration = ["fps",
                                                      "hdr",
                                                      "lowLightBoost",

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -217,7 +217,7 @@ public final class CameraView: UIView {
           }
         }
       }
-      
+
       // Audio Configuration
       if shouldReconfigureAudioSession {
         audioQueue.async {

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -76,8 +76,6 @@ public final class CameraView: UIView {
   // pragma MARK: Internal Properties
 
   internal var isReady = false
-  /// The serial execution queue for the camera preview layer (input stream) as well as output processing (take photo and record video)
-  internal let queue = DispatchQueue(label: "com.mrousavy.camera-queue", qos: .userInteractive, attributes: [], autoreleaseFrequency: .inherit, target: nil)
   // Capture Session
   internal let captureSession = AVCaptureSession()
   internal let audioCaptureSession = AVCaptureSession()

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -27,6 +27,10 @@ RCT_EXPORT_VIEW_PROPERTY(cameraId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enableDepthData, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(enableHighResolutionCapture, NSNumber); // nullable bool
 RCT_EXPORT_VIEW_PROPERTY(enablePortraitEffectsMatteDelivery, BOOL);
+// use cases
+RCT_EXPORT_VIEW_PROPERTY(photo, NSNumber); // nullable bool
+RCT_EXPORT_VIEW_PROPERTY(video, NSNumber); // nullable bool
+RCT_EXPORT_VIEW_PROPERTY(audio, NSNumber); // nullable bool
 // device format
 RCT_EXPORT_VIEW_PROPERTY(format, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(fps, NSNumber);

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -99,6 +99,7 @@ final class CameraViewManager: RCTViewManager {
           "maxZoom": $0.maxAvailableVideoZoomFactor,
           "neutralZoom": $0.neutralZoomPercent,
           "isMultiCam": $0.isMultiCam,
+          "supportsPhotoAndVideoCapture": true,
           "supportsDepthCapture": false, // TODO: supportsDepthCapture
           "supportsRawCapture": false, // TODO: supportsRawCapture
           "supportsLowLightBoost": $0.isLowLightBoostSupported,

--- a/ios/Frame Processor/FrameHostObject.mm
+++ b/ios/Frame Processor/FrameHostObject.mm
@@ -75,10 +75,6 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     auto planesCount = CVPixelBufferGetPlaneCount(imageBuffer);
     return jsi::Value((double) planesCount);
   }
-  if (name == "buffer") {
-    // TODO: Actually return the pixels of the buffer. Not sure if this will be a huge performance hit or not
-    return jsi::Array(runtime, 0);
-  }
 
   return jsi::Value::undefined();
 }

--- a/ios/Parsers/AVFileType+descriptor.swift
+++ b/ios/Parsers/AVFileType+descriptor.swift
@@ -10,11 +10,25 @@ import AVFoundation
 import Foundation
 
 extension AVFileType {
-  init(withString string: String) {
-    self.init(rawValue: string)
+  init(withString string: String) throws {
+    switch string {
+    case "mov":
+      self = .mov
+    case "mp4":
+      self = .mp4
+    default:
+      throw EnumParserError.invalidValue
+    }
   }
 
-  var descriptor: String {
-    return rawValue
+  var descriptor: String? {
+    switch self {
+    case .mov:
+      return "mov"
+    case .mp4:
+      return "mp4"
+    default:
+      return nil
+    }
   }
 }

--- a/ios/Parsers/AVFileType+descriptor.swift
+++ b/ios/Parsers/AVFileType+descriptor.swift
@@ -16,6 +16,10 @@ extension AVFileType {
       self = .mov
     case "mp4":
       self = .mp4
+    case "avci":
+      self = .avci
+    case "m4v":
+      self = .m4v
     default:
       throw EnumParserError.invalidValue
     }
@@ -27,6 +31,10 @@ extension AVFileType {
       return "mov"
     case .mp4:
       return "mp4"
+    case .avci:
+      return "avci"
+    case .m4v:
+      return "m4v"
     default:
       return nil
     }

--- a/ios/Parsers/EnumParserError.swift
+++ b/ios/Parsers/EnumParserError.swift
@@ -20,8 +20,4 @@ enum EnumParserError: Error {
    Raised when the descriptor does not match any of the possible values.
    */
   case invalidValue
-  /**
-   Raised when no descriptor for the given enum is available.
-   */
-  case noDescriptorAvailable
 }

--- a/ios/React Utils/Callback.swift
+++ b/ios/React Utils/Callback.swift
@@ -1,0 +1,38 @@
+//
+//  Callback.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 07.06.21.
+//  Copyright © 2021 mrousavy. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Represents a callback to JavaScript. Syntax is the same as with Promise.
+ */
+class Callback {
+  init(_ callback: @escaping RCTResponseSenderBlock) {
+    self.callback = callback
+  }
+  
+  func reject(error: CameraError, cause: NSError?) {
+    self.callback([NSNull(), makeReactError(error, cause: cause)])
+  }
+  
+  func reject(error: CameraError) {
+    reject(error: error, cause: nil)
+  }
+  
+  func resolve(_ value: Any?) {
+    self.callback([value, NSNull()])
+  }
+  
+  func resolve() {
+    resolve(nil)
+  }
+  
+  // MARK: Private
+  
+  private let callback: RCTResponseSenderBlock
+}

--- a/ios/React Utils/Callback.swift
+++ b/ios/React Utils/Callback.swift
@@ -15,24 +15,24 @@ class Callback {
   init(_ callback: @escaping RCTResponseSenderBlock) {
     self.callback = callback
   }
-  
+
   func reject(error: CameraError, cause: NSError?) {
-    self.callback([NSNull(), makeReactError(error, cause: cause)])
+    callback([NSNull(), makeReactError(error, cause: cause)])
   }
-  
+
   func reject(error: CameraError) {
     reject(error: error, cause: nil)
   }
-  
+
   func resolve(_ value: Any?) {
-    self.callback([value, NSNull()])
+    callback([value, NSNull()])
   }
-  
+
   func resolve() {
     resolve(nil)
   }
-  
+
   // MARK: Private
-  
+
   private let callback: RCTResponseSenderBlock
 }

--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -11,7 +11,7 @@ import Foundation
 
 // MARK: - BufferType
 
-enum BufferType: String {
+enum BufferType {
   case audio
   case video
 }
@@ -112,7 +112,7 @@ class RecordingSession {
     }
     guard let initialTimestamp = initialTimestamp else {
       ReactLogger.log(level: .error,
-                      message: "A \(bufferType.rawValue) frame arrived, but initialTimestamp was nil. Is this RecordingSession running?",
+                      message: "A frame arrived, but initialTimestamp was nil. Is this RecordingSession running?",
                       alsoLogToJS: true)
       return
     }

--- a/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		B88B47472667C8E00091F538 /* AVCaptureSession+setVideoStabilizationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88B47462667C8E00091F538 /* AVCaptureSession+setVideoStabilizationMode.swift */; };
 		B8994E6C263F03E100069589 /* JSIUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = B8994E6B263F03E100069589 /* JSIUtils.mm */; };
 		B8A751D82609E4B30011C623 /* FrameProcessorRuntimeManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = B8A751D72609E4B30011C623 /* FrameProcessorRuntimeManager.mm */; };
+		B8BD3BA2266E22D2006C80A2 /* Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8BD3BA1266E22D2006C80A2 /* Callback.swift */; };
 		B8D22CDC2642DB4D00234472 /* AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D22CDB2642DB4D00234472 /* AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift */; };
 		B8DB3BC8263DC28C004C18D7 /* AVAssetWriter.Status+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BC7263DC28C004C18D7 /* AVAssetWriter.Status+descriptor.swift */; };
 		B8DB3BCA263DC4D8004C18D7 /* RecordingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BC9263DC4D8004C18D7 /* RecordingSession.swift */; };
@@ -132,6 +133,7 @@
 		B8994E6B263F03E100069589 /* JSIUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSIUtils.mm; sourceTree = "<group>"; };
 		B8A751D62609E4980011C623 /* FrameProcessorRuntimeManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameProcessorRuntimeManager.h; sourceTree = "<group>"; };
 		B8A751D72609E4B30011C623 /* FrameProcessorRuntimeManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrameProcessorRuntimeManager.mm; sourceTree = "<group>"; };
+		B8BD3BA1266E22D2006C80A2 /* Callback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Callback.swift; sourceTree = "<group>"; };
 		B8D22CDB2642DB4D00234472 /* AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift"; sourceTree = "<group>"; };
 		B8DB3BC7263DC28C004C18D7 /* AVAssetWriter.Status+descriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAssetWriter.Status+descriptor.swift"; sourceTree = "<group>"; };
 		B8DB3BC9263DC4D8004C18D7 /* RecordingSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSession.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				B887516E25E0102000DB86D6 /* MakeReactError.swift */,
 				B887516F25E0102000DB86D6 /* ReactLogger.swift */,
 				B887517025E0102000DB86D6 /* Promise.swift */,
+				B8BD3BA1266E22D2006C80A2 /* Callback.swift */,
 				B82FBA942614B69D00909718 /* RCTBridge+runOnJS.h */,
 				B82FBA952614B69D00909718 /* RCTBridge+runOnJS.mm */,
 				B81D41EF263C86F900B041FD /* JSIUtils.h */,
@@ -391,6 +394,7 @@
 				B88751A725E0102000DB86D6 /* CameraView+Zoom.swift in Sources */,
 				B887518525E0102000DB86D6 /* PhotoCaptureDelegate.swift in Sources */,
 				B887518B25E0102000DB86D6 /* AVCaptureDevice.Format+isBetterThan.swift in Sources */,
+				B8BD3BA2266E22D2006C80A2 /* Callback.swift in Sources */,
 				B84760A62608EE7C004C3180 /* FrameHostObject.mm in Sources */,
 				B8103E1C25FF553B007A1684 /* FrameProcessorUtils.mm in Sources */,
 				B887518E25E0102000DB86D6 /* AVFrameRateRange+includes.swift in Sources */,

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -358,6 +358,13 @@ export class Camera extends React.PureComponent<CameraProps> {
       this.assertFrameProcessorsEnabled();
       // frameProcessor argument changed. Update native to reflect the change.
       if (this.props.frameProcessor != null) {
+        if (this.props.video !== true) {
+          throw new CameraCaptureError(
+            'capture/video-not-enabled',
+            'Video capture is disabled! Pass `video={true}` to enable frame processors.',
+          );
+        }
+
         // 1. Spawn threaded JSI Runtime (if not already done)
         // 2. Add video data output to Camera stream (if not already done)
         // 3. Workletize the frameProcessor and prepare it for being called with frames

--- a/src/CameraDevice.ts
+++ b/src/CameraDevice.ts
@@ -243,6 +243,28 @@ export interface CameraDevice {
    */
   formats: CameraDeviceFormat[];
   /**
+   * Whether this camera device supports enabling photo and video capture at the same time.
+   *
+   * * On **iOS** devices this value is always `true`.
+   * * On newer **Android** devices this value is always `true`.
+   * * On older **Android** devices this value is `true` if the device's hardware level is `LIMITED` and above, `false` otherwise. (`LEGACY`) (See [this table](https://developer.android.com/reference/android/hardware/camera2/CameraDevice#regular-capture))
+   *
+   * If the device does not allow enabling `photo` and `video` capture at the same time, you might want to fall back to **snapshot capture** (See ["Taking Snapshots"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing#taking-snapshots)) instead:
+   *
+   * @example
+   * ```tsx
+   * const captureMode = device.supportsPhotoAndVideoCapture ? "photo" : "snapshot"
+   * return (
+   *   <Camera
+   *     photo={captureMode === "photo"}
+   *     video={true}
+   *     audio={true}
+   *   />
+   * )
+   * ```
+   */
+  supportsPhotoAndVideoCapture: boolean;
+  /**
    * Whether this camera device supports low light boost.
    */
   supportsLowLightBoost: boolean;

--- a/src/CameraError.ts
+++ b/src/CameraError.ts
@@ -37,6 +37,8 @@ export type CaptureError =
   | 'capture/invalid-photo-codec'
   | 'capture/not-bound-error'
   | 'capture/capture-type-not-supported'
+  | 'capture/video-not-enabled'
+  | 'capture/photo-not-enabled'
   | 'capture/unknown';
 export type SystemError = 'system/no-camera-manager';
 export type UnknownError = 'unknown/unknown';

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -36,15 +36,16 @@ export interface CameraProps extends ViewProps {
 
   //#region Use-cases
   /**
-   * Enable **photo capture** with the `takePhoto` function (see ["Taking Photos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing#taking-photos)).
+   * * Enables **photo capture** with the `takePhoto` function (see ["Taking Photos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing#taking-photos))
    */
   photo?: boolean;
   /**
-   * Enable **video capture** with the `startRecording` function (see ["Recording Videos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing/#recording-videos)), and **frame processing** (see ["Frame Processors"](https://cuvent.github.io/react-native-vision-camera/docs/guides/frame-processors)).
+   * * Enables **video capture** with the `startRecording` function (see ["Recording Videos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing/#recording-videos))
+   * * Enables **frame processing** (see ["Frame Processors"](https://cuvent.github.io/react-native-vision-camera/docs/guides/frame-processors))
    */
   video?: boolean;
   /**
-   * Enable **audio capture** for video recordings (see ["Recording Videos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing/#recording-videos)).
+   * * Enables **audio capture** for video recordings (see ["Recording Videos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing/#recording-videos))
    */
   audio?: boolean;
   //#endregion

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -34,6 +34,21 @@ export interface CameraProps extends ViewProps {
    */
   isActive: boolean;
 
+  //#region Use-cases
+  /**
+   * Enable **photo capture** with the `takePhoto` function (see ["Taking Photos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing#taking-photos)).
+   */
+  photo?: boolean;
+  /**
+   * Enable **video capture** with the `startRecording` function (see ["Recording Videos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing/#recording-videos)), and **frame processing** (see ["Frame Processors"](https://cuvent.github.io/react-native-vision-camera/docs/guides/frame-processors)).
+   */
+  video?: boolean;
+  /**
+   * Enable **audio capture** for video recordings (see ["Recording Videos"](https://cuvent.github.io/react-native-vision-camera/docs/guides/capturing/#recording-videos)).
+   */
+  audio?: boolean;
+  //#endregion
+
   //#region Common Props (torch, zoom)
   /**
    * Set the current torch mode.

--- a/src/Frame.ts
+++ b/src/Frame.ts
@@ -3,10 +3,6 @@
  */
 export interface Frame {
   /**
-   * The raw pixel buffer.
-   */
-  buffer: unknown[];
-  /**
    * Whether the underlying buffer is still valid or not. The buffer will be released after the frame processor returns.
    */
   isValid: boolean;


### PR DESCRIPTION
Adds

* `photo`
* `video`
* `audio`

props to configure what use-cases to attach. 

* Allows recording videos without audio
* Allows using the camera without microphone permission
* Allows faster camera startup by specifying what use-cases to attach

By default, they're all `false`.

## Side-effects

* (Android) Fixes PreviewView having a way too high resolution
* (Android) Fixes wrong orientation when not using a `format`
* (Android) Make `startRecording` non-blocking
* (Android) Reject with errors instead of crashing the app in `startRecording`
* (Android) Support devices with `LEGACY` hardware level
* Fix Splash page wrong redirect
* (iOS) Remove unused DispatchQueue
* (iOS) Fix `startRecording` `fileType` not being applied correctly, add correct extension
* Remove `Frame.buffer`

## Resolves

* resolves #127 
* resolves #78 