### PR TITLE
chore(deps): Upgrade CameraX to alpha05

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,10 +135,10 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.0"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0"
 
-  implementation "androidx.camera:camera-core:1.1.0-alpha04"
-  implementation "androidx.camera:camera-camera2:1.1.0-alpha04"
-  implementation "androidx.camera:camera-lifecycle:1.1.0-alpha04"
-  implementation "androidx.camera:camera-extensions:1.0.0-alpha24"
-  implementation "androidx.camera:camera-view:1.0.0-alpha24"
+  implementation "androidx.camera:camera-core:1.1.0-alpha05"
+  implementation "androidx.camera:camera-camera2:1.1.0-alpha05"
+  implementation "androidx.camera:camera-lifecycle:1.1.0-alpha05"
+  implementation "androidx.camera:camera-extensions:1.0.0-alpha25"
+  implementation "androidx.camera:camera-view:1.0.0-alpha25"
   implementation "androidx.exifinterface:exifinterface:1.3.2"
 }


### PR DESCRIPTION
<!-- ❤️ Thank you for your contribution! ❤️ -->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
