### PR TITLE
feat: dynamically determine recorder pixel format

### DIFF
--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -54,6 +54,10 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
           return
         }
       }
+      guard let videoDevice = self.videoDeviceInput?.device else {
+        callback.reject(error: .session(.cameraNotReady))
+        return
+      }
 
       // TODO: The startRecording() func cannot be async because RN doesn't allow
       //       both a callback and a Promise in a single function. Wait for TurboModules?
@@ -109,7 +113,8 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         return
       }
       self.recordingSession!.initializeVideoWriter(withSettings: videoSettings,
-                                                   isVideoMirrored: self.videoOutput!.isMirrored)
+                                                   isVideoMirrored: self.videoOutput!.isMirrored,
+                                                   activeFormat: videoDevice.activeFormat)
 
       // Init Audio (optional, async)
       if enableAudio {

--- a/ios/Extensions/AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift
+++ b/ios/Extensions/AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift
@@ -13,7 +13,9 @@ extension AVAssetWriterInputPixelBufferAdaptor {
   /**
    Convenience initializer to extract correct attributes from the given videoSettings.
    */
-  convenience init(assetWriterInput: AVAssetWriterInput, withVideoSettings videoSettings: [String: Any]) {
+  convenience init(assetWriterInput: AVAssetWriterInput,
+                   withVideoSettings videoSettings: [String: Any],
+                   activeFormat: AVCaptureDevice.Format) {
     var attributes: [String: Any] = [:]
 
     if let width = videoSettings[AVVideoWidthKey] as? NSNumber,
@@ -21,9 +23,8 @@ extension AVAssetWriterInputPixelBufferAdaptor {
       attributes[kCVPixelBufferWidthKey as String] = width as CFNumber
       attributes[kCVPixelBufferHeightKey as String] = height as CFNumber
     }
-
-    // TODO: Is "Bi-Planar Y'CbCr 8-bit 4:2:0 full-range" the best CVPixelFormatType? How can I find natively supported ones?
-    attributes[kCVPixelBufferPixelFormatTypeKey as String] = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+    
+    attributes[kCVPixelBufferPixelFormatTypeKey as String] = CMFormatDescriptionGetMediaSubType(activeFormat.formatDescription)
 
     self.init(assetWriterInput: assetWriterInput, sourcePixelBufferAttributes: attributes)
   }

--- a/ios/Extensions/AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift
+++ b/ios/Extensions/AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift
@@ -23,7 +23,7 @@ extension AVAssetWriterInputPixelBufferAdaptor {
       attributes[kCVPixelBufferWidthKey as String] = width as CFNumber
       attributes[kCVPixelBufferHeightKey as String] = height as CFNumber
     }
-    
+
     attributes[kCVPixelBufferPixelFormatTypeKey as String] = CMFormatDescriptionGetMediaSubType(activeFormat.formatDescription)
 
     self.init(assetWriterInput: assetWriterInput, sourcePixelBufferAttributes: attributes)

--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -68,7 +68,7 @@ class RecordingSession {
   /**
    Initializes an AssetWriter for video frames (CMSampleBuffers).
    */
-  func initializeVideoWriter(withSettings settings: [String: Any], isVideoMirrored: Bool) {
+  func initializeVideoWriter(withSettings settings: [String: Any], isVideoMirrored: Bool, activeFormat: AVCaptureDevice.Format) {
     guard !settings.isEmpty else {
       ReactLogger.log(level: .error, message: "Tried to initialize Video Writer with empty settings!", alsoLogToJS: true)
       return
@@ -88,7 +88,9 @@ class RecordingSession {
     }
 
     assetWriter.add(videoWriter)
-    bufferAdaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: videoWriter, withVideoSettings: settings)
+    bufferAdaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: videoWriter,
+                                                         withVideoSettings: settings,
+                                                         activeFormat: activeFormat)
     ReactLogger.log(level: .info, message: "Initialized Video AssetWriter.")
   }
 


### PR DESCRIPTION
<!-- ❤️ Thank you for your contribution! ❤️ -->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
