### PR TITLE
feat: High quality mode (`enableHighQualityPhotos`)

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -49,9 +49,6 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   if (options.hasKey("enableDualCameraFusion")) {
     // TODO enableDualCameraFusion
   }
-  if (options.hasKey("enableVirtualDeviceFusion")) {
-    // TODO enableVirtualDeviceFusion
-  }
   if (options.hasKey("enableAutoStabilization")) {
     // TODO enableAutoStabilization
   }

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -55,7 +55,6 @@ import kotlin.math.min
 // TODO: takePhoto() photoCodec ("hevc" | "jpeg" | "raw")
 // TODO: takePhoto() qualityPrioritization
 // TODO: takePhoto() enableAutoRedEyeReduction
-// TODO: takePhoto() enableVirtualDeviceFusion
 // TODO: takePhoto() enableAutoStabilization
 // TODO: takePhoto() enableAutoDistortionCorrection
 // TODO: takePhoto() return with jsi::Value Image reference for faster capture

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -39,7 +39,7 @@ import kotlin.math.min
 // TODO: Configurable FPS higher than 30
 // TODO: High-speed video recordings (export in CameraViewModule::getAvailableVideoDevices(), and set in CameraView::configurePreview()) (120FPS+)
 // TODO: configureSession() enableDepthData
-// TODO: configureSession() enableHighQualityCapture
+// TODO: configureSession() enableHighQualityPhotos
 // TODO: configureSession() enablePortraitEffectsMatteDelivery
 // TODO: configureSession() colorSpace
 
@@ -65,7 +65,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   // props that require reconfiguring
   var cameraId: String? = null // this is actually not a react prop directly, but the result of setting device={}
   var enableDepthData = false
-  var enableHighQualityCapture: Boolean? = null
+  var enableHighQualityPhotos: Boolean? = null
   var enablePortraitEffectsMatteDelivery = false
   // use-cases
   var photo: Boolean? = null

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -39,7 +39,7 @@ import kotlin.math.min
 // TODO: Configurable FPS higher than 30
 // TODO: High-speed video recordings (export in CameraViewModule::getAvailableVideoDevices(), and set in CameraView::configurePreview()) (120FPS+)
 // TODO: configureSession() enableDepthData
-// TODO: configureSession() enableHighResolutionCapture
+// TODO: configureSession() enableHighQualityCapture
 // TODO: configureSession() enablePortraitEffectsMatteDelivery
 // TODO: configureSession() colorSpace
 
@@ -66,7 +66,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   // props that require reconfiguring
   var cameraId: String? = null // this is actually not a react prop directly, but the result of setting device={}
   var enableDepthData = false
-  var enableHighResolutionCapture: Boolean? = null
+  var enableHighQualityCapture: Boolean? = null
   var enablePortraitEffectsMatteDelivery = false
   // use-cases
   var photo: Boolean? = null

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -51,11 +51,11 @@ class CameraViewManager : SimpleViewManager<CameraView>() {
     view.enableDepthData = enableDepthData
   }
 
-  @ReactProp(name = "enableHighResolutionCapture")
-  fun setEnableHighResolutionCapture(view: CameraView, enableHighResolutionCapture: Boolean?) {
-    if (view.enableHighResolutionCapture != enableHighResolutionCapture)
-      addChangedPropToTransaction(view, "enableHighResolutionCapture")
-    view.enableHighResolutionCapture = enableHighResolutionCapture
+  @ReactProp(name = "enableHighQualityCapture")
+  fun setenableHighQualityCapture(view: CameraView, enableHighQualityCapture: Boolean?) {
+    if (view.enableHighQualityCapture != enableHighQualityCapture)
+      addChangedPropToTransaction(view, "enableHighQualityCapture")
+    view.enableHighQualityCapture = enableHighQualityCapture
   }
 
   @ReactProp(name = "enablePortraitEffectsMatteDelivery")

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -51,11 +51,11 @@ class CameraViewManager : SimpleViewManager<CameraView>() {
     view.enableDepthData = enableDepthData
   }
 
-  @ReactProp(name = "enableHighQualityCapture")
-  fun setEnableHighQualityCapture(view: CameraView, enableHighQualityCapture: Boolean?) {
-    if (view.enableHighQualityCapture != enableHighQualityCapture)
-      addChangedPropToTransaction(view, "enableHighQualityCapture")
-    view.enableHighQualityCapture = enableHighQualityCapture
+  @ReactProp(name = "enableHighQualityPhotos")
+  fun setEnableHighQualityPhotos(view: CameraView, enableHighQualityPhotos: Boolean?) {
+    if (view.enableHighQualityPhotos != enableHighQualityPhotos)
+      addChangedPropToTransaction(view, "enableHighQualityPhotos")
+    view.enableHighQualityPhotos = enableHighQualityPhotos
   }
 
   @ReactProp(name = "enablePortraitEffectsMatteDelivery")

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -52,7 +52,7 @@ class CameraViewManager : SimpleViewManager<CameraView>() {
   }
 
   @ReactProp(name = "enableHighQualityCapture")
-  fun setenableHighQualityCapture(view: CameraView, enableHighQualityCapture: Boolean?) {
+  fun setEnableHighQualityCapture(view: CameraView, enableHighQualityCapture: Boolean?) {
     if (view.enableHighQualityCapture != enableHighQualityCapture)
       addChangedPropToTransaction(view, "enableHighQualityCapture")
     view.enableHighQualityCapture = enableHighQualityCapture

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -94,7 +94,6 @@ extension CameraView {
     if photo?.boolValue == true {
       ReactLogger.log(level: .info, message: "Adding Photo output...")
       photoOutput = AVCapturePhotoOutput()
-      photoOutput!.isDepthDataDeliveryEnabled = photoOutput!.isDepthDataDeliverySupported && enableDepthData
 
       if enableHighQualityCapture?.boolValue == true {
         photoOutput!.isHighResolutionCaptureEnabled = true
@@ -105,8 +104,11 @@ extension CameraView {
           photoOutput!.isDualCameraDualPhotoDeliveryEnabled = photoOutput!.isDualCameraDualPhotoDeliverySupported
         }
       }
-      if #available(iOS 12.0, *) {
-        photoOutput!.isPortraitEffectsMatteDeliveryEnabled = photoOutput!.isPortraitEffectsMatteDeliverySupported && self.enablePortraitEffectsMatteDelivery
+      if enableDepthData {
+        photoOutput!.isDepthDataDeliveryEnabled = photoOutput!.isDepthDataDeliverySupported
+      }
+      if #available(iOS 12.0, *), enablePortraitEffectsMatteDelivery {
+        photoOutput!.isPortraitEffectsMatteDeliveryEnabled = photoOutput!.isPortraitEffectsMatteDeliverySupported
       }
       guard captureSession.canAddOutput(photoOutput!) else {
         invokeOnError(.parameter(.unsupportedOutput(outputDescriptor: "photo-output")))

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -95,7 +95,7 @@ extension CameraView {
       ReactLogger.log(level: .info, message: "Adding Photo output...")
       photoOutput = AVCapturePhotoOutput()
 
-      if enableHighQualityCapture?.boolValue == true {
+      if enableHighQualityPhotos?.boolValue == true {
         photoOutput!.isHighResolutionCaptureEnabled = true
         if #available(iOS 13.0, *) {
           photoOutput!.isVirtualDeviceConstituentPhotoDeliveryEnabled = photoOutput!.isVirtualDeviceConstituentPhotoDeliverySupported

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -95,8 +95,15 @@ extension CameraView {
       ReactLogger.log(level: .info, message: "Adding Photo output...")
       photoOutput = AVCapturePhotoOutput()
       photoOutput!.isDepthDataDeliveryEnabled = photoOutput!.isDepthDataDeliverySupported && enableDepthData
-      if let enableHighResolutionCapture = self.enableHighResolutionCapture?.boolValue {
-        photoOutput!.isHighResolutionCaptureEnabled = enableHighResolutionCapture
+
+      if enableHighQualityCapture?.boolValue == true {
+        photoOutput!.isHighResolutionCaptureEnabled = true
+        if #available(iOS 13.0, *) {
+          photoOutput!.isVirtualDeviceConstituentPhotoDeliveryEnabled = photoOutput!.isVirtualDeviceConstituentPhotoDeliverySupported
+          photoOutput!.maxPhotoQualityPrioritization = .quality
+        } else {
+          photoOutput!.isDualCameraDualPhotoDeliveryEnabled = photoOutput!.isDualCameraDualPhotoDeliverySupported
+        }
       }
       if #available(iOS 12.0, *) {
         photoOutput!.isPortraitEffectsMatteDeliveryEnabled = photoOutput!.isPortraitEffectsMatteDeliverySupported && self.enablePortraitEffectsMatteDelivery

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -37,6 +37,8 @@ extension CameraView {
       }
 
       var photoSettings = AVCapturePhotoSettings()
+      
+      // photo codec
       if let photoCodecString = options["photoCodec"] as? String {
         guard let photoCodec = AVVideoCodecType(withString: photoCodecString) else {
           promise.reject(error: .capture(.invalidPhotoCodec))
@@ -49,6 +51,18 @@ extension CameraView {
           return
         }
       }
+      
+      if self.enableHighQualityCapture?.boolValue == true {
+        photoSettings.isHighResolutionPhotoEnabled = true
+        if #available(iOS 13.0, *) {
+          photoSettings.photoQualityPrioritization = .quality
+          photoSettings.isAutoVirtualDeviceFusionEnabled = photoOutput.isVirtualDeviceFusionSupported
+        } else {
+          photoSettings.isAutoDualCameraFusionEnabled = photoOutput.isDualCameraFusionSupported
+        }
+      }
+      
+      // flash
       if videoDeviceInput.device.isFlashAvailable, let flash = options["flash"] as? String {
         guard let flashMode = AVCaptureDevice.FlashMode(withString: flash) else {
           promise.reject(error: .parameter(.invalid(unionName: "FlashMode", receivedValue: flash)))
@@ -56,16 +70,22 @@ extension CameraView {
         }
         photoSettings.flashMode = flashMode
       }
+      
+      // high resolution
       photoSettings.isHighResolutionPhotoEnabled = photoOutput.isHighResolutionCaptureEnabled
-      if !photoSettings.__availablePreviewPhotoPixelFormatTypes.isEmpty {
-        photoSettings.previewPhotoFormat = [kCVPixelBufferPixelFormatTypeKey as String: photoSettings.__availablePreviewPhotoPixelFormatTypes.first!]
+      if !photoSettings.availablePreviewPhotoPixelFormatTypes.isEmpty {
+        photoSettings.previewPhotoFormat = [kCVPixelBufferPixelFormatTypeKey as String: photoSettings.availablePreviewPhotoPixelFormatTypes.first!]
       }
+      
+      // depth data
       photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
       photoSettings.embedsDepthDataInPhoto = photoSettings.isDepthDataDeliveryEnabled
       if #available(iOS 12.0, *) {
         photoSettings.isPortraitEffectsMatteDeliveryEnabled = photoOutput.isPortraitEffectsMatteDeliveryEnabled
         photoSettings.embedsPortraitEffectsMatteInPhoto = photoSettings.isPortraitEffectsMatteDeliveryEnabled
       }
+      
+      // quality prioritization
       if #available(iOS 13.0, *), let qualityPrioritization = options["qualityPrioritization"] as? String {
         guard let photoQualityPrioritization = AVCapturePhotoOutput.QualityPrioritization(withString: qualityPrioritization) else {
           promise.reject(error: .parameter(.invalid(unionName: "QualityPrioritization", receivedValue: qualityPrioritization)))
@@ -73,9 +93,13 @@ extension CameraView {
         }
         photoSettings.photoQualityPrioritization = photoQualityPrioritization
       }
+      
+      // red-eye reduction
       if #available(iOS 12.0, *), let autoRedEyeReduction = options["enableAutoRedEyeReduction"] as? Bool {
         photoSettings.isAutoRedEyeReductionEnabled = autoRedEyeReduction
       }
+      
+      // virtual device fusion
       if let enableVirtualDeviceFusion = options["enableVirtualDeviceFusion"] as? Bool {
         if #available(iOS 13.0, *) {
           photoSettings.isAutoVirtualDeviceFusionEnabled = enableVirtualDeviceFusion
@@ -83,9 +107,13 @@ extension CameraView {
           photoSettings.isAutoDualCameraFusionEnabled = enableVirtualDeviceFusion
         }
       }
+      
+      // stabilization
       if let enableAutoStabilization = options["enableAutoStabilization"] as? Bool {
         photoSettings.isAutoStillImageStabilizationEnabled = enableAutoStabilization
       }
+      
+      // distortion correction
       if #available(iOS 14.1, *), let enableAutoDistortionCorrection = options["enableAutoDistortionCorrection"] as? Bool {
         photoSettings.isAutoContentAwareDistortionCorrectionEnabled = enableAutoDistortionCorrection
       }

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -42,13 +42,13 @@ extension CameraView {
       // photo codec
       if let photoCodecString = options["photoCodec"] as? String {
         guard let photoCodec = AVVideoCodecType(withString: photoCodecString) else {
-          promise.reject(error: .capture(.invalidPhotoCodec))
+          promise.reject(error: .parameter(.invalid(unionName: "PhotoCodec", receivedValue: photoCodecString)))
           return
         }
         if photoOutput.availablePhotoCodecTypes.contains(photoCodec) {
           format = [AVVideoCodecKey: photoCodec]
         } else {
-          promise.reject(error: .parameter(.invalid(unionName: "PhotoCodec", receivedValue: photoCodecString)))
+          promise.reject(error: .capture(.invalidPhotoCodec))
           return
         }
       }

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -71,18 +71,10 @@ extension CameraView {
         photoSettings.flashMode = flashMode
       }
       
-      // high resolution
-      photoSettings.isHighResolutionPhotoEnabled = photoOutput.isHighResolutionCaptureEnabled
-      if !photoSettings.availablePreviewPhotoPixelFormatTypes.isEmpty {
-        photoSettings.previewPhotoFormat = [kCVPixelBufferPixelFormatTypeKey as String: photoSettings.availablePreviewPhotoPixelFormatTypes.first!]
-      }
-      
       // depth data
       photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
-      photoSettings.embedsDepthDataInPhoto = photoSettings.isDepthDataDeliveryEnabled
       if #available(iOS 12.0, *) {
         photoSettings.isPortraitEffectsMatteDeliveryEnabled = photoOutput.isPortraitEffectsMatteDeliveryEnabled
-        photoSettings.embedsPortraitEffectsMatteInPhoto = photoSettings.isPortraitEffectsMatteDeliveryEnabled
       }
       
       // quality prioritization

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -41,7 +41,7 @@ extension CameraView {
       var photoSettings = AVCapturePhotoSettings()
 
       // default, overridable settings if high quality capture was enabled
-      if self.enableHighQualityCapture?.boolValue == true {
+      if self.enableHighQualityPhotos?.boolValue == true {
         photoSettings.isHighResolutionPhotoEnabled = true
         if #available(iOS 13.0, *) {
           photoSettings.photoQualityPrioritization = .quality

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -91,6 +91,9 @@ extension CameraView {
       }
 
       photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise))
+      
+      // Assume that `takePhoto` is always called with the same parameters, so prepare the next call too.
+      photoOutput.setPreparedPhotoSettingsArray([photoSettings], completionHandler: nil)
     }
   }
 }

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -35,11 +35,11 @@ extension CameraView {
           return
         }
       }
-      
+
       ReactLogger.log(level: .info, message: "Capturing photo...")
 
       var photoSettings = AVCapturePhotoSettings()
-      
+
       // default, overridable settings if high quality capture was enabled
       if self.enableHighQualityCapture?.boolValue == true {
         photoSettings.isHighResolutionPhotoEnabled = true
@@ -47,7 +47,7 @@ extension CameraView {
           photoSettings.photoQualityPrioritization = .quality
         }
       }
-      
+
       // photo codec
       if let photoCodecString = options["photoCodec"] as? String {
         guard let photoCodec = AVVideoCodecType(withString: photoCodecString) else {
@@ -61,7 +61,7 @@ extension CameraView {
           return
         }
       }
-      
+
       // flash
       if videoDeviceInput.device.isFlashAvailable, let flash = options["flash"] as? String {
         guard let flashMode = AVCaptureDevice.FlashMode(withString: flash) else {
@@ -70,13 +70,13 @@ extension CameraView {
         }
         photoSettings.flashMode = flashMode
       }
-      
+
       // depth data
       photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
       if #available(iOS 12.0, *) {
         photoSettings.isPortraitEffectsMatteDeliveryEnabled = photoOutput.isPortraitEffectsMatteDeliveryEnabled
       }
-      
+
       // quality prioritization
       if #available(iOS 13.0, *), let qualityPrioritization = options["qualityPrioritization"] as? String {
         guard let photoQualityPrioritization = AVCapturePhotoOutput.QualityPrioritization(withString: qualityPrioritization) else {
@@ -85,24 +85,24 @@ extension CameraView {
         }
         photoSettings.photoQualityPrioritization = photoQualityPrioritization
       }
-      
+
       // red-eye reduction
       if #available(iOS 12.0, *), let autoRedEyeReduction = options["enableAutoRedEyeReduction"] as? Bool {
         photoSettings.isAutoRedEyeReductionEnabled = autoRedEyeReduction
       }
-      
+
       // stabilization
       if let enableAutoStabilization = options["enableAutoStabilization"] as? Bool {
         photoSettings.isAutoStillImageStabilizationEnabled = enableAutoStabilization
       }
-      
+
       // distortion correction
       if #available(iOS 14.1, *), let enableAutoDistortionCorrection = options["enableAutoDistortionCorrection"] as? Bool {
         photoSettings.isAutoContentAwareDistortionCorrectionEnabled = enableAutoDistortionCorrection
       }
 
       photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise))
-      
+
       // Assume that `takePhoto` is always called with the same parameters, so prepare the next call too.
       photoOutput.setPreparedPhotoSettingsArray([photoSettings], completionHandler: nil)
     }

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -35,8 +35,18 @@ extension CameraView {
           return
         }
       }
+      
+      ReactLogger.log(level: .info, message: "Capturing photo...")
 
       var photoSettings = AVCapturePhotoSettings()
+      
+      // default, overridable settings if high quality capture was enabled
+      if self.enableHighQualityCapture?.boolValue == true {
+        photoSettings.isHighResolutionPhotoEnabled = true
+        if #available(iOS 13.0, *) {
+          photoSettings.photoQualityPrioritization = .quality
+        }
+      }
       
       // photo codec
       if let photoCodecString = options["photoCodec"] as? String {
@@ -49,16 +59,6 @@ extension CameraView {
         } else {
           promise.reject(error: .parameter(.invalid(unionName: "PhotoCodec", receivedValue: photoCodecString)))
           return
-        }
-      }
-      
-      if self.enableHighQualityCapture?.boolValue == true {
-        photoSettings.isHighResolutionPhotoEnabled = true
-        if #available(iOS 13.0, *) {
-          photoSettings.photoQualityPrioritization = .quality
-          photoSettings.isAutoVirtualDeviceFusionEnabled = photoOutput.isVirtualDeviceFusionSupported
-        } else {
-          photoSettings.isAutoDualCameraFusionEnabled = photoOutput.isDualCameraFusionSupported
         }
       }
       
@@ -97,15 +97,6 @@ extension CameraView {
       // red-eye reduction
       if #available(iOS 12.0, *), let autoRedEyeReduction = options["enableAutoRedEyeReduction"] as? Bool {
         photoSettings.isAutoRedEyeReductionEnabled = autoRedEyeReduction
-      }
-      
-      // virtual device fusion
-      if let enableVirtualDeviceFusion = options["enableVirtualDeviceFusion"] as? Bool {
-        if #available(iOS 13.0, *) {
-          photoSettings.isAutoVirtualDeviceFusionEnabled = enableVirtualDeviceFusion
-        } else {
-          photoSettings.isAutoDualCameraFusionEnabled = enableVirtualDeviceFusion
-        }
       }
       
       // stabilization

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -38,7 +38,7 @@ extension CameraView {
 
       ReactLogger.log(level: .info, message: "Capturing photo...")
 
-      var format: [String: Any]? = nil
+      var format: [String: Any]?
       // photo codec
       if let photoCodecString = options["photoCodec"] as? String {
         guard let photoCodec = AVVideoCodecType(withString: photoCodecString) else {
@@ -52,7 +52,7 @@ extension CameraView {
           return
         }
       }
-      
+
       // Create photo settings
       let photoSettings = AVCapturePhotoSettings(format: format)
 

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -38,16 +38,7 @@ extension CameraView {
 
       ReactLogger.log(level: .info, message: "Capturing photo...")
 
-      var photoSettings = AVCapturePhotoSettings()
-
-      // default, overridable settings if high quality capture was enabled
-      if self.enableHighQualityPhotos?.boolValue == true {
-        photoSettings.isHighResolutionPhotoEnabled = true
-        if #available(iOS 13.0, *) {
-          photoSettings.photoQualityPrioritization = .quality
-        }
-      }
-
+      var format: [String: Any]? = nil
       // photo codec
       if let photoCodecString = options["photoCodec"] as? String {
         guard let photoCodec = AVVideoCodecType(withString: photoCodecString) else {
@@ -55,10 +46,21 @@ extension CameraView {
           return
         }
         if photoOutput.availablePhotoCodecTypes.contains(photoCodec) {
-          photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: photoCodec])
+          format = [AVVideoCodecKey: photoCodec]
         } else {
           promise.reject(error: .parameter(.invalid(unionName: "PhotoCodec", receivedValue: photoCodecString)))
           return
+        }
+      }
+      
+      // Create photo settings
+      let photoSettings = AVCapturePhotoSettings(format: format)
+
+      // default, overridable settings if high quality capture was enabled
+      if self.enableHighQualityPhotos?.boolValue == true {
+        photoSettings.isHighResolutionPhotoEnabled = true
+        if #available(iOS 13.0, *) {
+          photoSettings.photoQualityPrioritization = .quality
         }
       }
 

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -21,7 +21,7 @@ import UIKit
 
 private let propsThatRequireReconfiguration = ["cameraId",
                                                "enableDepthData",
-                                               "enableHighResolutionCapture",
+                                               "enableHighQualityCapture",
                                                "enablePortraitEffectsMatteDelivery",
                                                "preset",
                                                "photo",
@@ -40,7 +40,7 @@ public final class CameraView: UIView {
   // props that require reconfiguring
   @objc var cameraId: NSString?
   @objc var enableDepthData = false
-  @objc var enableHighResolutionCapture: NSNumber? // nullable bool
+  @objc var enableHighQualityCapture: NSNumber? // nullable bool
   @objc var enablePortraitEffectsMatteDelivery = false
   @objc var preset: String?
   // use cases

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -21,7 +21,7 @@ import UIKit
 
 private let propsThatRequireReconfiguration = ["cameraId",
                                                "enableDepthData",
-                                               "enableHighQualityCapture",
+                                               "enableHighQualityPhotos",
                                                "enablePortraitEffectsMatteDelivery",
                                                "preset",
                                                "photo",
@@ -40,7 +40,7 @@ public final class CameraView: UIView {
   // props that require reconfiguring
   @objc var cameraId: NSString?
   @objc var enableDepthData = false
-  @objc var enableHighQualityCapture: NSNumber? // nullable bool
+  @objc var enableHighQualityPhotos: NSNumber? // nullable bool
   @objc var enablePortraitEffectsMatteDelivery = false
   @objc var preset: String?
   // use cases

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -25,7 +25,7 @@ RCT_EXTERN_METHOD(getAvailableCameraDevices:(RCTPromiseResolveBlock)resolve reje
 RCT_EXPORT_VIEW_PROPERTY(isActive, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(cameraId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enableDepthData, BOOL);
-RCT_EXPORT_VIEW_PROPERTY(enableHighResolutionCapture, NSNumber); // nullable bool
+RCT_EXPORT_VIEW_PROPERTY(enableHighQualityCapture, NSNumber); // nullable bool
 RCT_EXPORT_VIEW_PROPERTY(enablePortraitEffectsMatteDelivery, BOOL);
 // use cases
 RCT_EXPORT_VIEW_PROPERTY(photo, NSNumber); // nullable bool

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -25,7 +25,7 @@ RCT_EXTERN_METHOD(getAvailableCameraDevices:(RCTPromiseResolveBlock)resolve reje
 RCT_EXPORT_VIEW_PROPERTY(isActive, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(cameraId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enableDepthData, BOOL);
-RCT_EXPORT_VIEW_PROPERTY(enableHighQualityCapture, NSNumber); // nullable bool
+RCT_EXPORT_VIEW_PROPERTY(enableHighQualityPhotos, NSNumber); // nullable bool
 RCT_EXPORT_VIEW_PROPERTY(enablePortraitEffectsMatteDelivery, BOOL);
 // use cases
 RCT_EXPORT_VIEW_PROPERTY(photo, NSNumber); // nullable bool

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -135,11 +135,17 @@ export interface CameraProps extends ViewProps {
    */
   enablePortraitEffectsMatteDelivery?: boolean;
   /**
-   * Indicates whether the photo render pipeline should be configured to deliver high resolution still images
+   * Indicates whether the Camera should prioritize high quality photo capture over speed.
+   *
+   * This enables:
+   * * High Resolution Capture ([`isHighResolutionCaptureEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/1648721-ishighresolutioncaptureenabled))
+   * * Virtual Device fusion for greater detail ([`isVirtualDeviceConstituentPhotoDeliveryEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/3192189-isvirtualdeviceconstituentphotod))
+   * * Dual Device fusion for greater detail ([`isDualCameraDualPhotoDeliveryEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotosettings/2873917-isdualcameradualphotodeliveryena))
+   * * Sets the maximum quality prioritization to `.quality` ([`maxPhotoQualityPrioritization`](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/3182995-maxphotoqualityprioritization))
    *
    * @default false
    */
-  enableHighResolutionCapture?: boolean;
+  enableHighQualityCapture?: boolean;
 
   //#region Events
   /**

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -145,7 +145,7 @@ export interface CameraProps extends ViewProps {
    *
    * @default false
    */
-  enableHighQualityCapture?: boolean;
+  enableHighQualityPhotos?: boolean;
 
   //#region Events
   /**

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -135,7 +135,7 @@ export interface CameraProps extends ViewProps {
    */
   enablePortraitEffectsMatteDelivery?: boolean;
   /**
-   * Indicates whether the Camera should prioritize high quality photo capture over speed.
+   * Indicates whether the Camera should prepare the photo pipeline to provide maximum quality photos.
    *
    * This enables:
    * * High Resolution Capture ([`isHighResolutionCaptureEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/1648721-ishighresolutioncaptureenabled))

--- a/src/PhotoFile.ts
+++ b/src/PhotoFile.ts
@@ -25,13 +25,6 @@ export interface TakePhotoOptions {
    */
   enableAutoRedEyeReduction?: boolean;
   /**
-   * Specifies whether a virtual multi-cam device should capture images from all containing physical cameras
-   * to create a combined, higher quality image.
-   *
-   * @see [`isAutoVirtualDeviceFusionEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotosettings/3192192-isautovirtualdevicefusionenabled)
-   */
-  enableVirtualDeviceFusion?: boolean;
-  /**
    * Indicates whether still image stabilization will be employed when capturing the photo
    *
    * @default false


### PR DESCRIPTION
* Remove `enableVirtualDeviceFusion` (default is true anyways)
* Add `enableHighQualityPhotos` which toggles 3 props
* Prepare `photoOutput` for next `takePhoto` call for faster performance on consecutive photo requests