### PR TITLE
fix: add rotation when flipping an image

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
@@ -45,6 +45,8 @@ fun flipImage(imageBytes: ByteArray): ByteArray {
   val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
   val matrix = Matrix()
   matrix.preScale(-1f, 1f)
+  // Setting post rotate to 90 because image will be possibly in landscape
+  matrix.postRotate(90f);
   val newBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
   val stream = ByteArrayOutputStream()
   newBitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)


### PR DESCRIPTION
Based on SO: https://stackoverflow.com/a/28657257/12270852

What I noticed is that the image is rotated. This worked on my pixel 2 XL. I am not sure exactly why the rotation is needed. any help would be appreciated

<!-- ❤️ Thank you for your contribution! ❤️ -->

## What

<!--
This PR fixes an issue where selfie images appear rotated

## Changes

if you are flipping the image, add a 90-degree rotation

## Tested on

Pixel 2 XL Android 11

## Related issues

Fixes: #146 
