### PR TITLE
fix: React Native 0.65 compatibility

### DIFF
--- a/VisionCamera.podspec
+++ b/VisionCamera.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     "DEFINES_MODULE" => "YES",
     "USE_HEADERMAP" => "YES",
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\""
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"$(PODS_ROOT)/Headers/Public/React-hermes\" \"$(PODS_ROOT)/Headers/Public/hermes-engine\""
   }
   s.requires_arc = true
 

--- a/VisionCamera.podspec
+++ b/VisionCamera.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     "DEFINES_MODULE" => "YES",
     "USE_HEADERMAP" => "YES",
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/Headers/Private/React-Core\" "
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\""
   }
   s.requires_arc = true
 

--- a/cpp/MakeJSIRuntime.h
+++ b/cpp/MakeJSIRuntime.h
@@ -19,7 +19,10 @@
 
 // on iOS, we simply check by __has_include. Headers are only available if the sources are there too.
 
-#if __has_include(<hermes/hermes.h>)
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+// Hermes (https://hermesengine.dev) (RN 0.65+)
+#include <reacthermes/HermesExecutorFactory.h>
+#elif __has_include(<hermes/hermes.h>)
 // Hermes (https://hermesengine.dev)
 #include <hermes/hermes.h>
 #elif __has_include(<v8runtime/V8RuntimeFactory.h>)
@@ -47,7 +50,7 @@ static std::unique_ptr<jsi::Runtime> makeJSIRuntime() {
 
 #else
 
-  #if __has_include(<hermes/hermes.h>)
+  #if __has_include(<hermes/hermes.h>) || __has_include(<reacthermes/HermesExecutorFactory.h>)
   return facebook::hermes::makeHermesRuntime();
   #elif __has_include(<v8runtime/V8RuntimeFactory.h>)
   return facebook::createV8Runtime("");


### PR DESCRIPTION
Uses the new Hermes header import from RN 0.65 to fix compatibility.

Thanks to @Titozzz via https://github.com/software-mansion/react-native-reanimated/pull/2156