### PR TITLE
perf: Avoid expensive CMSampleBuffer copy

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -322,7 +322,7 @@ PODS:
     - React
   - RNVectorIcons (8.1.0):
     - React-Core
-  - VisionCamera (2.4.2-beta.3):
+  - VisionCamera (2.4.2-beta.7):
     - React
     - React-callinvoker
     - React-Core
@@ -490,7 +490,7 @@ SPEC CHECKSUMS:
   RNReanimated: 9c13c86454bfd54dab7505c1a054470bfecd2563
   RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
-  VisionCamera: 33eb4044a1bee72eac4e1ad26a64b30b5ffe41a6
+  VisionCamera: d65c038e7a538fbd719f3ff3e7511a2c71111e3a
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac
 
 PODFILE CHECKSUM: 4b093c1d474775c2eac3268011e4b0b80929d3a2

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -215,23 +215,14 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       if diff > UInt64(nanosecondsPerFrame) {
         if !isRunningFrameProcessor {
           // we're not in the middle of executing the Frame Processor, so prepare for next call.
-          var bufferCopy: CMSampleBuffer?
-          CMSampleBufferCreateCopy(allocator: kCFAllocatorDefault,
-                                   sampleBuffer: sampleBuffer,
-                                   sampleBufferOut: &bufferCopy)
-          if let bufferCopy = bufferCopy {
-            // successfully copied buffer, dispatch frame processor call.
-            CameraQueues.frameProcessorQueue.async {
-              self.isRunningFrameProcessor = true
-              let frame = Frame(buffer: bufferCopy, orientation: self.bufferOrientation)
-              frameProcessor(frame)
-              self.isRunningFrameProcessor = false
-            }
-            lastFrameProcessorCall = DispatchTime.now()
-          } else {
-            // failed to create a buffer copy.
-            ReactLogger.log(level: .error, message: "Failed to copy buffer! Frame Processor cannot be called.", alsoLogToJS: true)
+          // successfully copied buffer, dispatch frame processor call.
+          CameraQueues.frameProcessorQueue.async {
+            self.isRunningFrameProcessor = true
+            let frame = Frame(buffer: sampleBuffer, orientation: self.bufferOrientation)
+            frameProcessor(frame)
+            self.isRunningFrameProcessor = false
           }
+          lastFrameProcessorCall = DispatchTime.now()
         } else {
           // we're still in the middle of executing a Frame Processor for a previous frame, notify user about dropped frame.
           if !hasLoggedFrameProcessorFrameDropWarning {

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -215,7 +215,6 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       if diff > UInt64(nanosecondsPerFrame) {
         if !isRunningFrameProcessor {
           // we're not in the middle of executing the Frame Processor, so prepare for next call.
-          // successfully copied buffer, dispatch frame processor call.
           CameraQueues.frameProcessorQueue.async {
             self.isRunningFrameProcessor = true
             let frame = Frame(buffer: sampleBuffer, orientation: self.bufferOrientation)


### PR DESCRIPTION
For calling Frame Processors I always created a copy of the `CMSampleBuffer`. I don't think this is necessary, ARC will automatically retain it until the frame processor has finished executing anyways. I also don't think video frames will be dropped, since AVFoundation maintains a pool of buffers and the frame processor does (often) not execute every single frame.

This requires a bit more testing, but in general it should greatly improve the performance of frame processors, since a huge copy (~10MB per frame) is avoided.