### PR TITLE
fix: Fix Frame Processor Runtime being initialized twice causing a hot-reload crash

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -478,7 +478,6 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
     const val TAG_PERF = "CameraView.performance"
 
     private val propsThatRequireSessionReconfiguration = arrayListOf("cameraId", "format", "fps", "hdr", "lowLightBoost", "photo", "video", "frameProcessorFps")
-
     private val arrayListOfZoom = arrayListOf("zoom")
   }
 }

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -113,7 +113,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   private var maxZoom: Float = 1f
 
   @DoNotStrip
-  private var mHybridData: HybridData?
+  private var mHybridData: HybridData
 
   @Suppress("LiftReturnOrAssignment", "RedundantIf")
   internal val fallbackToSnapshot: Boolean
@@ -185,7 +185,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   }
 
   fun finalize() {
-    mHybridData?.resetNative()
+    mHybridData.resetNative()
   }
 
   private external fun initHybrid(): HybridData

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -155,16 +155,16 @@ class CameraViewManager : SimpleViewManager<CameraView>() {
   }
 
   override fun onDropViewInstance(view: CameraView) {
-    Log.d(REACT_CLASS, "onDropViewInstance() called!")
+    Log.d(TAG, "onDropViewInstance() called!")
     super.onDropViewInstance(view)
   }
 
   override fun getName(): String {
-    return REACT_CLASS
+    return TAG
   }
 
   companion object {
-    const val REACT_CLASS = "CameraView"
+    const val TAG = "CameraView"
 
     val cameraViewTransactions: HashMap<CameraView, ArrayList<String>> = HashMap()
   }

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -28,7 +28,6 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     const val REACT_CLASS = "CameraView"
     var RequestCode = 10
     val FrameProcessorThread: ExecutorService = Executors.newSingleThreadExecutor()
-    private var didInitFrameProcessorRuntime = false
 
     fun parsePermissionStatus(status: Int): String {
       return when (status) {
@@ -43,8 +42,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
 
   override fun initialize() {
     super.initialize()
-    if (!didInitFrameProcessorRuntime) {
-      didInitFrameProcessorRuntime = true
+    if (frameProcessorManager == null) {
       FrameProcessorThread.execute {
         frameProcessorManager = FrameProcessorRuntimeManager(reactApplicationContext)
         reactApplicationContext.runOnJSQueueThread {
@@ -57,6 +55,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
   override fun onCatalystInstanceDestroy() {
     super.onCatalystInstanceDestroy()
     frameProcessorManager?.destroy()
+    frameProcessorManager = null
   }
 
   override fun getName(): String {

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -28,6 +28,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     const val REACT_CLASS = "CameraView"
     var RequestCode = 10
     val FrameProcessorThread: ExecutorService = Executors.newSingleThreadExecutor()
+    private var didInitFrameProcessorRuntime = false
 
     fun parsePermissionStatus(status: Int): String {
       return when (status) {
@@ -42,10 +43,13 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
 
   override fun initialize() {
     super.initialize()
-    FrameProcessorThread.execute {
-      frameProcessorManager = FrameProcessorRuntimeManager(reactApplicationContext)
-      reactApplicationContext.runOnJSQueueThread {
-        frameProcessorManager!!.installJSIBindings()
+    if (!didInitFrameProcessorRuntime) {
+      didInitFrameProcessorRuntime = true
+      FrameProcessorThread.execute {
+        frameProcessorManager = FrameProcessorRuntimeManager(reactApplicationContext)
+        reactApplicationContext.runOnJSQueueThread {
+          frameProcessorManager!!.installJSIBindings()
+        }
       }
     }
   }

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.guava.await
 
 class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
   companion object {
-    const val REACT_CLASS = "CameraView"
+    const val TAG = "CameraView"
     var RequestCode = 10
     val FrameProcessorThread: ExecutorService = Executors.newSingleThreadExecutor()
 
@@ -59,7 +59,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
   }
 
   override fun getName(): String {
-    return REACT_CLASS
+    return TAG
   }
 
   private fun findCameraView(id: Int): CameraView = reactApplicationContext.currentActivity?.findViewById(id) ?: throw ViewNotFoundError(id)
@@ -211,7 +211,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
               val secondsPerFrame = try {
                 cameraConfig.getOutputMinFrameDuration(formatId, size) / 1_000_000_000.0
               } catch (error: Throwable) {
-                Log.e(REACT_CLASS, "Minimum Frame Duration for MediaRecorder Output cannot be calculated, format \"$formatName\" is not supported.")
+                Log.e(TAG, "Minimum Frame Duration for MediaRecorder Output cannot be calculated, format \"$formatName\" is not supported.")
                 null
               }
 
@@ -267,7 +267,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
         }
 
         val difference = System.currentTimeMillis() - startTime
-        Log.w(REACT_CLASS, "CameraViewModule::getAvailableCameraDevices took: $difference ms")
+        Log.w(TAG, "CameraViewModule::getAvailableCameraDevices took: $difference ms")
         return@withPromise cameraDevices
       }
     }

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
@@ -24,15 +24,15 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext) {
   }
 
   @DoNotStrip
-  private var mHybridData: HybridData?
-  private var mContext: WeakReference<ReactApplicationContext>?
-  private var mScheduler: Scheduler?
+  private var mHybridData: HybridData
+  private var mContext: WeakReference<ReactApplicationContext>
+  private var mScheduler: Scheduler
 
   init {
     val holder = context.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl
     mScheduler = Scheduler(context)
     mContext = WeakReference(context)
-    mHybridData = initHybrid(context.javaScriptContextHolder.get(), holder, mScheduler!!)
+    mHybridData = initHybrid(context.javaScriptContextHolder.get(), holder, mScheduler)
     initializeRuntime()
 
     Log.i(TAG, "Installing Frame Processor Plugins...")
@@ -43,15 +43,15 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext) {
   }
 
   fun destroy() {
-    mScheduler?.deactivate()
-    mHybridData?.resetNative()
+    mScheduler.deactivate()
+    mHybridData.resetNative()
   }
 
   @DoNotStrip
   @Keep
   fun findCameraViewById(viewId: Int): CameraView {
     Log.d(TAG, "finding view $viewId...")
-    val view = mContext?.get()?.currentActivity?.findViewById<CameraView>(viewId)
+    val view = mContext.get()?.currentActivity?.findViewById<CameraView>(viewId)
     Log.d(TAG, "found view $viewId! is null: ${view == null}")
     return view ?: throw ViewNotFoundError(viewId)
   }

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
@@ -61,7 +61,7 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext) {
     jsContext: Long,
     jsCallInvokerHolder: CallInvokerHolderImpl,
     scheduler: Scheduler
-  ): HybridData?
+  ): HybridData
   private external fun initializeRuntime()
   private external fun registerPlugin(plugin: FrameProcessorPlugin)
 

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
@@ -15,15 +15,7 @@ import java.lang.ref.WeakReference
 class FrameProcessorRuntimeManager(context: ReactApplicationContext) {
   companion object {
     const val TAG = "FrameProcessorRuntime"
-    private var HasRegisteredPlugins = false
     val Plugins: ArrayList<FrameProcessorPlugin> = ArrayList()
-      get() {
-        if (HasRegisteredPlugins) {
-          throw Error("Tried to access Frame Processor Plugin list, " +
-            "but plugins have already been registered (list is frozen now!).")
-        }
-        return field
-      }
 
     init {
       System.loadLibrary("reanimated")
@@ -48,7 +40,6 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext) {
       registerPlugin(plugin)
     }
     Log.i(TAG, "Successfully installed ${Plugins.count()} Frame Processor Plugins!")
-    HasRegisteredPlugins = true
   }
 
   fun destroy() {


### PR DESCRIPTION

<!-- ❤️ Thank you for your contribution! ❤️ -->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
