### PR TITLE
chore: fix the permission issue for dependabot

### DIFF
--- a/.github/workflows/notice-yarn-changes.yml
+++ b/.github/workflows/notice-yarn-changes.yml
@@ -1,11 +1,11 @@
 name: Notice yarn.lock changes
 on: [pull_request]
-permissions:
-  pull-requests: write
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/notice-yarn-changes.yml
+++ b/.github/workflows/notice-yarn-changes.yml
@@ -1,5 +1,7 @@
 name: Notice yarn.lock changes
 on: [pull_request]
+permissions:
+  pull-requests: write
 
 jobs:
   check:


### PR DESCRIPTION
## What

This PR attempts to fix the lacking permission for the Dependabot PR.

## Changes

To achieve this, I have added manually the additional `permissions` to the Yarn Lock workflow, according to the docs:
* https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions

Maybe also `action` will need to be set to `write`.

> You can use the permissions key to add and remove read permissions for forked repositories, but typically you can't grant write access. The exception to this behavior is where an admin user has selected the "Send write tokens to workflows from pull requests" option in the GitHub Actions settings.

If the workflow change alone did not help, please check if you have the mentioned option selected in the repository settings.

## Tested on

~~This workflow? 😨~~

* https://github.com/Simek/yarn-lock-changes/pull/31

## Related issues

* https://github.com/Simek/yarn-lock-changes/issues/26
