### PR TITLE
fix: Fix "`REACT_NATIVE_UTILS_LIB` not found" build error

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -54,12 +54,32 @@ target_include_directories(
 # find libraries
 
 file (GLOB LIBRN_DIR "${BUILD_DIR}/react-native-0*/jni/${ANDROID_ABI}")
-file (GLOB LIBJSC_DIR "${BUILD_DIR}/android-jsc*.aar/jni/${ANDROID_ABI}")
-file (GLOB LIBHERMES_DIR "${BUILD_DIR}/third-party-ndk/hermes/jni/${ANDROID_ABI}")
 
 if(${FOR_HERMES})
+else()
+endif()
+
+if(${FOR_HERMES})
+    file (GLOB LIBHERMES_DIR "${BUILD_DIR}/third-party-ndk/hermes/jni/${ANDROID_ABI}")
+    # Use Hermes
+    find_library(
+            JS_ENGINE_LIB
+            hermes
+            PATHS ${LIBHERMES_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+    # Use Reanimated Hermes
     file (GLOB LIBREANIMATED_DIR "${BUILD_DIR}/react-native-reanimated-*-hermes.aar/jni/${ANDROID_ABI}")
 else()
+    file (GLOB LIBJSC_DIR "${BUILD_DIR}/android-jsc*.aar/jni/${ANDROID_ABI}")
+    # Use JSC
+    find_library(
+            JS_ENGINE_LIB
+            jscexecutor
+            PATHS ${LIBRN_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+    # Use Reanimated JSC
     file (GLOB LIBREANIMATED_DIR "${BUILD_DIR}/react-native-reanimated-*-jsc.aar/jni/${ANDROID_ABI}")
 endif()
 
@@ -95,43 +115,16 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 
-find_library(
-        HERMES_LIB
-        hermes
-        PATHS ${LIBHERMES_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
-        JSEXECUTOR_LIB
-        jscexecutor
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-
 # linking
 
 message(WARNING "VisionCamera linking: FOR_HERMES=${FOR_HERMES}")
-
-if(${FOR_HERMES})
-    target_link_libraries(
-            ${PACKAGE_NAME}
-            ${LOG_LIB}
-            ${HERMES_LIB}
-            ${REANIMATED_LIB}
-            ${REACT_NATIVE_JNI_LIB}
-            ${FBJNI_LIB}
-            ${FOLLY_JSON_LIB}
-            android
-    )
-else()
-    target_link_libraries(
-            ${PACKAGE_NAME}
-            ${LOG_LIB}
-            ${JSEXECUTOR_LIB}
-            ${REANIMATED_LIB}
-            ${REACT_NATIVE_JNI_LIB}
-            ${FBJNI_LIB}
-            ${FOLLY_JSON_LIB}
-            android
-    )
-endif()
+target_link_libraries(
+        ${PACKAGE_NAME}
+        ${LOG_LIB}
+        ${JS_ENGINE_LIB} # <-- Hermes or JSC
+        ${REANIMATED_LIB}
+        ${REACT_NATIVE_JNI_LIB}
+        ${FBJNI_LIB}
+        ${FOLLY_JSON_LIB}
+        android
+)

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -96,13 +96,6 @@ find_library(
 )
 
 find_library(
-        REACT_NATIVE_UTILS_LIB
-        reactnativeutilsjni
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-
-find_library(
         HERMES_LIB
         hermes
         PATHS ${LIBHERMES_DIR}
@@ -126,7 +119,6 @@ if(${FOR_HERMES})
             ${HERMES_LIB}
             ${REANIMATED_LIB}
             ${REACT_NATIVE_JNI_LIB}
-            ${REACT_NATIVE_UTILS_LIB}
             ${FBJNI_LIB}
             ${FOLLY_JSON_LIB}
             android
@@ -138,7 +130,6 @@ else()
             ${JSEXECUTOR_LIB}
             ${REANIMATED_LIB}
             ${REACT_NATIVE_JNI_LIB}
-            ${REACT_NATIVE_UTILS_LIB}
             ${FBJNI_LIB}
             ${FOLLY_JSON_LIB}
             android


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What


<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
* Fixes #292
