### PR TITLE
fix: Use `RCTBlockGuard` for callback conversion

### DIFF
--- a/ios/React Utils/JSIUtils.mm
+++ b/ios/React Utils/JSIUtils.mm
@@ -192,7 +192,10 @@ RCTResponseSenderBlock convertJSIFunctionToCallback(jsi::Runtime &runtime, const
       }
 
       const jsi::Value* args = convertNSArrayToJSICStyleArray(strongWrapper2->runtime(), responses);
+
       strongWrapper2->callback().call(strongWrapper2->runtime(), args, static_cast<size_t>(responses.count));
+
+      delete[] args;
       strongWrapper2->destroy();
 
       // Delete the CallbackWrapper when the block gets dealloced without being invoked.


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Right now, a JS Callback that never gets called results in a memory leak (`CallbackWrapper` is a dangling weak reference).  This PR fixes this by using `RCTBlockGuard`, a new API introduced in RN 0.64 for cleaning up a JS Callback that never got called.

So now the dangling weak `CallbackWrapper` gets deleted once the native code has no strong references to the callback anymore.

This is a really rare use-case and will probably never be used anyways, so I'm not sure about merging this.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
