### PR TITLE
fix: Throw JS errors if JSI <-> JNI conversion failed

### DIFF
--- a/android/src/main/cpp/JSIJNIConversion.cpp
+++ b/android/src/main/cpp/JSIJNIConversion.cpp
@@ -74,14 +74,14 @@ jobject JSIJNIConversion::convertJSIValueToJNIObject(jsi::Runtime &runtime, cons
         return hostObject->frame.get();
       } else {
         // it's different kind of HostObject. We don't support it.
-        return nullptr;
+        throw std::runtime_error("Received an unknown HostObject! Cannot convert to a JNI value.");
       }
 
     } else if (object.isFunction(runtime)) {
       // jsi::Function
 
       // TODO: Convert Function to Callback
-      return nullptr;
+      throw std::runtime_error("Cannot convert a JS Function to a JNI value (yet)!");
 
     } else {
       // jsi::Object
@@ -89,13 +89,15 @@ jobject JSIJNIConversion::convertJSIValueToJNIObject(jsi::Runtime &runtime, cons
       auto dynamic = jsi::dynamicFromValue(runtime, value);
       auto map = react::ReadableNativeMap::createWithContents(std::move(dynamic));
       return map.release();
+
     }
   } else {
     // unknown jsi type!
+
     auto stringRepresentation = value.toString(runtime).utf8(runtime);
-    auto message = "Received unknown JSI value! (" + stringRepresentation + ") Cannot convert to JNI Object.";
-    __android_log_write(ANDROID_LOG_ERROR, "VisionCamera", message.c_str());
-    return nullptr;
+    auto message = "Received unknown JSI value! (" + stringRepresentation + ") Cannot convert to a JNI value.";
+    throw std::runtime_error(message);
+
   }
 }
 

--- a/docs/docs/guides/FRAME_PROCESSORS_CREATE_OVERVIEW.mdx
+++ b/docs/docs/guides/FRAME_PROCESSORS_CREATE_OVERVIEW.mdx
@@ -39,8 +39,8 @@ Similar to a TurboModule, the Frame Processor Plugin Registry API automatically 
 | `number`             | `NSNumber*` (double)          | `Double`                   |
 | `boolean`            | `NSNumber*` (boolean)         | `Boolean`                  |
 | `string`             | `NSString*`                   | `String`                   |
-| `[]`                 | `NSArray*`                    | `ArrayList<E>`             |
-| `{}`                 | `NSDictionary*`               | `HashMap<K, V>`            |
+| `[]`                 | `NSArray*`                    | `ReadableNativeArray`      |
+| `{}`                 | `NSDictionary*`               | `ReadableNativeMap`        |
 | `undefined` / `null` | `nil`                         | `null`                     |
 | `(any, any) => void` | [`RCTResponseSenderBlock`][4] | `(Object, Object) -> void` |
 | [`Frame`][1]         | [`Frame*`][2]                 | [`ImageProxy`][3]          |


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
