### PR TITLE
fix: Improve Android resource efficiency/cleanup (use class members for `CoroutineScope` and `FrameProcessorThread`)

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraPackage.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraPackage.kt
@@ -11,6 +11,6 @@ class CameraPackage : ReactPackage {
   }
 
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-    return listOf(CameraViewManager())
+    return listOf(CameraViewManager(reactContext))
   }
 }

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -62,6 +62,14 @@ import kotlin.math.min
 @Suppress("KotlinJniMissingFunction") // I use fbjni, Android Studio is not smart enough to realize that.
 @SuppressLint("ClickableViewAccessibility") // suppresses the warning that the pinch to zoom gesture is not accessible
 class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
+  companion object {
+    const val TAG = "CameraView"
+    const val TAG_PERF = "CameraView.performance"
+
+    private val propsThatRequireSessionReconfiguration = arrayListOf("cameraId", "format", "fps", "hdr", "lowLightBoost", "photo", "video", "enableFrameProcessor")
+    private val arrayListOfZoom = arrayListOf("zoom")
+  }
+
   // react properties
   // props that require reconfiguring
   var cameraId: String? = null // this is actually not a react prop directly, but the result of setting device={}
@@ -252,7 +260,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   fun update(changedProps: ArrayList<String>) = previewView.post {
     // TODO: Does this introduce too much overhead?
     //  I need to .post on the previewView because it might've not been initialized yet
-    //  I need to use GlobalScope.launch because of the suspend fun [configureSession]
+    //  I need to use CoroutineScope.launch because of the suspend fun [configureSession]
     CameraViewModule.CoroutineScope.launch {
       try {
         val shouldReconfigureSession = changedProps.containsAny(propsThatRequireSessionReconfiguration)
@@ -472,13 +480,5 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
       map.putMap("cause", errorToMap(cause))
     }
     return map
-  }
-
-  companion object {
-    const val TAG = "CameraView"
-    const val TAG_PERF = "CameraView.performance"
-
-    private val propsThatRequireSessionReconfiguration = arrayListOf("cameraId", "format", "fps", "hdr", "lowLightBoost", "photo", "video", "enableFrameProcessor")
-    private val arrayListOfZoom = arrayListOf("zoom")
   }
 }

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -182,7 +182,6 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
     scaleGestureDetector = ScaleGestureDetector(context, scaleGestureListener)
     touchEventListener = OnTouchListener { _, event -> return@OnTouchListener scaleGestureDetector.onTouchEvent(event) }
 
-
     hostLifecycleState = Lifecycle.State.INITIALIZED
     lifecycleRegistry = LifecycleRegistry(this)
     reactContext.addLifecycleEventListener(object : LifecycleEventListener {

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -253,7 +253,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
     // TODO: Does this introduce too much overhead?
     //  I need to .post on the previewView because it might've not been initialized yet
     //  I need to use GlobalScope.launch because of the suspend fun [configureSession]
-    GlobalScope.launch(Dispatchers.Main) {
+    CameraViewModule.CoroutineScope.launch {
       try {
         val shouldReconfigureSession = changedProps.containsAny(propsThatRequireSessionReconfiguration)
         val shouldReconfigureZoom = shouldReconfigureSession || changedProps.contains("zoom")

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -216,10 +216,6 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
     }
   }
 
-  fun finalize() {
-    mHybridData.resetNative()
-  }
-
   private external fun initHybrid(): HybridData
   private external fun frameProcessorCallback(frame: ImageProxy)
 

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -27,7 +27,6 @@ class CameraViewManager(reactContext: ReactApplicationContext) : SimpleViewManag
   }
 
   private fun destroy() {
-    frameProcessorManager?.destroy()
     frameProcessorManager = null
     frameProcessorThread.shutdown()
   }

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -1,18 +1,68 @@
 package com.mrousavy.camera
 
-import android.util.Log
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.mrousavy.camera.frameprocessor.FrameProcessorRuntimeManager
+import java.util.concurrent.Executors
 
-class CameraViewManager : SimpleViewManager<CameraView>() {
-  private fun addChangedPropToTransaction(view: CameraView, changedProp: String) {
-    if (cameraViewTransactions[view] == null) {
-      cameraViewTransactions[view] = ArrayList()
+@Suppress("unused")
+class CameraViewManager(reactContext: ReactApplicationContext) : SimpleViewManager<CameraView>() {
+  private val frameProcessorThread = Executors.newSingleThreadExecutor()
+  private var frameProcessorManager: FrameProcessorRuntimeManager? = null
+
+  init {
+    if (frameProcessorManager == null) {
+      frameProcessorThread.execute {
+        frameProcessorManager = FrameProcessorRuntimeManager(reactContext, frameProcessorThread)
+
+        reactContext.runOnJSQueueThread {
+          frameProcessorManager!!.installJSIBindings()
+        }
+      }
     }
-    cameraViewTransactions[view]!!.add(changedProp)
+  }
+
+  private fun destroy() {
+    frameProcessorManager?.destroy()
+    frameProcessorManager = null
+    frameProcessorThread.shutdown()
+  }
+
+
+  override fun onCatalystInstanceDestroy() {
+    super.onCatalystInstanceDestroy()
+    destroy()
+  }
+
+  override fun invalidate() {
+    super.invalidate()
+    destroy()
+  }
+
+  public override fun createViewInstance(context: ThemedReactContext): CameraView {
+    return CameraView(context, frameProcessorThread)
+  }
+
+  override fun onAfterUpdateTransaction(view: CameraView) {
+    super.onAfterUpdateTransaction(view)
+    val changedProps = cameraViewTransactions[view] ?: ArrayList()
+    view.update(changedProps)
+    cameraViewTransactions.remove(view)
+  }
+
+  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
+    return MapBuilder.builder<String, Any>()
+      .put("cameraInitialized", MapBuilder.of("registrationName", "onInitialized"))
+      .put("cameraError", MapBuilder.of("registrationName", "onError"))
+      .build()
+  }
+
+  override fun getName(): String {
+    return TAG
   }
 
   @ReactProp(name = "cameraId")
@@ -78,6 +128,7 @@ class CameraViewManager : SimpleViewManager<CameraView>() {
     view.format = format
   }
 
+  // TODO: Change when TurboModules release.
   // We're treating -1 as "null" here, because when I make the fps parameter
   // of type "Int?" the react bridge throws an error.
   @ReactProp(name = "fps", defaultInt = -1)
@@ -144,36 +195,16 @@ class CameraViewManager : SimpleViewManager<CameraView>() {
     view.enableZoomGesture = enableZoomGesture
   }
 
-  override fun onAfterUpdateTransaction(view: CameraView) {
-    super.onAfterUpdateTransaction(view)
-    val changedProps = cameraViewTransactions[view] ?: ArrayList()
-    view.update(changedProps)
-    cameraViewTransactions.remove(view)
-  }
-
-  public override fun createViewInstance(context: ThemedReactContext): CameraView {
-    return CameraView(context)
-  }
-
-  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
-    return MapBuilder.builder<String, Any>()
-      .put("cameraInitialized", MapBuilder.of("registrationName", "onInitialized"))
-      .put("cameraError", MapBuilder.of("registrationName", "onError"))
-      .build()
-  }
-
-  override fun onDropViewInstance(view: CameraView) {
-    Log.d(TAG, "onDropViewInstance() called!")
-    super.onDropViewInstance(view)
-  }
-
-  override fun getName(): String {
-    return TAG
-  }
-
   companion object {
     const val TAG = "CameraView"
 
     val cameraViewTransactions: HashMap<CameraView, ArrayList<String>> = HashMap()
+
+    private fun addChangedPropToTransaction(view: CameraView, changedProp: String) {
+      if (cameraViewTransactions[view] == null) {
+        cameraViewTransactions[view] = ArrayList()
+      }
+      cameraViewTransactions[view]!!.add(changedProp)
+    }
   }
 }

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -53,10 +53,22 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     }
   }
 
-  override fun onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy()
+  private fun cleanup() {
     frameProcessorManager?.destroy()
     frameProcessorManager = null
+    if (CoroutineScope.isActive) {
+      CoroutineScope.cancel("CameraViewModule has been destroyed.")
+    }
+  }
+
+  override fun onCatalystInstanceDestroy() {
+    super.onCatalystInstanceDestroy()
+    cleanup()
+  }
+
+  override fun invalidate() {
+    super.invalidate()
+    cleanup()
   }
 
   override fun getName(): String {
@@ -280,18 +292,21 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     }
   }
 
+  @Suppress("unused")
   @ReactMethod
   fun getCameraPermissionStatus(promise: Promise) {
     val status = ContextCompat.checkSelfPermission(reactApplicationContext, Manifest.permission.CAMERA)
     promise.resolve(parsePermissionStatus(status))
   }
 
+  @Suppress("unused")
   @ReactMethod
   fun getMicrophonePermissionStatus(promise: Promise) {
     val status = ContextCompat.checkSelfPermission(reactApplicationContext, Manifest.permission.RECORD_AUDIO)
     promise.resolve(parsePermissionStatus(status))
   }
 
+  @Suppress("unused")
   @ReactMethod
   fun requestCameraPermission(promise: Promise) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
@@ -316,6 +331,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     }
   }
 
+  @Suppress("unused")
   @ReactMethod
   fun requestMicrophonePermission(promise: Promise) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -28,6 +28,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     const val TAG = "CameraView"
     var RequestCode = 10
     val FrameProcessorThread: ExecutorService = Executors.newSingleThreadExecutor()
+    val CoroutineScope = CoroutineScope(Dispatchers.Default)
 
     fun parsePermissionStatus(status: Int): String {
       return when (status) {
@@ -64,9 +65,10 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
 
   private fun findCameraView(id: Int): CameraView = reactApplicationContext.currentActivity?.findViewById(id) ?: throw ViewNotFoundError(id)
 
+  @Suppress("unused")
   @ReactMethod
   fun takePhoto(viewTag: Int, options: ReadableMap, promise: Promise) {
-    GlobalScope.launch(Dispatchers.Main) {
+    CoroutineScope.launch {
       withPromise(promise) {
         val view = findCameraView(viewTag)
         view.takePhoto(options)
@@ -74,9 +76,10 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     }
   }
 
+  @Suppress("unused")
   @ReactMethod
   fun takeSnapshot(viewTag: Int, options: ReadableMap, promise: Promise) {
-    GlobalScope.launch(Dispatchers.Main) {
+    CoroutineScope.launch {
       withPromise(promise) {
         val view = findCameraView(viewTag)
         view.takeSnapshot(options)
@@ -85,9 +88,10 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
   }
 
   // TODO: startRecording() cannot be awaited, because I can't have a Promise and a onRecordedCallback in the same function. Hopefully TurboModules allows that
+  @Suppress("unused")
   @ReactMethod
   fun startRecording(viewTag: Int, options: ReadableMap, onRecordCallback: Callback) {
-    GlobalScope.launch(Dispatchers.Main) {
+    CoroutineScope.launch {
       val view = findCameraView(viewTag)
       try {
         view.startRecording(options, onRecordCallback)
@@ -101,6 +105,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     }
   }
 
+  @Suppress("unused")
   @ReactMethod
   fun stopRecording(viewTag: Int, promise: Promise) {
     withPromise(promise) {
@@ -110,9 +115,10 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     }
   }
 
+  @Suppress("unused")
   @ReactMethod
   fun focus(viewTag: Int, point: ReadableMap, promise: Promise) {
-    GlobalScope.launch(Dispatchers.Main) {
+    CoroutineScope.launch {
       withPromise(promise) {
         val view = findCameraView(viewTag)
         view.focus(point)
@@ -123,10 +129,11 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
 
   // TODO: This uses the Camera2 API to list all characteristics of a camera device and therefore doesn't work with Camera1. Find a way to use CameraX for this
   // https://issuetracker.google.com/issues/179925896
+  @Suppress("unused")
   @ReactMethod
   fun getAvailableCameraDevices(promise: Promise) {
     val startTime = System.currentTimeMillis()
-    GlobalScope.launch(Dispatchers.Main) {
+    CoroutineScope.launch {
       withPromise(promise) {
         val extensionsManager = ExtensionsManager.getInstance(reactApplicationContext).await()
         val cameraProvider = ProcessCameraProvider.getInstance(reactApplicationContext).await()

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorPlugin.java
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorPlugin.java
@@ -39,14 +39,6 @@ public abstract class FrameProcessorPlugin {
         mHybridData = initHybrid(name);
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        super.finalize();
-        if (mHybridData != null) {
-            mHybridData.resetNative();
-        }
-    }
-
     private native @NonNull HybridData initHybrid(@NonNull String name);
 
     /**

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
@@ -10,9 +10,10 @@ import com.mrousavy.camera.CameraView
 import com.mrousavy.camera.ViewNotFoundError
 import com.swmansion.reanimated.Scheduler
 import java.lang.ref.WeakReference
+import java.util.concurrent.ExecutorService
 
 @Suppress("KotlinJniMissingFunction") // I use fbjni, Android Studio is not smart enough to realize that.
-class FrameProcessorRuntimeManager(context: ReactApplicationContext) {
+class FrameProcessorRuntimeManager(context: ReactApplicationContext, frameProcessorThread: ExecutorService) {
   companion object {
     const val TAG = "FrameProcessorRuntime"
     val Plugins: ArrayList<FrameProcessorPlugin> = ArrayList()
@@ -30,7 +31,7 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext) {
 
   init {
     val holder = context.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl
-    mScheduler = VisionCameraScheduler()
+    mScheduler = VisionCameraScheduler(frameProcessorThread)
     mContext = WeakReference(context)
     mHybridData = initHybrid(context.javaScriptContextHolder.get(), holder, mScheduler)
     initializeRuntime()
@@ -46,6 +47,7 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext) {
     mHybridData.resetNative()
   }
 
+  @Suppress("unused")
   @DoNotStrip
   @Keep
   fun findCameraViewById(viewId: Int): CameraView {

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
@@ -43,10 +43,6 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext, frameProces
     Log.i(TAG, "Successfully installed ${Plugins.count()} Frame Processor Plugins!")
   }
 
-  fun destroy() {
-    mHybridData.resetNative()
-  }
-
   @Suppress("unused")
   @DoNotStrip
   @Keep

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraScheduler.java
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraScheduler.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ExecutorService;
 
 @SuppressWarnings("JavaJniMissingFunction") // using fbjni here
 public class VisionCameraScheduler {
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
     @DoNotStrip
     private final HybridData mHybridData;
     private final ExecutorService frameProcessorThread;
@@ -13,12 +14,6 @@ public class VisionCameraScheduler {
     public VisionCameraScheduler(ExecutorService frameProcessorThread) {
         this.frameProcessorThread = frameProcessorThread;
         mHybridData = initHybrid();
-    }
-
-    @Override
-    protected void finalize() throws Throwable {
-        mHybridData.resetNative();
-        super.finalize();
     }
 
     private native HybridData initHybrid();

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraScheduler.java
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraScheduler.java
@@ -2,14 +2,16 @@ package com.mrousavy.camera.frameprocessor;
 
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
-import com.mrousavy.camera.CameraViewModule;
+import java.util.concurrent.ExecutorService;
 
 @SuppressWarnings("JavaJniMissingFunction") // using fbjni here
 public class VisionCameraScheduler {
     @DoNotStrip
     private final HybridData mHybridData;
+    private final ExecutorService frameProcessorThread;
 
-    public VisionCameraScheduler() {
+    public VisionCameraScheduler(ExecutorService frameProcessorThread) {
+        this.frameProcessorThread = frameProcessorThread;
         mHybridData = initHybrid();
     }
 
@@ -22,8 +24,9 @@ public class VisionCameraScheduler {
     private native HybridData initHybrid();
     private native void triggerUI();
 
+    @SuppressWarnings("unused")
     @DoNotStrip
     private void scheduleTrigger() {
-        CameraViewModule.Companion.getFrameProcessorThread().submit(this::triggerUI);
+        frameProcessorThread.submit(this::triggerUI);
     }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Allows the CameraViewModule to be torn down and cancels all running operations in it.

This is a preparation for lazy-initialized TurboModules.

* FrameProcessorThread can be torn down/re-created lazily anytime
* CoroutineScope can be torn down/re-created lazily anytime

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
