### PR TITLE
fix: Remove `jcenter()`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,6 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
     maven {
       url "https://plugins.gradle.org/m2/"
     }
@@ -136,7 +135,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,7 @@ buildscript {
   def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['VisionCamera_kotlinVersion']
 
   repositories {
+    mavenCentral()
     google()
     maven {
       url "https://plugins.gradle.org/m2/"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         ndkVersion = "20.1.5948944"
     }
     repositories {
+        mavenCentral()
         google()
     }
     dependencies {
@@ -23,6 +24,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
@@ -35,7 +34,6 @@ allprojects {
         }
 
         google()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
