### PR TITLE
fix: Fix Frame Processor null-dereference error (use ref-counted JNI `local_ref`)

### DIFF
--- a/android/src/main/cpp/FrameProcessorPlugin.cpp
+++ b/android/src/main/cpp/FrameProcessorPlugin.cpp
@@ -11,7 +11,7 @@ using namespace facebook;
 using namespace jni;
 
 using TSelf = local_ref<HybridClass<FrameProcessorPlugin>::jhybriddata>;
-using TFrameProcessorPlugin = jobject(alias_ref<JImageProxy::javaobject>, alias_ref<JArrayClass<jobject>>);
+using TFrameProcessorPlugin = jobject(local_ref<JImageProxy::javaobject>, local_ref<JArrayClass<jobject>>);
 
 TSelf vision::FrameProcessorPlugin::initHybrid(alias_ref<HybridClass::jhybridobject> jThis, const std::string& name) {
   return makeCxxInstance(jThis, name);
@@ -24,7 +24,7 @@ void FrameProcessorPlugin::registerNatives() {
   });
 }
 
-local_ref<jobject> FrameProcessorPlugin::callback(alias_ref<JImageProxy::javaobject> image, alias_ref<JArrayClass<jobject>> params) {
+local_ref<jobject> FrameProcessorPlugin::callback(local_ref<JImageProxy::javaobject> image, local_ref<JArrayClass<jobject>> params) {
   static const auto func = javaPart_->getClass()->getMethod<TFrameProcessorPlugin>("callback");
   auto result = func(javaPart_.get(), image, params);
   return make_local(result);

--- a/android/src/main/cpp/FrameProcessorPlugin.h
+++ b/android/src/main/cpp/FrameProcessorPlugin.h
@@ -22,7 +22,7 @@ class FrameProcessorPlugin: public HybridClass<FrameProcessorPlugin> {
                                                 const std::string& name);
   static void registerNatives();
 
-  local_ref<jobject> callback(alias_ref<JImageProxy::javaobject> image, alias_ref<JArrayClass<jobject>> params);
+  local_ref<jobject> callback(local_ref<JImageProxy::javaobject> image, local_ref<JArrayClass<jobject>> params);
   std::string getName();
 
  private:


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

With #350 it looks like a null-pointer has been tried to access. This happens randomly, after maybe 5 mins or so. 

My gut feeling tells me that this is the Java garbage collector running exactly at the point where a frame processor is being invoked, and since we only pass the frame, the parameters and the return values as `alias_ref` (non-ref counted pointers), Java thinks it can delete those values. Now I tried using a thread specific ref-counted pointer (`local_ref`) and it seems like everything is working - need feedback from #350's OP first though.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* _Maybe_ fixes #350 
