### PR TITLE
docs: add note about reanimated import

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSORS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSORS.mdx
@@ -50,7 +50,7 @@ Frame processors are by far not limited to Hotdog detection, other examples incl
 Because they are written in JS, Frame Processors are **simple**, **powerful**, **extensible** and **easy to create** while still running at **native performance**. (Frame Processors can run up to **1000 times a second**!) Also, you can use **fast-refresh** to quickly see changes while developing or publish [over-the-air updates](https://github.com/microsoft/react-native-code-push) to tweak the Hotdog detector's sensitivity in live apps without pushing a native update.
 
 :::note
-Frame Processors require [**react-native-reanimated**](https://github.com/software-mansion/react-native-reanimated) 2.2.0 or higher.
+Frame Processors require [**react-native-reanimated**](https://github.com/software-mansion/react-native-reanimated) 2.2.0 or higher to be imported prior to use. 
 :::
 
 ### Interacting with Frame Processors

--- a/docs/docs/guides/SETUP.mdx
+++ b/docs/docs/guides/SETUP.mdx
@@ -44,7 +44,7 @@ expo install react-native-vision-camera
 
 VisionCamera requires **iOS 11 or higher**, and **Android-SDK version 21 or higher**. See [Troubleshooting](/docs/guides/troubleshooting) if you're having installation issues.
 
-> **(Optional)** If you want to use [**Frame Processors**](/docs/guides/frame-processors), you need to install [**react-native-reanimated**](https://github.com/software-mansion/react-native-reanimated) 2.2.0 or higher.
+> **(Optional)** If you want to use [**Frame Processors**](/docs/guides/frame-processors), you need to install and import [**react-native-reanimated**](https://github.com/software-mansion/react-native-reanimated) 2.2.0 or higher before use.
 
 ## Updating manifests
 


### PR DESCRIPTION
## What

This PR adds a note to the documentation about needing to `import 'react-native-reanimated'` before using frame processors

## Related issues

https://github.com/mrousavy/react-native-vision-camera/discussions/353 