### PR TITLE
fix: Fix "`global.__reanimatedWorkletInit` is not a function" error by importing Reanimated

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -278,12 +278,12 @@ PODS:
     - React-cxxreact (= 0.64.2)
     - React-jsi (= 0.64.2)
     - React-perflogger (= 0.64.2)
-  - ReactNativeNavigation (7.16.0):
+  - ReactNativeNavigation (7.18.1):
     - React-Core
     - React-RCTImage
     - React-RCTText
-    - ReactNativeNavigation/Core (= 7.16.0)
-  - ReactNativeNavigation/Core (7.16.0):
+    - ReactNativeNavigation/Core (= 7.18.1)
+  - ReactNativeNavigation/Core (7.18.1):
     - React-Core
     - React-RCTImage
     - React-RCTText
@@ -322,7 +322,7 @@ PODS:
     - React
   - RNVectorIcons (8.1.0):
     - React-Core
-  - VisionCamera (2.4.2-beta.12):
+  - VisionCamera (2.5.0):
     - React
     - React-callinvoker
     - React-Core
@@ -485,14 +485,14 @@ SPEC CHECKSUMS:
   React-RCTVibration: 24600e3b1aaa77126989bc58b6747509a1ba14f3
   React-runtimeexecutor: a9904c6d0218fb9f8b19d6dd88607225927668f9
   ReactCommon: 149906e01aa51142707a10665185db879898e966
-  ReactNativeNavigation: 5303d00327dab4e26f74c3164b23ba3119664e77
+  ReactNativeNavigation: 88128fa06b2c349b613e1e0fd3cdff2c58c01c55
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: daebbd404c0cd9df6daa248d63dd940086bea9ff
   RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
-  VisionCamera: ed40e8380f2cd139ccf78bfbf9e5a98e91781033
+  VisionCamera: 55fbbd06480129be9b6f1e5bdfd262a4e52191fd
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac
 
 PODFILE CHECKSUM: 4b093c1d474775c2eac3268011e4b0b80929d3a2
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/src/hooks/useFrameProcessor.ts
+++ b/src/hooks/useFrameProcessor.ts
@@ -2,6 +2,7 @@
 
 import { DependencyList, useCallback } from 'react';
 import type { Frame } from 'src/Frame';
+import 'react-native-reanimated';
 
 type FrameProcessor = (frame: Frame) => void;
 


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

When trying to use worklets (frame processor) without importing Reanimated, the following error occurs:

```
global.__reanimatedWorkletInit is not a function
```

(see https://github.com/mrousavy/react-native-vision-camera/discussions/353)

this Pr fixes this by importing reanimated in `useFrameProcessor`

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

* Fixes #353 