### PR TITLE
fix: `Frame` has type `any` in frame processor function

### DIFF
--- a/src/hooks/useFrameProcessor.ts
+++ b/src/hooks/useFrameProcessor.ts
@@ -1,7 +1,7 @@
 /* global _setGlobalConsole */
 
 import { DependencyList, useCallback } from 'react';
-import type { Frame } from 'src/Frame';
+import type { Frame } from '../Frame';
 
 type FrameProcessor = (frame: Frame) => void;
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR fixes the parameter (`frame`) of the frame processor function in `useFrameProcessor` being `any` instead of `Frame`.

![any](https://user-images.githubusercontent.com/14955991/129492261-aeec2226-203a-4ca1-98ac-a26c4be1c6ff.png)


## Changes
Update import of `Frame` in `useFrameProcessor.ts` to be relative and be correctly resolved when using the library as a `node_module`.

## Tested on
`vision-camera-image-labeler` project in VSCode. Parameter type is `Frame` as it should be.
