### PR TITLE
fix: Apply correct initial rotation on Android

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -114,7 +114,7 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   private val lifecycleRegistry: LifecycleRegistry
   private var hostLifecycleState: Lifecycle.State
 
-  private var rotation: Int = Surface.ROTATION_0
+  private var rotation: Int
 
   private var minZoom: Float = 1f
   private var maxZoom: Float = 1f
@@ -169,6 +169,8 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
     }
     scaleGestureDetector = ScaleGestureDetector(context, scaleGestureListener)
     touchEventListener = OnTouchListener { _, event -> return@OnTouchListener scaleGestureDetector.onTouchEvent(event) }
+
+    rotation = context.displayRotation
     orientationEventListener = object : OrientationEventListener(context) {
       override fun onOrientationChanged(orientation : Int) {
         rotation = when (orientation) {

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -198,7 +198,6 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
   override fun onConfigurationChanged(newConfig: Configuration?) {
     super.onConfigurationChanged(newConfig)
 
-    val rotation = rotation
     if (preview?.targetRotation != rotation) {
       preview?.targetRotation = rotation
       imageCapture?.targetRotation = rotation
@@ -325,7 +324,6 @@ class CameraView(context: Context) : FrameLayout(context), LifecycleOwner {
         }
       }
 
-      val rotation = rotation
       val previewBuilder = Preview.Builder()
         .setTargetRotation(rotation)
       val imageCaptureBuilder = ImageCapture.Builder()

--- a/android/src/main/java/com/mrousavy/camera/utils/Context+displayRotation.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/Context+displayRotation.kt
@@ -1,0 +1,32 @@
+package com.mrousavy.camera.utils
+
+import android.content.Context
+import android.os.Build
+import android.view.Surface
+import android.view.WindowManager
+import com.facebook.react.bridge.ReactContext
+
+val Context.displayRotation: Int
+  get() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      this.display?.let { display ->
+        return display.rotation
+      }
+    }
+
+    val windowManager = getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+    if (windowManager != null) {
+      @Suppress("DEPRECATION") // deprecated since SDK 30
+      windowManager.defaultDisplay?.let { display ->
+        return display.rotation
+      }
+    }
+
+    if (this is ReactContext && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      currentActivity?.display?.let { display ->
+        return display.rotation
+      }
+    }
+
+    return Surface.ROTATION_0
+  }

--- a/android/src/main/java/com/mrousavy/camera/utils/Context+displayRotation.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/Context+displayRotation.kt
@@ -9,11 +9,20 @@ import com.facebook.react.bridge.ReactContext
 val Context.displayRotation: Int
   get() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      // Context.display
       this.display?.let { display ->
         return display.rotation
       }
+
+      // ReactContext.currentActivity.display
+      if (this is ReactContext) {
+        currentActivity?.display?.let { display ->
+          return display.rotation
+        }
+      }
     }
 
+    // WindowManager.defaultDisplay
     val windowManager = getSystemService(Context.WINDOW_SERVICE) as? WindowManager
     if (windowManager != null) {
       @Suppress("DEPRECATION") // deprecated since SDK 30
@@ -22,11 +31,6 @@ val Context.displayRotation: Int
       }
     }
 
-    if (this is ReactContext && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      currentActivity?.display?.let { display ->
-        return display.rotation
-      }
-    }
-
+    // 0
     return Surface.ROTATION_0
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Until now, the `rotation` was alway `0` when initially starting the Camera. This is a problem for landscape apps which do not start at rotation `0` but at some other value, so this PR fixes this by getting the initial rotation immediately upon initialization.


## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes #366
* Overrides #367
