### PR TITLE
fix: Exclude META-INF from packaging options

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -112,6 +112,7 @@ android {
 
   packagingOptions {
     excludes = ["**/libc++_shared.so"]
+    exclude "META-INF/**"
   }
 
   buildTypes {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -112,6 +112,7 @@ android {
 
   packagingOptions {
     excludes = ["**/libc++_shared.so"]
+    exclude "META-INF/*"
   }
 
   buildTypes {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -113,6 +113,7 @@ android {
   packagingOptions {
     excludes = ["**/libc++_shared.so"]
     exclude "META-INF/**"
+    pickFirst '**/*.so'
   }
 
   buildTypes {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## For #369 

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

Excluded META-INF files to avoid conflict issues

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

Android Studio 4.2.0 MacOS 11.4

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

* Fixes #369 
