### PR TITLE
chore(deps): Upgrade CameraX to alpha08

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -234,11 +234,11 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.0"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0"
 
-  implementation "androidx.camera:camera-core:1.1.0-alpha07"
-  implementation "androidx.camera:camera-camera2:1.1.0-alpha07"
-  implementation "androidx.camera:camera-lifecycle:1.1.0-alpha07"
-  implementation "androidx.camera:camera-extensions:1.0.0-alpha27"
-  implementation "androidx.camera:camera-view:1.0.0-alpha27"
+  implementation "androidx.camera:camera-core:1.1.0-alpha08"
+  implementation "androidx.camera:camera-camera2:1.1.0-alpha08"
+  implementation "androidx.camera:camera-lifecycle:1.1.0-alpha08"
+  implementation "androidx.camera:camera-extensions:1.0.0-alpha28"
+  implementation "androidx.camera:camera-view:1.0.0-alpha28"
   implementation "androidx.exifinterface:exifinterface:1.3.3"
 }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->



## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

* Fixed Preview screen is too bright on the Huawei P20 Lite. This problem only occurs when certain special Preview resolutions are used together with a large zoom in value. (Idefce, b/192129158)
* Fixed an issue that flash is not working on some devices when setting flash mode to FLASH_MODE_ON shortly followed by taking pictures. (Ieb49b)
* Fixed the issue where Preview will halt for a while when taking pictures if VideoCapture, ImageCapture and Preview are bound. (I56197, b/193864120)
* Allows ImageAnalysis to select a resolution larger than 1080p. A LIMITED-level above device can support a RECORD size resolution for ImageAnalysis when it is bound together with Preview and ImageCapture. The trade-off is the selected resolution for the ImageCapture will also need to be a RECORD size resolution. To successfully select a RECORD size resolution for ImageAnalysis, a RECORD size target resolution should be set on both ImageCapture and ImageAnalysis. This indicates that the application clearly understands the trade-off and prefers the ImageAnalysis to have a larger resolution rather than the ImageCapture to have a MAXIMUM resolution. For the definitions of RECORD, MAXIMUM sizes and more details see https://developer.android.com/reference/android/hardware/camera2/CameraDevice#regular-capture. The RECORD size refers to the camera device's maximum supported recording resolution, as determined by CamcorderProfile. The MAXIMUM size refers to the camera device's maximum output resolution for that format or target from * StreamConfigurationMap.getOutputSizes(int). (I1ee97, b/192911449)
* Add the Exif info to the captured image. (I01ff0, b/193342619)
* In ImageCapture, return the URI of the saved image if the saving location is File. (Ib5b49, b/149241379)
* Fixed an issue that captured images with flash is dark on many devices. (I4e510)


## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
