### PR TITLE
fix: Fix `close` being called on a collected reference (enforce `alias_ref`)

### DIFF
--- a/android/src/main/cpp/CameraView.cpp
+++ b/android/src/main/cpp/CameraView.cpp
@@ -34,9 +34,8 @@ void CameraView::frameProcessorCallback(const alias_ref<JImageProxy::javaobject>
     return;
   }
 
-  auto frameStrong = make_local(frame);
   try {
-    frameProcessor_(frameStrong);
+    frameProcessor_(frame);
   } catch (const std::exception& exception) {
     // TODO: jsi::JSErrors cannot be caught on Hermes. They crash the entire app.
     auto message = "Frame Processor threw an error! " + std::string(exception.what());

--- a/android/src/main/cpp/CameraView.h
+++ b/android/src/main/cpp/CameraView.h
@@ -14,7 +14,7 @@
 namespace vision {
 
 using namespace facebook;
-using FrameProcessor = std::function<void(jni::local_ref<JImageProxy::javaobject>)>;
+using FrameProcessor = std::function<void(jni::alias_ref<JImageProxy::javaobject>)>;
 
 class CameraView : public jni::HybridClass<CameraView> {
  public:

--- a/android/src/main/cpp/FrameProcessorRuntimeManager.cpp
+++ b/android/src/main/cpp/FrameProcessorRuntimeManager.cpp
@@ -155,7 +155,7 @@ void FrameProcessorRuntimeManager::installJSIBindings() {
       auto function = std::make_shared<jsi::Function>(worklet->getValue(rt).asObject(rt).asFunction(rt));
 
       // assign lambda to frame processor
-      cameraView->setFrameProcessor([this, &rt, function](jni::local_ref<JImageProxy::javaobject> frame) {
+      cameraView->setFrameProcessor([this, &rt, function](jni::alias_ref<JImageProxy::javaobject> frame) {
         try {
           // create HostObject which holds the Frame (JImageProxy)
           auto hostObject = std::make_shared<JImageProxyHostObject>(frame);

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
@@ -77,15 +77,9 @@ void JImageProxyHostObject::assertIsFrameStrong(jsi::Runtime& runtime, const std
   }
 }
 
-
-JImageProxyHostObject::~JImageProxyHostObject() {
-  this->close();
-}
-
 void JImageProxyHostObject::close() {
   if (this->frame) {
     this->frame->close();
-    this->frame.release();
   }
 }
 

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
@@ -18,8 +18,7 @@ using namespace facebook;
 
 class JSI_EXPORT JImageProxyHostObject : public jsi::HostObject {
  public:
-  explicit JImageProxyHostObject(jni::local_ref<JImageProxy::javaobject> image): frame(image) {}
-  ~JImageProxyHostObject();
+  explicit JImageProxyHostObject(jni::alias_ref<JImageProxy::javaobject> image): frame(image) {}
 
  public:
   jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;
@@ -28,7 +27,7 @@ class JSI_EXPORT JImageProxyHostObject : public jsi::HostObject {
   void close();
 
  public:
-  jni::local_ref<JImageProxy> frame;
+  jni::alias_ref<JImageProxy> frame;
 
  private:
   static auto constexpr TAG = "VisionCamera";

--- a/ios/Frame Processor/FrameHostObject.h
+++ b/ios/Frame Processor/FrameHostObject.h
@@ -17,7 +17,6 @@ using namespace facebook;
 class JSI_EXPORT FrameHostObject: public jsi::HostObject {
 public:
   explicit FrameHostObject(Frame* frame): frame(frame) {}
-  ~FrameHostObject();
 
 public:
   jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;

--- a/ios/Frame Processor/FrameHostObject.mm
+++ b/ios/Frame Processor/FrameHostObject.mm
@@ -89,10 +89,6 @@ void FrameHostObject::assertIsFrameStrong(jsi::Runtime &runtime, const std::stri
   }
 }
 
-FrameHostObject::~FrameHostObject() {
-  close();
-}
-
 void FrameHostObject::close() {
   if (frame != nil) {
     CMSampleBufferInvalidate(frame.buffer);


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Frames (`ImageProxy`) were passed to native using fbjni. They were used as `local_ref`s, but we don't really need that since they can be `alias_ref`s (the function execution is synchronous, we can assume the objects live as long as the function executes), and we now enforce this behaviour for the Host Object.

Before, the Host Object ran `close()` on the Frame (`ImageProxy`) when it was destructed, which happened at some random point when the JS runtime collects the object - at that point in time the reference is no longer valid and cannot be closed.

I believe that was the reason for all the crashes, not sure how this will be handled if frame processor plugins return frames that are not automatically closed...

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/376
* Fixes #350 
* Overrides #351