### PR TITLE
chore: fix `bootstrap` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build": "bob build",
     "release": "release-it",
     "pods": "cd example && yarn pods",
-    "bootstrap": "yarn && cd example && yarn && yarn pods",
+    "bootstrap": "yarn && cd example && yarn && yarn setup && yarn pods",
     "check-android": "scripts/ktlint.sh && scripts/cpplint.sh",
     "check-ios": "scripts/swiftformat.sh && scripts/swiftlint.sh",
     "check-js": "yarn lint --fix && yarn typescript",


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Currently running `yarn bootstrap` on the fresh repo checkout yields an error:

<img width="679" alt="Screenshot 2021-08-20 at 17 32 33" src="https://user-images.githubusercontent.com/719641/130257431-e876f443-ac71-40dd-b89f-667fe6aaa9a2.png">

## Changes

This PR adds `yarn setup` command to the `bootstrap` which fixes the issue above.

## Tested on

N/A

## Related issues

No.
