### PR TITLE
fix: Fix app hard-crashing when FPS value is not supported

### DIFF
--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -160,6 +160,14 @@ extension CameraView {
       try device.lockForConfiguration()
 
       if let fps = self.fps?.int32Value {
+        let supportsGivenFps = device.activeFormat.videoSupportedFrameRateRanges.contains { range in
+          return range.includes(fps: Double(fps))
+        }
+        if !supportsGivenFps {
+          invokeOnError(.format(.invalidFps(fps: Int(fps))))
+          return
+        }
+
         let duration = CMTimeMake(value: 1, timescale: fps)
         device.activeVideoMinFrameDuration = duration
         device.activeVideoMaxFrameDuration = duration


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
