### PR TITLE
Avoid division by zero

### DIFF
--- a/ios/Frame Processor/FrameProcessorPerformanceDataCollector.swift
+++ b/ios/Frame Processor/FrameProcessorPerformanceDataCollector.swift
@@ -30,7 +30,7 @@ class FrameProcessorPerformanceDataCollector {
 
   var averageExecutionTimeSeconds: Double {
     let sum = performanceSamples.reduce(0, +)
-    let average = sum / Double(performanceSamples.count)
+    let average = sum / Double(performanceSamples.count == 0 ? 1 : performanceSamples.count)
 
     lastEvaluation = counter
 


### PR DESCRIPTION

## What

    This PR fixes a bug in FrameProcessor (iOS). Variable averageExecutionTimeSeconds is wrongly initialised if the collector is run before obtaining any performanceSample.

## Tested on

    * iPhone 8

