### PR TITLE
fix: Fix divison by zero in Performance Sample collector

### DIFF
--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -236,6 +236,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
   private func evaluateNewPerformanceSamples() {
     lastFrameProcessorPerformanceEvaluation = DispatchTime.now()
     guard let videoDevice = videoDeviceInput?.device else { return }
+    guard frameProcessorPerformanceDataCollector.hasEnoughData else { return }
 
     let maxFrameProcessorFps = Double(videoDevice.activeVideoMinFrameDuration.timescale) * Double(videoDevice.activeVideoMinFrameDuration.value)
     let averageFps = 1.0 / frameProcessorPerformanceDataCollector.averageExecutionTimeSeconds

--- a/ios/Frame Processor/FrameProcessorPerformanceDataCollector.swift
+++ b/ios/Frame Processor/FrameProcessorPerformanceDataCollector.swift
@@ -28,6 +28,10 @@ class FrameProcessorPerformanceDataCollector {
   private var counter = 0
   private var lastEvaluation = -1
 
+  var hasEnoughData: Bool {
+    return performanceSamples.count > 0
+  }
+
   var averageExecutionTimeSeconds: Double {
     let sum = performanceSamples.reduce(0, +)
     let average = sum / Double(performanceSamples.count)

--- a/ios/Frame Processor/FrameProcessorPerformanceDataCollector.swift
+++ b/ios/Frame Processor/FrameProcessorPerformanceDataCollector.swift
@@ -29,7 +29,7 @@ class FrameProcessorPerformanceDataCollector {
   private var lastEvaluation = -1
 
   var hasEnoughData: Bool {
-    return performanceSamples.count > 0
+    return !performanceSamples.isEmpty
   }
 
   var averageExecutionTimeSeconds: Double {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
