### PR TITLE
fix: Fix Microphone usage request not showing on Android 11

### DIFF
--- a/example/src/Splash.tsx
+++ b/example/src/Splash.tsx
@@ -47,7 +47,7 @@ export const Splash: NavigationFunctionComponent = ({ componentId }) => {
   }, []);
 
   useEffect(() => {
-    if (cameraPermissionStatus === 'authorized' && microphonePermissionStatus !== 'not-determined') {
+    if (cameraPermissionStatus === 'authorized' && microphonePermissionStatus === 'authorized') {
       Navigation.setRoot({
         root: {
           stack: {
@@ -77,7 +77,7 @@ export const Splash: NavigationFunctionComponent = ({ componentId }) => {
             </Text>
           </Text>
         )}
-        {microphonePermissionStatus === 'not-determined' && (
+        {microphonePermissionStatus !== 'authorized' && (
           <Text style={styles.permissionText}>
             Vision Camera needs <Text style={styles.bold}>Microphone permission</Text>.
             <Text style={styles.hyperlink} onPress={requestMicrophonePermission}>


### PR DESCRIPTION
## What

This PR fixes an issue on Android 11 which wasn't showing the instruction and button to grant microphone permission usage. Fix made on example app.

## Changes
Now microphone permission usage is verified looking if it has been authorized or not rather than compares with an initial state value `not-determined`.

## Tested on
Samsung A10, Android 11

## Related issues
Closes #405 