### PR TITLE
refactor: suppress AppState.removeListener warning by deprecation

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -35,7 +35,7 @@
     "@react-native-community/eslint-config": "^3.0.0",
     "@react-native-community/eslint-plugin": "^1.1.0",
     "@types/react": "^17.0.19",
-    "@types/react-native": "^0.64.13",
+    "@types/react-native": "^0.65.0",
     "@types/react-native-vector-icons": "^6.4.6",
     "@types/react-native-video": "^5.0.5",
     "babel-plugin-module-resolver": "^4.1.0",

--- a/example/src/hooks/useIsForeground.ts
+++ b/example/src/hooks/useIsForeground.ts
@@ -10,7 +10,9 @@ export const useIsForeground = (): boolean => {
       setIsForeground(state === 'active');
     };
     const subscription = AppState.addEventListener('change', onChange);
-    return () => subscription.remove();
+    return () => {
+      subscription.remove()
+    };
   }, [setIsForeground]);
 
   return isForeground;

--- a/example/src/hooks/useIsForeground.ts
+++ b/example/src/hooks/useIsForeground.ts
@@ -11,7 +11,7 @@ export const useIsForeground = (): boolean => {
     };
     const subscription = AppState.addEventListener('change', onChange);
     return () => {
-      subscription.remove()
+      subscription.remove();
     };
   }, [setIsForeground]);
 

--- a/example/src/hooks/useIsForeground.ts
+++ b/example/src/hooks/useIsForeground.ts
@@ -9,8 +9,8 @@ export const useIsForeground = (): boolean => {
     const onChange = (state: AppStateStatus): void => {
       setIsForeground(state === 'active');
     };
-    AppState.addEventListener('change', onChange);
-    return () => AppState.removeEventListener('change', onChange);
+    const subscription = AppState.addEventListener('change', onChange);
+    return () => subscription.remove();
   }, [setIsForeground]);
 
   return isForeground;

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1056,10 +1056,17 @@
     "@types/react" "*"
     "@types/react-native" "*"
 
-"@types/react-native@*", "@types/react-native@^0.64.13":
+"@types/react-native@*":
   version "0.64.13"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.13.tgz#9e57b85631380b75979a09f5a97e1884299e8d5a"
   integrity sha512-QSOBN6m3TKBPFAcDhuFItDQtw1Fo1/FKDTHGeyeTwBXd3bu0V9s+oHEhntHN7PUK5dAOYFWsnO0wynWwS/KRxQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-native@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.65.0.tgz#bef9ca619f421abafae891ac0629e27cbfe63b42"
+  integrity sha512-GgM6d47SQM9a6iOWKsdseFtTsKZGvmbr0FEaJMdCVy2SJmgtUq5JVpr3+aqHdrJQrg93e08VxPAWmz0qUtIPOg==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
## What
Suppress AppState.removeListener warning by deprecation

## Changes
The way of removing a subscription has changed for AppState event listeners. Basically, it's an update for using a new way to handle unsubscription. AppState.AddEventListener returns a remove function subscription, which replaces the removeListener method

## Tested on
Samsung A10, Android 11

## Related issues
I couldn't find one.