### PR TITLE
fix: Fix Android Stabilization Modes

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -152,7 +152,8 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
             capabilities.contains(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES_DEPTH_OUTPUT)
           val supportsRawCapture = capabilities.contains(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES_RAW)
           val isoRange = characteristics.get(CameraCharacteristics.SENSOR_INFO_SENSITIVITY_RANGE)
-          val stabilizationModes = characteristics.get(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES)!! // only digital, no optical
+          val digitalStabilizationModes = characteristics.get(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES)
+          val opticalStabilizationModes = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION)
           val zoomRange = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
             characteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE)
           else null
@@ -230,12 +231,17 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
               colorSpaces.pushString(formatName)
 
               val videoStabilizationModes = Arguments.createArray()
-              if (stabilizationModes.contains(CameraCharacteristics.CONTROL_VIDEO_STABILIZATION_MODE_OFF)) {
-                videoStabilizationModes.pushString("off")
+              videoStabilizationModes.pushString("off")
+              if (digitalStabilizationModes != null) {
+                if (digitalStabilizationModes.contains(CameraCharacteristics.CONTROL_VIDEO_STABILIZATION_MODE_ON)) {
+                  videoStabilizationModes.pushString("auto")
+                  videoStabilizationModes.pushString("standard")
+                }
               }
-              if (stabilizationModes.contains(CameraCharacteristics.CONTROL_VIDEO_STABILIZATION_MODE_ON)) {
-                videoStabilizationModes.pushString("auto")
-                videoStabilizationModes.pushString("standard")
+              if (opticalStabilizationModes != null) {
+                if (opticalStabilizationModes.contains(CameraCharacteristics.LENS_OPTICAL_STABILIZATION_MODE_ON)) {
+                  videoStabilizationModes.pushString("cinematic")
+                }
               }
 
               val format = Arguments.createMap()


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

On some Samsung devices, getting the Digital Lens Stabilization Modes returns null, even though the Android Docs say it cannot be null:

![Screenshot 2021-09-23 at 13 55 55](https://user-images.githubusercontent.com/15199031/134502564-45397ccd-9d60-4425-90a5-5354f7439326.png)

So the docs are lying.



## Changes

* Fixes Stabilization Modes being `null` on some Samsung devices (even though the Android docs say it cannot be null!)
* Always returns at least `off` for stabilization modes
* Returns `cinematic` for optical stabilization mode

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes #438
* Fixes #238 