### PR TITLE
docs: Fix Frame Processor install step and QualityPrioritization Order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,13 @@ Read the READMEs in [`android/`](android/README.md) and [`ios/`](ios/README.md) 
 
 > Run `yarn check-android` to validate codestyle
 
+### Docs
+
+1. Edit the relevant file, it may be easiest to search for what you're editing to find the right file
+2. Install the documentation dependencies using `yarn` or `npm install` from the `docs` folder.
+
+> Run `yarn start` to generate the docs, you can then view them in your browser to confirm your changes.
+
 ## Committing
 
 We love to keep our codebases clean. To achieve that, we use linters and formatters which output errors when something isn't formatted the way we like it to be.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ Read the READMEs in [`android/`](android/README.md) and [`ios/`](ios/README.md) 
 ### Docs
 
 1. Edit the relevant file, it may be easiest to search for what you're editing to find the right file
-2. Install the documentation dependencies using `yarn` or `npm install` from the `docs` folder.
+2. Install all dependencies by running `yarn` inside the `docs` folder
 
-> Run `yarn start` to generate the docs, you can then view them in your browser to confirm your changes.
+> Run `yarn start` to generate the docs, you can then view them in your browser to confirm your changes
 
 ## Committing
 

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
@@ -74,10 +74,10 @@ public class QRCodeFrameProcessorPluginPackage implements ReactPackage {
   }
 }
 ```
+
 6. Register the package in MainApplication.java
 
-
-```java {8}
+```java {6}
         @Override
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
@@ -87,7 +87,6 @@ public class QRCodeFrameProcessorPluginPackage implements ReactPackage {
           return packages;
         }
 ```
-
 
 </TabItem>
 <TabItem value="kotlin">
@@ -134,10 +133,10 @@ class QRCodeFrameProcessorPluginPackage : ReactPackage {
   }
 }
 ```
+
 6. Register the package in MainApplication.java
 
-
-```java {8}
+```java {6}
         @Override
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
@@ -74,6 +74,20 @@ public class QRCodeFrameProcessorPluginPackage implements ReactPackage {
   }
 }
 ```
+6. Register the package in MainApplication.java
+
+
+```java {8}
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          ...
+          packages.add(new QRCodeFrameProcessorPluginPackage()); // <- add
+          return packages;
+        }
+```
+
 
 </TabItem>
 <TabItem value="kotlin">
@@ -119,6 +133,19 @@ class QRCodeFrameProcessorPluginPackage : ReactPackage {
     return emptyList()
   }
 }
+```
+6. Register the package in MainApplication.java
+
+
+```java {8}
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          ...
+          packages.add(new QRCodeFrameProcessorPluginPackage()); // <- add
+          return packages;
+        }
 ```
 
 </TabItem>

--- a/src/PhotoFile.ts
+++ b/src/PhotoFile.ts
@@ -4,9 +4,9 @@ export interface TakePhotoOptions {
   /**
    * Indicates how photo quality should be prioritized against speed.
    *
-   * * `"quality"` Indicates that speed of photo delivery is most important, even at the expense of quality
+   * * `"quality"` Indicates that photo quality is paramount, even at the expense of shot-to-shot time
    * * `"balanced"` Indicates that photo quality and speed of delivery are balanced in priority
-   * * `"speed"` Indicates that photo quality is paramount, even at the expense of shot-to-shot time
+   * * `"speed"` Indicates that speed of photo delivery is most important, even at the expense of quality
    *
    * @platform iOS 13.0+
    * @default "balanced"


### PR DESCRIPTION
fix: switched incorrect property ordering for `qualityPrioritization` options
fix: added extra step required for creating a frame processing plugin on Android

I couldn't work out how to test the changes using docosaurus, but hopefully they're so small that they're ok! 