### PR TITLE
fix: De-allocate `frame` HybridClass with JNI class loader if using Hermes

### DIFF
--- a/android/src/main/cpp/FrameProcessorRuntimeManager.cpp
+++ b/android/src/main/cpp/FrameProcessorRuntimeManager.cpp
@@ -140,8 +140,6 @@ void FrameProcessorRuntimeManager::installJSIBindings() {
     auto cameraView = findCameraViewById(static_cast<int>(viewTag));
     __android_log_write(ANDROID_LOG_INFO, TAG, "Found CameraView!");
 
-    // TODO: does this have to be called on the separate VisionCamera Frame Processor Thread?
-
     // convert jsi::Function to a ShareableValue (can be shared across runtimes)
     __android_log_write(ANDROID_LOG_INFO, TAG, "Adapting Shareable value from function (conversion to worklet)...");
     auto worklet = reanimated::ShareableValue::adapt(runtime, arguments[1],

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
@@ -4,26 +4,21 @@
 
 #include "JImageProxyHostObject.h"
 #include <android/log.h>
-#include <vector>
-#include <string>
-
-#if FOR_HERMES
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#endif
+#include <vector>
+#include <string>
 
 namespace vision {
 
 using namespace facebook;
 
 JImageProxyHostObject::~JImageProxyHostObject() {
-#if FOR_HERMES
   // Hermes' Garbage Collector (Hades GC) calls destructors on a separate Thread
   // which might not be attached to JNI. Ensure that we use the JNI class loader when
   // deallocating the `frame` HybridClass, because otherwise JNI cannot call the Java
   // destroy() function.
   jni::ThreadScope::WithClassLoader([&] { frame.reset(); });
-#endif
 }
 
 std::vector<jsi::PropNameID> JImageProxyHostObject::getPropertyNames(jsi::Runtime& rt) {

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
@@ -13,6 +13,8 @@ namespace vision {
 
 using namespace facebook;
 
+JImageProxyHostObject::JImageProxyHostObject(): frame(make_local(image)) { }
+
 JImageProxyHostObject::~JImageProxyHostObject() {
   // Hermes' Garbage Collector (Hades GC) calls destructors on a separate Thread
   // which might not be attached to JNI. Ensure that we use the JNI class loader when

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
@@ -13,7 +13,7 @@ namespace vision {
 
 using namespace facebook;
 
-JImageProxyHostObject::JImageProxyHostObject(): frame(make_local(image)) { }
+JImageProxyHostObject::JImageProxyHostObject(jni::alias_ref<JImageProxy::javaobject> image): frame(make_local(image)) { }
 
 JImageProxyHostObject::~JImageProxyHostObject() {
   // Hermes' Garbage Collector (Hades GC) calls destructors on a separate Thread

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
@@ -8,23 +8,19 @@
 #include <jni.h>
 #include <vector>
 #include <string>
-#include <thread>
 
 namespace vision {
 
 using namespace facebook;
 
-JImageProxyHostObject::JImageProxyHostObject(jni::alias_ref<JImageProxy::javaobject> image):
-  frame(make_local(image)), jniThreadId(std::this_thread::get_id()) { }
+JImageProxyHostObject::JImageProxyHostObject(jni::alias_ref<JImageProxy::javaobject> image): frame(make_local(image)) { }
 
 JImageProxyHostObject::~JImageProxyHostObject() {
-  if (this->jniThreadId != std::this_thread::get_id()) {
-    // Hermes' Garbage Collector (Hades GC) calls destructors on a separate Thread
-    // which might not be attached to JNI. Ensure that we use the JNI class loader when
-    // deallocating the `frame` HybridClass, because otherwise JNI cannot call the Java
-    // destroy() function.
-    jni::ThreadScope::WithClassLoader([=] { frame.reset(); });
-  }
+  // Hermes' Garbage Collector (Hades GC) calls destructors on a separate Thread
+  // which might not be attached to JNI. Ensure that we use the JNI class loader when
+  // deallocating the `frame` HybridClass, because otherwise JNI cannot call the Java
+  // destroy() function.
+  jni::ThreadScope::WithClassLoader([=] { frame.reset(); });
 }
 
 std::vector<jsi::PropNameID> JImageProxyHostObject::getPropertyNames(jsi::Runtime& rt) {

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.cpp
@@ -7,7 +7,24 @@
 #include <vector>
 #include <string>
 
+#if FOR_HERMES
+#include <fbjni/fbjni.h>
+#include <jni.h>
+#endif
+
 namespace vision {
+
+using namespace facebook;
+
+JImageProxyHostObject::~JImageProxyHostObject() {
+#if FOR_HERMES
+  // Hermes' Garbage Collector (Hades GC) calls destructors on a separate Thread
+  // which might not be attached to JNI. Ensure that we use the JNI class loader when
+  // deallocating the `frame` HybridClass, because otherwise JNI cannot call the Java
+  // destroy() function.
+  jni::ThreadScope::WithClassLoader([&] { frame.reset(); });
+#endif
+}
 
 std::vector<jsi::PropNameID> JImageProxyHostObject::getPropertyNames(jsi::Runtime& rt) {
   std::vector<jsi::PropNameID> result;

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
@@ -19,6 +19,7 @@ using namespace facebook;
 class JSI_EXPORT JImageProxyHostObject : public jsi::HostObject {
  public:
   explicit JImageProxyHostObject(jni::alias_ref<JImageProxy::javaobject> image): frame(image) {}
+  ~JImageProxyHostObject();
 
  public:
   jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
@@ -18,7 +18,7 @@ using namespace facebook;
 
 class JSI_EXPORT JImageProxyHostObject : public jsi::HostObject {
  public:
-  explicit JImageProxyHostObject(jni::alias_ref<JImageProxy::javaobject> image): frame(image) {}
+  explicit JImageProxyHostObject(jni::alias_ref<JImageProxy::javaobject> image);
   ~JImageProxyHostObject();
 
  public:
@@ -28,7 +28,7 @@ class JSI_EXPORT JImageProxyHostObject : public jsi::HostObject {
   void close();
 
  public:
-  jni::alias_ref<JImageProxy> frame;
+  jni::local_ref<JImageProxy> frame;
 
  private:
   static auto constexpr TAG = "VisionCamera";

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
@@ -9,6 +9,7 @@
 #include <fbjni/fbjni.h>
 #include <vector>
 #include <string>
+#include <thread>
 
 #include "JImageProxy.h"
 
@@ -29,6 +30,9 @@ class JSI_EXPORT JImageProxyHostObject : public jsi::HostObject {
 
  public:
   jni::local_ref<JImageProxy> frame;
+
+private:
+  std::thread::id jniThreadId;
 
  private:
   static auto constexpr TAG = "VisionCamera";

--- a/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
+++ b/android/src/main/cpp/java-bindings/JImageProxyHostObject.h
@@ -9,7 +9,6 @@
 #include <fbjni/fbjni.h>
 #include <vector>
 #include <string>
-#include <thread>
 
 #include "JImageProxy.h"
 
@@ -30,9 +29,6 @@ class JSI_EXPORT JImageProxyHostObject : public jsi::HostObject {
 
  public:
   jni::local_ref<JImageProxy> frame;
-
-private:
-  std::thread::id jniThreadId;
 
  private:
   static auto constexpr TAG = "VisionCamera";

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -292,7 +292,7 @@ PODS:
     - React-RCTText
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNReanimated (2.3.0-alpha.3):
+  - RNReanimated (2.3.0-beta.1):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -328,7 +328,7 @@ PODS:
     - React
   - RNVectorIcons (8.1.0):
     - React-Core
-  - VisionCamera (2.8.0):
+  - VisionCamera (2.8.1):
     - React
     - React-callinvoker
     - React-Core
@@ -498,11 +498,11 @@ SPEC CHECKSUMS:
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
   ReactNativeNavigation: d6f27d4ba71887a161534a13e8ef3873b26c68b5
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNReanimated: 48e578538b2fad573d3d5ce2e80ad375e1534d87
+  RNReanimated: 13f91e6ffd60b3f50c579804958c7610de6ba9c9
   RNScreens: 0591543e343c7444ea1756b6265d81a4295922c9
   RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
-  VisionCamera: c760f5e5207ca71962e46a7e70eef5d8d8e86ad7
+  VisionCamera: 1e4184f85ec6ac7b441b0266639baae7918b1396
   Yoga: aa0cb45287ebe1004c02a13f279c55a95f1572f4
 
 PODFILE CHECKSUM: 4b093c1d474775c2eac3268011e4b0b80929d3a2

--- a/example/package.json
+++ b/example/package.json
@@ -23,7 +23,7 @@
     "react-native-gesture-handler": "^1.10.3",
     "react-native-navigation": "^7.21.0",
     "react-native-pressable-opacity": "^1.0.4",
-    "react-native-reanimated": "^2.3.0-alpha.3",
+    "react-native-reanimated": "^2.3.0-beta.1",
     "react-native-screens": "^3.7.2",
     "react-native-static-safe-area-insets": "^2.1.1",
     "react-native-vector-icons": "^8.1.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4443,10 +4443,10 @@ react-native-pressable-opacity@^1.0.4:
   resolved "https://registry.yarnpkg.com/react-native-pressable-opacity/-/react-native-pressable-opacity-1.0.4.tgz#391f33fdc25cb84551f2743a25eced892b9f30f7"
   integrity sha512-DBIg7UoRiuBYiFEvx+XNMqH0OEx64WrSksXhT6Kq9XuyyKsThMNDqZ9G5QV7vfu7dU2/IctwIz5c0Xwkp4K3tA==
 
-react-native-reanimated@^2.3.0-alpha.3:
-  version "2.3.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.0-alpha.3.tgz#022f5b4eaa847304a155942165a77125c86428bc"
-  integrity sha512-Ln+edkTrepKUETKKmGl+GxL8RiB7awBDQFcRJIK39m5ggiLfksOAfqzclpKPLWbAfOvB4cSg+QdowzRN570FXA==
+react-native-reanimated@^2.3.0-beta.1:
+  version "2.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.0-beta.1.tgz#29deb1fe66db02b431f85b4afd5ba77d689554e6"
+  integrity sha512-scO945EqhQxbNox4GxY+NX0fsPNG7YheYnJTVs/u7XJ0+NuMeuSlUt9Yi89Q161hs2RpY7xAvYpQSU7PQXCeow==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.10.4"
     invariant "^2.2.4"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react": "^17.0.2",
     "react-native": "^0.65.1",
     "react-native-builder-bob": "^0.18.1",
-    "react-native-reanimated": "^2.3.0-alpha.3",
+    "react-native-reanimated": "^2.3.0-beta.1",
     "release-it": "^14.11.5",
     "typescript": "^4.4.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6238,10 +6238,10 @@ react-native-builder-bob@^0.18.1:
   optionalDependencies:
     jetifier "^1.6.6"
 
-react-native-reanimated@^2.3.0-alpha.3:
-  version "2.3.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.0-alpha.3.tgz#022f5b4eaa847304a155942165a77125c86428bc"
-  integrity sha512-Ln+edkTrepKUETKKmGl+GxL8RiB7awBDQFcRJIK39m5ggiLfksOAfqzclpKPLWbAfOvB4cSg+QdowzRN570FXA==
+react-native-reanimated@^2.3.0-beta.1:
+  version "2.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.0-beta.1.tgz#29deb1fe66db02b431f85b4afd5ba77d689554e6"
+  integrity sha512-scO945EqhQxbNox4GxY+NX0fsPNG7YheYnJTVs/u7XJ0+NuMeuSlUt9Yi89Q161hs2RpY7xAvYpQSU7PQXCeow==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.10.4"
     invariant "^2.2.4"


### PR DESCRIPTION
See https://github.com/facebook/hermes/commit/1b3a0c2612836802701c967bd43f8b9c56290637

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes "Could not get JNI environment. Is the Thread attached?" errors when `FrameHostObject` gets deallocated on Hermes with Hades GC.

The same fix landed at the Reanimated repo, so to actually fix this issue you need to be on reanimated version 2.3.0-beta.1 or higher.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes #456
* Fixes #350 
* Fixes #376