### PR TITLE
fix: Run `findViewById<T>(...)` on UI Thread

### DIFF
--- a/android/src/main/cpp/FrameProcessorRuntimeManager.h
+++ b/android/src/main/cpp/FrameProcessorRuntimeManager.h
@@ -55,6 +55,12 @@ class FrameProcessorRuntimeManager : public jni::HybridClass<FrameProcessorRunti
   void installJSIBindings();
   void registerPlugin(alias_ref<FrameProcessorPlugin::javaobject> plugin);
   void logErrorToJS(const std::string& message);
+
+  void setFrameProcessor(jsi::Runtime& runtime,
+                         jsi::Value& viewTag,
+                         const jsi::Value& frameProcessor);
+  void unsetFrameProcessor(jsi::Runtime& runtime,
+                           jsi::Value& viewTag);
 };
 
 } // namespace vision

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -91,7 +91,12 @@ export class Camera extends React.PureComponent<CameraProps> {
 
   private get handle(): number | null {
     const nodeHandle = findNodeHandle(this.ref.current);
-    if (nodeHandle == null) console.error('Camera: findNodeHandle(ref) returned null! Does the Camera view exist in the native view tree?');
+    if (nodeHandle == null || nodeHandle === -1) {
+      throw new CameraRuntimeError(
+        'system/view-not-found',
+        "Could not get the Camera's native view tag! Does the Camera View exist in the native view-tree?",
+      );
+    }
 
     return nodeHandle;
   }

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -1,13 +1,5 @@
 import React from 'react';
-import {
-  requireNativeComponent,
-  NativeModules,
-  NativeSyntheticEvent,
-  findNodeHandle,
-  NativeMethods,
-  Platform,
-  LayoutChangeEvent,
-} from 'react-native';
+import { requireNativeComponent, NativeModules, NativeSyntheticEvent, findNodeHandle, NativeMethods, Platform } from 'react-native';
 import type { FrameProcessorPerformanceSuggestion } from '.';
 import type { CameraDevice } from './CameraDevice';
 import type { ErrorWithCause } from './CameraError';
@@ -93,7 +85,6 @@ export class Camera extends React.PureComponent<CameraProps> {
     this.onInitialized = this.onInitialized.bind(this);
     this.onError = this.onError.bind(this);
     this.onFrameProcessorPerformanceSuggestionAvailable = this.onFrameProcessorPerformanceSuggestionAvailable.bind(this);
-    this.onLayout = this.onLayout.bind(this);
     this.ref = React.createRef<RefType>();
     this.lastFrameProcessor = undefined;
   }
@@ -370,17 +361,15 @@ export class Camera extends React.PureComponent<CameraProps> {
     global.unsetFrameProcessor(this.handle);
   }
 
-  private onLayout(event: LayoutChangeEvent): void {
-    if (!this.isNativeViewMounted) {
+  componentDidMount(): void {
+    requestAnimationFrame(() => {
       this.isNativeViewMounted = true;
       if (this.props.frameProcessor != null) {
         // user passed a `frameProcessor` but we didn't set it yet because the native view was not mounted yet. set it now.
         this.setFrameProcessor(this.props.frameProcessor);
         this.lastFrameProcessor = this.props.frameProcessor;
       }
-    }
-
-    this.props.onLayout?.(event);
+    });
   }
 
   /** @internal */
@@ -419,7 +408,6 @@ export class Camera extends React.PureComponent<CameraProps> {
         onError={this.onError}
         onFrameProcessorPerformanceSuggestionAvailable={this.onFrameProcessorPerformanceSuggestionAvailable}
         enableFrameProcessor={frameProcessor != null}
-        onLayout={this.onLayout}
       />
     );
   }

--- a/src/CameraError.ts
+++ b/src/CameraError.ts
@@ -43,7 +43,7 @@ export type CaptureError =
   | 'capture/photo-not-enabled'
   | 'capture/aborted'
   | 'capture/unknown';
-export type SystemError = 'system/no-camera-manager';
+export type SystemError = 'system/no-camera-manager' | 'system/view-not-found';
 export type UnknownError = 'unknown/unknown';
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Currently, `findViewById<T>` is called from the JS Thread (in the `setFrameProcessor` JSI C++ function).
This PR changes this so that function is dispatched on the UI Thread. This might make it redundant to use `requestAnimationFrame`, so #459 can be reverted.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
