### PR TITLE
fix: Throw `'frame-processor/unavailable'` error instead of normal JS Error

### DIFF
--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -348,7 +348,8 @@ export class Camera extends React.PureComponent<CameraProps> {
   private assertFrameProcessorsEnabled(): void {
     // @ts-expect-error JSI functions aren't typed
     if (global.setFrameProcessor == null || global.unsetFrameProcessor == null) {
-      throw new Error(
+      throw new CameraRuntimeError(
+        'frame-processor/unavailable',
         'Frame Processors are not enabled. See https://mrousavy.github.io/react-native-vision-camera/docs/guides/troubleshooting',
       );
     }

--- a/src/CameraDevice.ts
+++ b/src/CameraDevice.ts
@@ -33,10 +33,9 @@ export const parsePhysicalDeviceTypes = (
   const hasWide = physicalDeviceTypes.includes('wide-angle-camera');
   const hasUltra = physicalDeviceTypes.includes('ultra-wide-angle-camera');
   const hasTele = physicalDeviceTypes.includes('telephoto-camera');
+
   if (hasTele && hasWide && hasUltra) return 'triple-camera';
-
   if (hasWide && hasUltra) return 'dual-wide-camera';
-
   if (hasWide && hasTele) return 'dual-camera';
 
   throw new Error(`Invalid physical device type combination! ${physicalDeviceTypes.join(' + ')}`);

--- a/src/CameraError.ts
+++ b/src/CameraError.ts
@@ -15,6 +15,7 @@ export type DeviceError =
   | 'device/low-light-boost-not-supported'
   | 'device/focus-not-supported'
   | 'device/camera-not-available-on-simulator';
+export type FrameProcessorError = 'frame-processor/unavailable';
 export type FormatError =
   | 'format/invalid-fps'
   | 'format/invalid-hdr'
@@ -98,6 +99,7 @@ type CameraErrorCode =
   | PermissionError
   | ParameterError
   | DeviceError
+  | FrameProcessorError
   | FormatError
   | SessionError
   | CaptureError
@@ -152,7 +154,7 @@ export class CameraCaptureError extends CameraError<CaptureError> {}
  * See the ["Camera Errors" documentation](https://mrousavy.github.io/react-native-vision-camera/docs/guides/errors) for more information about Camera Errors.
  */
 export class CameraRuntimeError extends CameraError<
-  PermissionError | ParameterError | DeviceError | FormatError | SessionError | SystemError | UnknownError
+  PermissionError | ParameterError | DeviceError | FormatError | FrameProcessorError | SessionError | SystemError | UnknownError
 > {}
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
