### PR TITLE
fix: Avoid duplicate C++ symbols by using `libjsi.so` shared library

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -81,11 +81,6 @@ else()
     file (GLOB LIBREANIMATED_DIR "${BUILD_DIR}/react-native-reanimated-*-jsc.aar/jni/${ANDROID_ABI}")
 endif()
 
-
-find_library(
-        LOG_LIB
-        log
-)
 find_library(
         FBJNI_LIB
         fbjni
@@ -93,12 +88,11 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 find_library(
-        REANIMATED_LIB
-        reanimated
-        PATHS ${LIBREANIMATED_DIR}
+        JSI_LIB
+        jsi
+        PATHS ${LIBRN_DIR}
         NO_CMAKE_FIND_ROOT_PATH
 )
-
 find_library(
         FOLLY_JSON_LIB
         folly_json
@@ -113,12 +107,25 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 
+find_library(
+        REANIMATED_LIB
+        reanimated
+        PATHS ${LIBREANIMATED_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+)
+
+find_library(
+        LOG_LIB
+        log
+)
+
 # linking
 
 message(WARNING "VisionCamera linking: FOR_HERMES=${FOR_HERMES}")
 target_link_libraries(
         ${PACKAGE_NAME}
         ${LOG_LIB}
+        ${JSI_LIB}
         ${JS_ENGINE_LIB} # <-- Hermes or JSC
         ${REANIMATED_LIB}
         ${REACT_NATIVE_JNI_LIB}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -112,7 +112,7 @@ android {
   }
 
   packagingOptions {
-    excludes = ["**/libc++_shared.so", "**/libfbjni.so"]
+    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so"]
   }
 
   buildTypes {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

By compiling `jsi.cpp`, we will have duplicate C++ symbols in the user's app because `jsi.cpp` is compiled multiple times. (once for RN, once for REA, and maybe also for other third party libs)

This PR re-uses the shared/dynamic C++ library `libjsi.so`.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
