### PR TITLE
fix: Fix expo build / downgrade CameraX to alpha08

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -233,11 +233,11 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.2"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"
 
-  implementation "androidx.camera:camera-core:1.1.0-alpha09"
-  implementation "androidx.camera:camera-camera2:1.1.0-alpha09"
-  implementation "androidx.camera:camera-lifecycle:1.1.0-alpha09"
-  implementation "androidx.camera:camera-extensions:1.0.0-alpha29"
-  implementation "androidx.camera:camera-view:1.0.0-alpha29"
+  implementation "androidx.camera:camera-core:1.1.0-alpha08"
+  implementation "androidx.camera:camera-camera2:1.1.0-alpha08"
+  implementation "androidx.camera:camera-lifecycle:1.1.0-alpha08"
+  implementation "androidx.camera:camera-extensions:1.0.0-alpha28"
+  implementation "androidx.camera:camera-view:1.0.0-alpha28"
   implementation "androidx.exifinterface:exifinterface:1.3.3"
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -12,9 +12,9 @@
 # org.gradle.parallel=true
 #Fri Feb 19 20:46:14 CET 2021
 VisionCamera_buildToolsVersion=30.0.0
-VisionCamera_compileSdkVersion=31
+VisionCamera_compileSdkVersion=30
 VisionCamera_kotlinVersion=1.5.30
-VisionCamera_targetSdkVersion=31
+VisionCamera_targetSdkVersion=30
 VisionCamera_ndkVersion=21.4.7075529
 android.enableJetifier=true
 android.useAndroidX=true

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         RNNKotlinVersion = "1.3.61"
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 30
+        targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
     }
     repositories {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

CameraX alpha 09 requires you to use `compileSdkVersion` `31`, but Expo projects use `30`. We can't use the new CameraX versions until Expo projects change `targetSdkVersion` and `compileSdkVersion` to `31`.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
