### PR TITLE
feat: Add `pixelFormat` field

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -244,6 +244,9 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
                 }
               }
 
+              // TODO: Get the pixel format programatically rather than assuming a default of 420v
+              val pixelFormat = "420v"
+
               val format = Arguments.createMap()
               format.putDouble("photoHeight", size.height.toDouble())
               format.putDouble("photoWidth", size.width.toDouble())
@@ -260,6 +263,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
               format.putArray("frameRateRanges", frameRateRanges)
               format.putString("autoFocusSystem", "none") // TODO: Revisit getAvailableCameraDevices (autoFocusSystem) (CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES or CameraCharacteristics.LENS_INFO_FOCUS_DISTANCE_CALIBRATION)
               format.putArray("videoStabilizationModes", videoStabilizationModes)
+              format.putString("pixelFormat", pixelFormat)
               formats.pushMap(format)
             }
           }

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -101,13 +101,7 @@ final class CameraViewManager: RCTViewManager {
           "supportsLowLightBoost": $0.isLowLightBoostSupported,
           "supportsFocus": $0.isFocusPointOfInterestSupported,
           "formats": $0.formats.map { format -> [String: Any] in
-            var dict = format.toDictionary()
-            // Get the pixel format (mediaSubType), remove apostrophes from start and end
-            // of value
-            if #available(iOS 13.0, *) {
-              dict["mediaSubType"] = String(format.formatDescription.mediaSubType.description.dropFirst(1).dropLast(1))
-            }
-            return dict
+            format.toDictionary()
           },
         ]
       }

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -101,7 +101,13 @@ final class CameraViewManager: RCTViewManager {
           "supportsLowLightBoost": $0.isLowLightBoostSupported,
           "supportsFocus": $0.isFocusPointOfInterestSupported,
           "formats": $0.formats.map { format -> [String: Any] in
-            format.toDictionary()
+            var dict = format.toDictionary()
+            // Get the pixel format (mediaSubType), remove apostrophes from start and end
+            // of value
+            if #available(iOS 13.0, *) {
+              dict["mediaSubType"] = String(format.formatDescription.mediaSubType.description.dropFirst(1).dropLast(1))
+            }
+            return dict
           },
         ]
       }

--- a/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
+++ b/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
@@ -42,12 +42,13 @@ extension AVCaptureDevice.Format {
           "maxFrameRate": $0.maxFrameRate,
         ]
       },
+      "pixelFormat": CMFormatDescriptionGetMediaSubType(formatDescription).toString()
     ]
 
     if #available(iOS 13.0, *) {
       dict["isHighestPhotoQualitySupported"] = self.isHighestPhotoQualitySupported
     }
-
+    
     return dict
   }
 }

--- a/ios/Extensions/FourCharCode+toString.swift
+++ b/ios/Extensions/FourCharCode+toString.swift
@@ -1,0 +1,17 @@
+//
+//  FourCharCode+toString.swift
+//  VisionCamera
+//
+//  Created by Thomas Coldwell on 28/10/2021.
+//  Based off this SO answer: https://stackoverflow.com/a/25625744
+//
+
+extension FourCharCode {
+    func toString() -> String {
+        var s: String = String (UnicodeScalar((self >> 24) & 255)!)
+        s.append(String(UnicodeScalar((self >> 16) & 255)!))
+        s.append(String(UnicodeScalar((self >> 8) & 255)!))
+        s.append(String(UnicodeScalar(self & 255)!))
+        return (s)
+    }
+}

--- a/src/CameraDevice.ts
+++ b/src/CameraDevice.ts
@@ -171,6 +171,10 @@ export interface CameraDeviceFormat {
    * All supported video stabilization modes
    */
   videoStabilizationModes: VideoStabilizationMode[];
+  /**
+   * Specifies the pixel format on iOS. e.g. 420v, 420f
+   */
+  mediaSubType?: string;
 }
 
 /**

--- a/src/CameraDevice.ts
+++ b/src/CameraDevice.ts
@@ -1,4 +1,5 @@
 import type { CameraPosition } from './CameraPosition';
+import type { PixelFormat } from './PixelFormat';
 
 /**
  * Indentifiers for a physical camera (one that actually exists on the back/front of the device)
@@ -174,7 +175,7 @@ export interface CameraDeviceFormat {
   /**
    * Specifies the pixel format on iOS. e.g. 420v, 420f
    */
-  pixelFormat: string;
+  pixelFormat: PixelFormat;
 }
 
 /**

--- a/src/CameraDevice.ts
+++ b/src/CameraDevice.ts
@@ -174,7 +174,7 @@ export interface CameraDeviceFormat {
   /**
    * Specifies the pixel format on iOS. e.g. 420v, 420f
    */
-  mediaSubType?: string;
+  pixelFormat: string;
 }
 
 /**

--- a/src/PixelFormat.ts
+++ b/src/PixelFormat.ts
@@ -1,0 +1,7 @@
+/**
+ * Represents the pixel format of a `Frame`.
+ * * `420v`: 420 YpCbCr 8 Bi-Planar Video Range
+ * * `420f`: 420 YpCbCr 8 Bi-Planar Full Range
+ * * `x420`: 420 YpCbCr 10 Bi-Planar Video Range
+ */
+export type PixelFormat = '420f' | '420v' | 'x420';


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

This PR adds support to include the pixel format code as part of the camera device format object on iOS. This is useful if you need to select a specific format for frame processors such as is required when using MLKit: https://developers.google.com/ml-kit/reference/ios/mlkitvision/api/reference/Classes/MLKVisionImage#parameters_1

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

Adds an extra field on the `device.format` called `mediaSubType` that will hold the pixel format e.g. 420v, 420f

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

iPad 8, iOS 14.4.2

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
