### PR TITLE
Update compileSdkVersion and targetSdkVersion

### DIFF
--- a/docs/docs/guides/TROUBLESHOOTING.mdx
+++ b/docs/docs/guides/TROUBLESHOOTING.mdx
@@ -52,8 +52,8 @@ Before opening an issue, make sure you try the following:
 4. Make sure your minimum SDK version is **21 or higher**, and target SDK version is **30 or higher**. See [the example's `build.gradle`](https://github.com/mrousavy/react-native-vision-camera/blob/main/example/android/build.gradle#L5-L10) for reference.
    1. Open your `build.gradle`
    2. Set `buildToolsVersion` to `30.0.0` or higher
-   3. Set `compileSdkVersion` to `30` or higher
-   4. Set `targetSdkVersion` to `30` or higher
+   3. Set `compileSdkVersion` to `31` or higher
+   4. Set `targetSdkVersion` to `31` or higher
    5. Set `minSdkVersion` to `21` or higher
    6. Set `ndkVersion` to `"20.1.5948944"` or higher
    7. Update the Gradle Build-Tools version to `4.1.2` or higher:


### PR DESCRIPTION
SDK version 31 required after 8d24e344c9252a6a500e5f63a39539e0ff24fa11

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
Quick update to docs since it seems like the latest version of `react-native-vision-camera` requires SDK version 31 on Android.

## Changes

Just updates the SDK version on the troubleshooting page.

## Tested on

N/A

## Related issues

#472
