### PR TITLE
fix: Fix duplicate `JHashMap` definition by moving to custom namespace

### DIFF
--- a/android/src/main/cpp/JSIJNIConversion.cpp
+++ b/android/src/main/cpp/JSIJNIConversion.cpp
@@ -156,10 +156,10 @@ jsi::Value JSIJNIConversion::convertJNIObjectToJSIValue(jsi::Runtime &runtime, c
     auto array = toArrayListFunc(object.get());
     return convertJNIObjectToJSIValue(runtime, array);
 
-  } else if (object->isInstanceOf(jni::JHashMap<jstring, jobject>::javaClassStatic())) {
+  } else if (object->isInstanceOf(JHashMap<jstring, jobject>::javaClassStatic())) {
     // HashMap<K, V>
 
-    auto map = static_ref_cast<jni::JHashMap<jstring, jobject>>(object);
+    auto map = static_ref_cast<JHashMap<jstring, jobject>>(object);
 
     auto result = jsi::Object(runtime);
     for (const auto& entry : *map) {
@@ -173,7 +173,7 @@ jsi::Value JSIJNIConversion::convertJNIObjectToJSIValue(jsi::Runtime &runtime, c
   } else if (object->isInstanceOf(react::ReadableMap::javaClassStatic())) {
     // ReadableMap
 
-    static const auto toHashMapFunc = react::ReadableMap::javaClassLocal()->getMethod<jni::JHashMap<jstring, jobject>()>("toHashMap");
+    static const auto toHashMapFunc = react::ReadableMap::javaClassLocal()->getMethod<JHashMap<jstring, jobject>()>("toHashMap");
 
     // call recursive, this time HashMap<K, V>
     auto hashMap = toHashMapFunc(object.get());

--- a/android/src/main/cpp/java-bindings/JHashMap.cpp
+++ b/android/src/main/cpp/java-bindings/JHashMap.cpp
@@ -7,14 +7,14 @@
 #include <jni.h>
 #include <fbjni/fbjni.h>
 
+namespace vision {
 
-namespace facebook {
-namespace jni {
+using namespace facebook;
+using namespace jni;
 
 template <typename K, typename V>
 local_ref<JHashMap<K, V>> JHashMap<K, V>::create() {
   return JHashMap<K, V>::newInstance();
 }
 
-} // namespace jni
-} // namespace facebook
+} // namespace vision

--- a/android/src/main/cpp/java-bindings/JHashMap.h
+++ b/android/src/main/cpp/java-bindings/JHashMap.h
@@ -7,9 +7,10 @@
 #include <jni.h>
 #include <fbjni/fbjni.h>
 
+namespace vision {
 
-namespace facebook {
-namespace jni {
+using namespace facebook;
+using namespace jni;
 
 // TODO: Remove when fbjni 0.2.3 releases.
 template <typename K = jobject, typename V = jobject>
@@ -19,5 +20,4 @@ struct JHashMap : JavaClass<JHashMap<K, V>, JMap<K, V>> {
   static local_ref<JHashMap<K, V>> create();
 };
 
-} // namespace jni
-} // namespace facebook
+} // namespace vision


### PR DESCRIPTION
Technically `JHashMap` is duplicated now, but in separate namespaces. If I were to remove my `JHashMap` (and `JArrayList`) definitions, the user is forced to use fbjni v3.

fixes #609