### PR TITLE
Fix extract tasks being added to clean tasks

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -466,7 +466,7 @@ extractJNIFiles.mustRunAfter extractAARHeaders
 // pre-native build pipeline
 
 tasks.whenTaskAdded { task ->
-  if (task.name.contains('externalNative') || task.name.contains('CMake')) {
+  if (!task.name.contains('Clean') && (task.name.contains('externalNative') || task.name.contains('CMake'))) {
     task.dependsOn(extractAARHeaders)
     task.dependsOn(extractJNIFiles)
     task.dependsOn(prepareJSC)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

The extract tasks are being incorrectly added to clean tasks (`externalNativeBuild{Debug|Release}Clean`) which causes files to be missing when running `./gradlew clean assembleRelease`.

## Changes

Make sure task name does not contain "clean".

## Tested on

Builds on android when running `./gradlew clean assembleRelease`.

## Related issues

N/A
