### PR TITLE
feat: [ios] video codec option

### DIFF
--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -114,10 +114,8 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       }
 
       // Init Video
-      guard let videoSettings = videoCodec != nil ?
-        videoOutput.recommendedVideoSettings(forVideoCodecType: videoCodec!, assetWriterOutputFileType: fileType) :
-        videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType),
-        !videoSettings.isEmpty else {
+      guard let videoSettings = self.recommendedVideoSettings(videoOutput: videoOutput, fileType: fileType, videoCodec: videoCodec),
+            !videoSettings.isEmpty else {
         callback.reject(error: .capture(.createRecorderError(message: "Failed to get video settings!")))
         return
       }
@@ -261,6 +259,14 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       // frameProcessorFps={someCustomFpsValue}
       invokeOnFrameProcessorPerformanceSuggestionAvailable(currentFps: frameProcessorFps.doubleValue,
                                                            suggestedFps: suggestedFrameProcessorFps)
+    }
+  }
+
+  private func recommendedVideoSettings(videoOutput: AVCaptureVideoDataOutput, fileType: AVFileType, videoCodec: AVVideoCodecType?) -> [String: Any]? {
+    if videoCodec != nil {
+      return videoOutput.recommendedVideoSettings(forVideoCodecType: videoCodec!, assetWriterOutputFileType: fileType)
+    } else {
+      return videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType)
     }
   }
 

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -107,20 +107,20 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         callback.reject(error: .capture(.createRecorderError(message: nil)), cause: error)
         return
       }
-      
-      var videoCodec:AVVideoCodecType?
+
+      var videoCodec: AVVideoCodecType?
       if let codecString = options["videoCodec"] as? String {
-        videoCodec = AVVideoCodecType.init(withString: codecString)
+        videoCodec = AVVideoCodecType(withString: codecString)
       }
-      
+
       // Init Video
       guard let videoSettings = videoCodec != nil ?
-              videoOutput.recommendedVideoSettings(forVideoCodecType: videoCodec!, assetWriterOutputFileType: fileType) :
-                videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType),
-            !videoSettings.isEmpty else {
-              callback.reject(error: .capture(.createRecorderError(message: "Failed to get video settings!")))
-              return
-            }
+        videoOutput.recommendedVideoSettings(forVideoCodecType: videoCodec!, assetWriterOutputFileType: fileType) :
+        videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType),
+        !videoSettings.isEmpty else {
+        callback.reject(error: .capture(.createRecorderError(message: "Failed to get video settings!")))
+        return
+      }
 
       // get pixel format (420f, 420v, x420)
       let pixelFormat = CMFormatDescriptionGetMediaSubType(videoInput.device.activeFormat.formatDescription)

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -109,11 +109,16 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       }
 
       // Init Video
-      guard let videoSettings = videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType),
+      guard var videoSettings = videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType),
             !videoSettings.isEmpty else {
         callback.reject(error: .capture(.createRecorderError(message: "Failed to get video settings!")))
         return
       }
+
+      if let videoCodec = options["videoCodec"] as? String {
+        videoSettings["AVVideoCodecKey"] = AVVideoCodecType.init(withString: videoCodec)
+      }
+
       // get pixel format (420f, 420v, x420)
       let pixelFormat = CMFormatDescriptionGetMediaSubType(videoInput.device.activeFormat.formatDescription)
       self.recordingSession!.initializeVideoWriter(withSettings: videoSettings,

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -57,4 +57,6 @@ RCT_EXTERN_METHOD(stopRecording:(nonnull NSNumber *)node resolve:(RCTPromiseReso
 RCT_EXTERN_METHOD(takePhoto:(nonnull NSNumber *)node options:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(focus:(nonnull NSNumber *)node point:(NSDictionary *)point resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(getAvailableVideoCodecs:(nonnull NSNumber *)node fileType:(NSString *)fileType resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
+
 @end

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -79,7 +79,7 @@ final class CameraViewManager: RCTViewManager {
       guard let videoOutput = component.videoOutput else {
         throw CameraError.session(SessionError.cameraNotReady)
       }
-      
+
       var parsedFileType = AVFileType.mov
       if fileType != nil {
         guard let parsed = try? AVFileType(withString: fileType!) else {

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -73,6 +73,26 @@ final class CameraViewManager: RCTViewManager {
   }
 
   @objc
+  final func getAvailableVideoCodecs(_ node: NSNumber, fileType: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    withPromise(resolve: resolve, reject: reject) {
+      let component = getCameraView(withTag: node)
+      guard let videoOutput = component.videoOutput else {
+        throw CameraError.session(SessionError.cameraNotReady)
+      }
+      
+      var parsedFileType = AVFileType.mov
+      if fileType != nil {
+        guard let parsed = try? AVFileType(withString: fileType!) else {
+          throw CameraError.parameter(ParameterError.invalid(unionName: "fileType", receivedValue: fileType!))
+        }
+        parsedFileType = parsed
+      }
+
+      return videoOutput.availableVideoCodecTypesForAssetWriter(writingTo: parsedFileType).map(\.descriptor)
+    }
+  }
+
+  @objc
   final func getAvailableCameraDevices(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     withPromise(resolve: resolve, reject: reject) {
       let discoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: getAllDeviceTypes(), mediaType: .video, position: .unspecified)

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { requireNativeComponent, NativeModules, NativeSyntheticEvent, findNodeHandle, NativeMethods, Platform } from 'react-native';
-import type { FrameProcessorPerformanceSuggestion } from '.';
+import type { FrameProcessorPerformanceSuggestion, VideoFileType } from '.';
 import type { CameraDevice } from './CameraDevice';
 import type { ErrorWithCause } from './CameraError';
 import { CameraCaptureError, CameraRuntimeError, tryParseNativeCameraError, isErrorWithCause } from './CameraError';
@@ -9,7 +9,7 @@ import type { Frame } from './Frame';
 import type { PhotoFile, TakePhotoOptions } from './PhotoFile';
 import type { Point } from './Point';
 import type { TakeSnapshotOptions } from './Snapshot';
-import type { RecordVideoOptions, VideoFile } from './VideoFile';
+import type { CameraVideoCodec, RecordVideoOptions, VideoFile } from './VideoFile';
 
 //#region Types
 export type CameraPermissionStatus = 'authorized' | 'not-determined' | 'denied' | 'restricted';
@@ -237,6 +237,22 @@ export class Camera extends React.PureComponent<CameraProps> {
     }
   }
   //#endregion
+
+  /**
+   * Get a list of video codecs the current camera supports for a given file type.  Returned values are ordered by efficiency (descending).
+   * @example
+   * ```ts
+   * const codecs = await camera.current.getAvailableVideoCodecs("mp4")
+   * ```
+   * @throws {@linkcode CameraRuntimeError} When any kind of error occured while getting available video codecs. Use the {@linkcode ParameterError.code | code} property to get the actual error
+   */
+  public async getAvailableVideoCodecs(fileType?: VideoFileType): Promise<CameraVideoCodec[]> {
+    try {
+      return await CameraModule.getAvailableVideoCodecs(this.handle, fileType);
+    } catch (e) {
+      throw tryParseNativeCameraError(e);
+    }
+  }
 
   //#region Static Functions (NativeModule)
   /**

--- a/src/VideoFile.ts
+++ b/src/VideoFile.ts
@@ -3,6 +3,17 @@ import type { TemporaryFile } from './TemporaryFile';
 
 export type VideoFileType = 'mov' | 'avci' | 'm4v' | 'mp4';
 
+export type CameraVideoCodec =
+  | 'h264'
+  | 'hevc'
+  | 'hevc-alpha'
+  | 'jpeg'
+  | 'pro-res-4444'
+  | 'pro-res-422'
+  | 'pro-res-422-hq'
+  | 'pro-res-422-lt'
+  | 'pro-res-422-proxy';
+
 export interface RecordVideoOptions {
   /**
    * Set the video flash mode. Natively, this just enables the torch while recording.
@@ -21,6 +32,13 @@ export interface RecordVideoOptions {
    * Called when the recording has been successfully saved to file.
    */
   onRecordingFinished: (video: VideoFile) => void;
+  /**
+   * IOS only
+   * Specify the video codec to use. To get a list of available video codecs use the `getAvailableVideoCodecs()` function.
+   *
+   * @default undefined
+   */
+  videoCodec?: CameraVideoCodec;
 }
 
 /**

--- a/src/VideoFile.ts
+++ b/src/VideoFile.ts
@@ -33,8 +33,8 @@ export interface RecordVideoOptions {
    */
   onRecordingFinished: (video: VideoFile) => void;
   /**
-   * IOS only
-   * Specify the video codec to use. To get a list of available video codecs use the `getAvailableVideoCodecs()` function.
+   * Set the video codec to record in. Different video codecs affect video quality and video size.
+   * To get a list of all available video codecs use the `getAvailableVideoCodecs()` function.
    *
    * @default undefined
    */


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

For IOS only, adds an optional `videoCodec` parameter to the `startRecording` options to specify the codec to record with. Requires IOS 11 (see commit a09201c2bc88eb6c11417046824cac88d9338069 vs 17b960603298e19d45e10933fe6dbf1da6ee00a6 .... please advise if not suitable)

## Changes
- handle user provided video codec in `CameraView+RecordVideo.swift`
- adds an optional `videoCodec` parameter to the `RecordVideoOptions` interface
- adds a `getAvailableVideoCodecs` method which takes a `fileType` parameter (see: https://stackoverflow.com/questions/46843849/why-is-videodataoutputs-availablevideocodectypes-empty/58017253)

## Tested on
- iphone 7, ios 12
- ipad air, ios 14.4


## Related issues

resolves #485 