### PR TITLE
Prepare for Fabric / TurboModules

### DIFF
--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { requireNativeComponent, NativeModules, NativeSyntheticEvent, NativeMethods, Platform } from 'react-native';
+import { NativeModules, NativeSyntheticEvent, NativeMethods, Platform } from 'react-native';
 import type { FrameProcessorPerformanceSuggestion } from '.';
 import type { CameraDevice } from './CameraDevice';
 import type { ErrorWithCause } from './CameraError';
 import { CameraCaptureError, CameraRuntimeError, tryParseNativeCameraError, isErrorWithCause } from './CameraError';
+import type { CameraNativeComponentProps } from './CameraNativeComponent';
+import CameraNativeComponent from './CameraNativeComponent';
 import type { CameraProps } from './CameraProps';
 import type { Frame } from './Frame';
 import type { PhotoFile, TakePhotoOptions } from './PhotoFile';
@@ -20,19 +22,7 @@ interface OnErrorEvent {
   message: string;
   cause?: ErrorWithCause;
 }
-type NativeCameraViewProps = Omit<
-  CameraProps,
-  'device' | 'onInitialized' | 'onError' | 'onFrameProcessorPerformanceSuggestionAvailable' | 'frameProcessor' | 'frameProcessorFps'
-> & {
-  cameraId: string;
-  frameProcessorFps?: number; // native cannot use number | string, so we use '-1' for 'auto'
-  enableFrameProcessor: boolean;
-  onInitialized?: (event: NativeSyntheticEvent<void>) => void;
-  onError?: (event: NativeSyntheticEvent<OnErrorEvent>) => void;
-  onFrameProcessorPerformanceSuggestionAvailable?: (event: NativeSyntheticEvent<FrameProcessorPerformanceSuggestion>) => void;
-  onViewReady: () => void;
-};
-type RefType = React.Component<NativeCameraViewProps> & Readonly<NativeMethods>;
+type RefType = React.Component<CameraNativeComponentProps> & Readonly<NativeMethods>;
 //#endregion
 
 // NativeModules automatically resolves 'CameraView' to 'CameraViewModule'
@@ -407,7 +397,7 @@ export class Camera extends React.PureComponent<CameraProps> {
     // We remove the big `device` object from the props because we only need to pass `cameraId` to native.
     const { device, frameProcessor, frameProcessorFps, ...props } = this.props;
     return (
-      <NativeCameraView
+      <CameraNativeComponent
         {...props}
         frameProcessorFps={frameProcessorFps === 'auto' ? -1 : frameProcessorFps}
         cameraId={device.id}
@@ -422,10 +412,3 @@ export class Camera extends React.PureComponent<CameraProps> {
   }
 }
 //#endregion
-
-// requireNativeComponent automatically resolves 'CameraView' to 'CameraViewManager'
-const NativeCameraView = requireNativeComponent<NativeCameraViewProps>(
-  'CameraView',
-  // @ts-expect-error because the type declarations are kinda wrong, no?
-  Camera,
-);

--- a/src/CameraNativeComponent.ts
+++ b/src/CameraNativeComponent.ts
@@ -1,0 +1,25 @@
+import { NativeSyntheticEvent, requireNativeComponent } from 'react-native';
+import type { ErrorWithCause } from './CameraError';
+import type { CameraProps, FrameProcessorPerformanceSuggestion } from './CameraProps';
+
+interface OnErrorEvent {
+  code: string;
+  message: string;
+  cause?: ErrorWithCause;
+}
+
+export type CameraNativeComponentProps = Omit<
+  CameraProps,
+  'device' | 'onInitialized' | 'onError' | 'onFrameProcessorPerformanceSuggestionAvailable' | 'frameProcessor' | 'frameProcessorFps'
+> & {
+  cameraId: string;
+  frameProcessorFps?: number; // native cannot use number | string, so we use '-1' for 'auto'
+  enableFrameProcessor: boolean;
+  onInitialized?: (event: NativeSyntheticEvent<void>) => void;
+  onError?: (event: NativeSyntheticEvent<OnErrorEvent>) => void;
+  onFrameProcessorPerformanceSuggestionAvailable?: (event: NativeSyntheticEvent<FrameProcessorPerformanceSuggestion>) => void;
+  onViewReady: () => void;
+};
+
+const CameraNativeComponent = requireNativeComponent<CameraNativeComponentProps>('CameraNativeComponent');
+export default CameraNativeComponent;


### PR DESCRIPTION
… Module (1/3)

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Prepares VisionCamera for Fabric and TurboModules. Some notable changes:

### Fabric

* Uses a direct HostComponent Ref/Handle instead of passing through a View Tag (`findNodeHandle(...)`) to a static function. This ensures that the native view is always referenced, and even works if referenced under a separate React Root (e.g. in RN Modals)
    - Fixes #570  
    - Fixes #500 
* Binds `setFrameProcessor` and `unsetFrameProcessor` to the native HostComponent and access directly via a Ref/Handle
     - Fixes #626

### TurboModules

* Improves stability of `setFrameProcessor` and `unsetFrameProcessor` by binding directly to native C++ HostComponent instead of manually injecting via JSI.
* Link against correct JSI lib.
    - Fixes #513 
    - Fixes #546 
    - Fixes #515 
    - Fixes #422 
    - Fixes #390 
    - Fixes #388 
    - Fixes #369 
    - Fixes #365 
    - Fixes #341 
    - Fixes #340 
    - Fixes #338


## Changes

whole lotta changes.

## Tested on

* iPhone 11 Pro
