### PR TITLE
Updates to fix android builds failing in Expo

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
         src/main/cpp/java-bindings/JFrameProcessorPlugin.cpp
         src/main/cpp/java-bindings/JImageProxy.cpp
         src/main/cpp/java-bindings/JHashMap.cpp
+        ${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp
 )
 
 # includes
@@ -88,12 +89,6 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 find_library(
-        JSI_LIB
-        jsi
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
         FOLLY_JSON_LIB
         folly_json
         PATHS ${LIBRN_DIR}
@@ -125,7 +120,6 @@ message(WARNING "VisionCamera linking: FOR_HERMES=${FOR_HERMES}")
 target_link_libraries(
         ${PACKAGE_NAME}
         ${LOG_LIB}
-        ${JSI_LIB}
         ${JS_ENGINE_LIB} # <-- Hermes or JSC
         ${REANIMATED_LIB}
         ${REACT_NATIVE_JNI_LIB}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,7 +111,7 @@ android {
   }
 
   packagingOptions {
-    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so"]
+    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so", "**/libreactnativejni.so", "**/libfolly_json.so", "**/libreanimated.so", "**/libjscexecutor.so"]
   }
 
   buildTypes {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -12,7 +12,7 @@
 # org.gradle.parallel=true
 #Fri Feb 19 20:46:14 CET 2021
 VisionCamera_buildToolsVersion=30.0.0
-VisionCamera_compileSdkVersion=31
+VisionCamera_compileSdkVersion=30
 VisionCamera_kotlinVersion=1.5.30
 VisionCamera_targetSdkVersion=31
 VisionCamera_ndkVersion=21.4.7075529


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR applies all the changes from the following [comment](https://github.com/mrousavy/react-native-vision-camera/issues/546#issuecomment-1000849122) which did fix the android build issue when using expo custom-dev-client. 

## Changes

-  in /android/CMakeLists.txt added ${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp  in the "add_library" list
- in /android/CMakeLists.txt removed ${JSI_LIB} from the target_link_libraries list
- in /android/build.gradle added the following excludes to the packagingOptions  "**/libreactnativejni.so", "**/libfolly_json.so", "**/libreanimated.so", "**/libjscexecutor.so"
- in grade.properties changed VisionCamera_compileSdkVersion from 31 to 30


⚠️NOTE⚠️
Even with these changes applied the user will need to use the following config plugin (Courtesy of [AdamMercy](https://github.com/mercyaj)) to get a successful build.

```Javascript
const { withProjectBuildGradle } = require('@expo/config-plugins')

const setCompileSdkVersion = (buildGradle, sdkVersion) => {
    const regexpCompileSdkVersion = /\bcompileSdkVersion\s*=\s*(\d+)/
    const match = buildGradle.match(regexpCompileSdkVersion)

    if (match) {
        const existingVersion = parseInt(match[1], 10)

        if (existingVersion < sdkVersion) {
            buildGradle = buildGradle.replace(
                /\bcompileSdkVersion\s*=\s*\d+/,
                `compileSdkVersion = ${sdkVersion}`
            )
        } else {
            throw new Error(`minSdkVersion is already >= ${sdkVersion}`)
        }
    }

    return buildGradle
}

module.exports = (config, sdkVersion) => {
    return withProjectBuildGradle(config, (config) => {
        if (config.modResults.language === 'groovy') {
            config.modResults.contents = setCompileSdkVersion(
                config.modResults.contents,
                sdkVersion
            )
        } else {
            throw new Error(
                "Can't set minSdkVersion in the project build.gradle, because it's not groovy"
            )
        }
        return config
    })
}
```
Then inside of app.json

//---------------IN APP.JSON-----------------
```JSON
"plugins": [
            "react-native-vision-camera",
            ["./withCompileSdkVersion", 31]
        ]
```
//---------------IN APP.JSON-----------------

## Tested on
    * Samsung Galaxy Note8


## Related issues
    * Closes #546 
