### PR TITLE
fix: Re-install FP plugins on bundle reload

### DIFF
--- a/ios/Frame Processor/FrameProcessorPluginRegistry.h
+++ b/ios/Frame Processor/FrameProcessorPluginRegistry.h
@@ -18,6 +18,4 @@ typedef id (^FrameProcessorPlugin) (Frame* frame, NSArray<id>* arguments);
 + (NSMutableDictionary<NSString*, FrameProcessorPlugin>*)frameProcessorPlugins;
 + (void) addFrameProcessorPlugin:(NSString*)name callback:(FrameProcessorPlugin)callback;
 
-+ (void) markInvalid;
-
 @end

--- a/ios/Frame Processor/FrameProcessorPluginRegistry.mm
+++ b/ios/Frame Processor/FrameProcessorPluginRegistry.mm
@@ -19,15 +19,7 @@
   return plugins;
 }
 
-static BOOL _isValid = YES;
-+ (void) markInvalid {
-  _isValid = NO;
-  [[FrameProcessorPluginRegistry frameProcessorPlugins] removeAllObjects];
-}
-
 + (void) addFrameProcessorPlugin:(NSString*)name callback:(FrameProcessorPlugin)callback {
-  NSAssert(_isValid, @"Tried to add Frame Processor Plugin but Frame Processor Registry has already registered all plugins!");
-
   BOOL alreadyExists = [[FrameProcessorPluginRegistry frameProcessorPlugins] valueForKey:name] != nil;
   NSAssert(!alreadyExists, @"Tried to two Frame Processor Plugins with the same name! Either choose unique names, or remove the unused plugin.");
 

--- a/ios/Frame Processor/FrameProcessorRuntimeManager.mm
+++ b/ios/Frame Processor/FrameProcessorRuntimeManager.mm
@@ -107,8 +107,6 @@ __attribute__((objc_runtime_name("_TtC12VisionCamera10CameraView")))
                                                                                                 function));
     }
 
-    [FrameProcessorPluginRegistry markInvalid];
-
     NSLog(@"FrameProcessorBindings: Frame Processor plugins installed!");
 #else
     NSLog(@"Reanimated not found, Frame Processors are disabled.");


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Re-install/initialize all Frame processor plugins on bundle reload

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes #675
