### PR TITLE
fix: JNI crash in FrameHostObject dtor

### DIFF
--- a/android/src/main/cpp/FrameHostObject.cpp
+++ b/android/src/main/cpp/FrameHostObject.cpp
@@ -13,14 +13,14 @@ namespace vision {
 
 using namespace facebook;
 
-FrameHostObject::FrameHostObject(jni::alias_ref<JImageProxy::javaobject> image): frame(make_local(image)) { }
+FrameHostObject::FrameHostObject(jni::alias_ref<JImageProxy::javaobject> image): frame(make_global(image)) { }
 
 FrameHostObject::~FrameHostObject() {
   // Hermes' Garbage Collector (Hades GC) calls destructors on a separate Thread
   // which might not be attached to JNI. Ensure that we use the JNI class loader when
   // deallocating the `frame` HybridClass, because otherwise JNI cannot call the Java
   // destroy() function.
-  jni::ThreadScope::WithClassLoader([=] { frame.reset(); });
+  jni::ThreadScope::WithClassLoader([&] { frame.reset(); });
 }
 
 std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt) {

--- a/android/src/main/cpp/FrameHostObject.h
+++ b/android/src/main/cpp/FrameHostObject.h
@@ -28,7 +28,7 @@ class JSI_EXPORT FrameHostObject : public jsi::HostObject {
   void close();
 
  public:
-  jni::local_ref<JImageProxy> frame;
+  jni::global_ref<JImageProxy> frame;
 
  private:
   static auto constexpr TAG = "VisionCamera";


### PR DESCRIPTION
## What

On android, upon FrameHostObject destructor running the app can crash with the following error:

```
12-31 14:03:24.076 10992 10992 F DEBUG   : Abort message: 'JNI DETECTED ERROR IN APPLICATION: JNI ERROR (app bug): jobject is an invalid local reference: 0x15 (stale reference with serial number 1 v. current 2)
12-31 14:03:24.076 10992 10992 F DEBUG   :     in call to GetObjectRefType
12-31 14:03:24.076 10992 10992 F DEBUG   :     from void com.mrousavy.camera.CameraView.frameProcessorCallback(androidx.camera.core.ImageProxy)'
12-31 14:03:24.076 10992 10992 F DEBUG   :     x0  0000000000000000  x1  0000000000002561  x2  0000000000000006  x3  0000006f85bdd160
```

This seems to be caused because we store a local ref in the FrameHostObject and deallocate it in a JNI callback which might not happen synchronously in the dtor. After the dtor is run, the local ref will be invalidated and will crash upon further access. The reset of the jni ref still needs to happen inside the JNI `WithClassLoader` callback since otherwise it can crash when deallocating on another thread.

## Changes

To fix this instead of using a local ref we can use a global ref to control when deallocation happens manually. 

This is what is used in the hermes intl implementation https://github.com/facebook/hermes/blob/main/lib/Platform/Intl/PlatformIntlAndroid.cpp#L417.

## Tested on

Android simulator, also used profiler tools to make sure memory is not leaking after this change.

## Related issues

* Fixes #587