### PR TITLE
fix: setup jsi bindings after dev reload

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -6,44 +6,13 @@ import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.mrousavy.camera.frameprocessor.FrameProcessorRuntimeManager
-import java.util.concurrent.Executors
 
 @Suppress("unused")
 class CameraViewManager(reactContext: ReactApplicationContext) : SimpleViewManager<CameraView>() {
-  private val frameProcessorThread = Executors.newSingleThreadExecutor()
-  private var frameProcessorManager: FrameProcessorRuntimeManager? = null
-
-  init {
-    if (frameProcessorManager == null) {
-      frameProcessorThread.execute {
-        frameProcessorManager = FrameProcessorRuntimeManager(reactContext, frameProcessorThread)
-
-        reactContext.runOnJSQueueThread {
-          frameProcessorManager!!.installJSIBindings()
-        }
-      }
-    }
-  }
-
-  private fun destroy() {
-    frameProcessorManager = null
-    frameProcessorThread.shutdown()
-  }
-
-
-  override fun onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy()
-    destroy()
-  }
-
-  override fun invalidate() {
-    super.invalidate()
-    destroy()
-  }
 
   public override fun createViewInstance(context: ThemedReactContext): CameraView {
-    return CameraView(context, frameProcessorThread)
+    val cameraViewModule = context.getNativeModule(CameraViewModule::class.java)!!
+    return CameraView(context, cameraViewModule.frameProcessorThread)
   }
 
   override fun onAfterUpdateTransaction(view: CameraView) {


### PR DESCRIPTION
## What

On JS reload on Android there is an `frame-processor/unavailable` error. This can be reproduced in the example app.

This happens because instances of ViewManagers and native modules are reused. Instead of installing JS bindings in the constructor we can use the `initialize` method which will be called when native modules are reused on JS reload. For some reason `initialize` for ViewManagers doesn't seem to work properly and is not called, so this also move init to the native module instead of the view manager.

## Changes

- Move init code to `initialize` method of native module

## Tested on

Android simulator

## Related issues

N/A
