### PR TITLE
fix: Fix Android build on React Native 0.65 and older

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -10,6 +10,17 @@ set (RN_SO_DIR ${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni/first-
 
 # VisionCamera shared
 
+if(${REACT_NATIVE_VERSION} LESS 66)
+        set (
+                INCLUDE_JSI_CPP
+                "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp"
+        )
+        set (
+                INCLUDE_JSIDYNAMIC_CPP
+                "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/JSIDynamic.cpp"
+        )
+endif()
+
 add_library(
         ${PACKAGE_NAME}
         SHARED
@@ -31,11 +42,14 @@ file (GLOB LIBFBJNI_INCLUDE_DIR "${BUILD_DIR}/fbjni-*-headers.jar/")
 target_include_directories(
         ${PACKAGE_NAME}
         PRIVATE
+        # --- fbjni ---
         "${LIBFBJNI_INCLUDE_DIR}"
+        # --- Third Party (required by RN) ---
         "${BUILD_DIR}/third-party-ndk/boost"
         "${BUILD_DIR}/third-party-ndk/double-conversion"
         "${BUILD_DIR}/third-party-ndk/folly"
         "${BUILD_DIR}/third-party-ndk/glog"
+        # --- React Native ---
         "${NODE_MODULES_DIR}/react-native/React"
         "${NODE_MODULES_DIR}/react-native/React/Base"
         "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni"
@@ -44,6 +58,9 @@ target_include_directories(
         "${NODE_MODULES_DIR}/react-native/ReactCommon/callinvoker"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi"
         "${NODE_MODULES_DIR}/hermes-engine/android/include/"
+        ${INCLUDE_JSI_CPP} # only on older RN versions
+        ${INCLUDE_JSIDYNAMIC_CPP} # only on older RN versions
+        # --- Reanimated ---
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/Tools"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/SpecTools"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/SharedItems"
@@ -88,12 +105,6 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 find_library(
-        JSI_LIB
-        jsi
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
         FOLLY_JSON_LIB
         folly_json
         PATHS ${LIBRN_DIR}
@@ -106,6 +117,18 @@ find_library(
         PATHS ${LIBRN_DIR}
         NO_CMAKE_FIND_ROOT_PATH
 )
+if(${REACT_NATIVE_TARGET_VERSION} LESS 66)
+        # JSI lib didn't exist on RN 0.65 and before. Simply omit it.
+        set (JSI_LIB "")
+else()
+        # RN 0.66 distributes libjsi.so, can be used instead of compiling jsi.cpp manually.
+        find_library(
+                JSI_LIB
+                jsi
+                PATHS ${LIBRN_DIR}
+                NO_CMAKE_FIND_ROOT_PATH
+        )
+endif()
 
 find_library(
         REANIMATED_LIB

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -117,7 +117,7 @@ find_library(
         PATHS ${LIBRN_DIR}
         NO_CMAKE_FIND_ROOT_PATH
 )
-if(${REACT_NATIVE_TARGET_VERSION} LESS 66)
+if(${REACT_NATIVE_VERSION} LESS 66)
         # JSI lib didn't exist on RN 0.65 and before. Simply omit it.
         set (JSI_LIB "")
 else()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -118,6 +118,8 @@ android {
   packagingOptions {
     // Exclude all Libraries that are already present in the user's app (through React Native or by him installing REA)
     excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so", "**/libreactnativejni.so", "**/libfolly_json.so", "**/libreanimated.so", "**/libjscexecutor.so"]
+    // META-INF is duplicate by CameraX.
+    exclude "META-INF/**"
   }
 
   buildTypes {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -116,7 +116,8 @@ android {
   }
 
   packagingOptions {
-    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so"]
+    // Exclude all Libraries that are already present in the user's app (through React Native or by him installing REA)
+    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so", "**/libreactnativejni.so", "**/libfolly_json.so", "**/libreanimated.so", "**/libjscexecutor.so"]
   }
 
   buildTypes {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,10 @@ import java.nio.file.Paths
 
 def reactNative = new File("$projectDir/../node_modules/react-native")
 
+def reactProperties = new Properties()
+file("$projectDir/../node_modules/react-native/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
+def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\.")[1].toInteger()
+
 def FOR_HERMES = System.getenv("FOR_HERMES") == "True"
 rootProject.getSubprojects().forEach({project ->
   if (project.plugins.hasPlugin("com.android.application")) {
@@ -94,6 +98,7 @@ android {
         cppFlags "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"
         abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         arguments '-DANDROID_STL=c++_shared',
+                "-DREACT_NATIVE_VERSION=${REACT_NATIVE_VERSION}",
                 "-DNODE_MODULES_DIR=${rootDir}/../node_modules",
                 "-DFOR_HERMES=${FOR_HERMES}"
       }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/654
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/588
* Fixes #546 
* Fixes #513 
* Fixes #422 
* Fixes #390 
* Fixes #388 
* Fixes #369 
* Fixes #365 
* Fixes #341 
* Fixes #338 
* Fixes #269 
* Overrides #370 
* Overrides #676 
* Resolves https://github.com/mrousavy/react-native-vision-camera/issues/663