### PR TITLE
fix: Import REA before Worklet API usage

### DIFF
--- a/src/hooks/useFrameProcessor.ts
+++ b/src/hooks/useFrameProcessor.ts
@@ -3,7 +3,11 @@
 import { DependencyList, useCallback } from 'react';
 import type { Frame } from '../Frame';
 
-if (global.__reanimatedWorkletInit == null) require('react-native-reanimated');
+// @ts-expect-error
+if (global.__reanimatedWorkletInit == null) {
+  // import REA to initialize it before we use the Worklet API.
+  require('react-native-reanimated');
+}
 
 type FrameProcessor = (frame: Frame) => void;
 

--- a/src/hooks/useFrameProcessor.ts
+++ b/src/hooks/useFrameProcessor.ts
@@ -3,6 +3,8 @@
 import { DependencyList, useCallback } from 'react';
 import type { Frame } from '../Frame';
 
+if (global.__reanimatedWorkletInit == null) require('react-native-reanimated');
+
 type FrameProcessor = (frame: Frame) => void;
 
 const capturableConsole = console;


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

Import REA in `useFrameProcessor.ts` file if REA is not yet initialized. 

Before the user needed to add

```
import 'react-native-reanimated'
```

to the top of his file to use Frame Processors, now that becomes redundant.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
