### PR TITLE
fix: version_code issue on Android 29

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -172,7 +172,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
           val isoRange = characteristics.get(CameraCharacteristics.SENSOR_INFO_SENSITIVITY_RANGE)
           val digitalStabilizationModes = characteristics.get(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES)
           val opticalStabilizationModes = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION)
-          val zoomRange = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+          val zoomRange = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q)
             characteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE)
           else null
           val name = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)

--- a/android/src/main/java/com/mrousavy/camera/utils/Context+displayRotation.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/Context+displayRotation.kt
@@ -8,7 +8,7 @@ import com.facebook.react.bridge.ReactContext
 
 val Context.displayRotation: Int
   get() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
       // Context.display
       this.display?.let { display ->
         return display.rotation


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

I'm currently using the library on a project with React Native 0.63.3 and Android Version 29 and with the last fix, I'm not able to run it due to the condition against Android 30

this PR adds the option to install on React Native with VERSION_CODES = 29 without having to upgrade

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

* This PR changes `Build.VERSION.SDK_INT >= Build.VERSION_CODES.R` to support Build.VERSION_CODES.Q without having to upgrade React Native/Android Version

## Tested on
* Pixel 2 API 30

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
