### PR TITLE
feat: Make `takePhoto(..)` return in-memory Photo JSI-HostObject

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -81,7 +81,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   val photo = results.first { it is ImageProxy } as ImageProxy
   val file = results.first { it is File } as File
 
-  val exif: ExifInterface?
+  val exif: ExifInterface
   @Suppress("BlockingMethodInNonBlockingContext")
   withContext(Dispatchers.IO) {
     Log.d(CameraView.TAG, "Saving picture to ${file.absolutePath}...")
@@ -100,7 +100,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   map.putInt("height", photo.height)
   map.putBoolean("isRawPhoto", photo.isRaw)
 
-  val metadata = exif?.buildMetadataMap()
+  val metadata = exif.buildMetadataMap()
   map.putMap("metadata", metadata)
 
   photo.close()

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -60,7 +60,6 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
   if (options.hasKey("enableAutoDistortionCorrection")) {
     // TODO enableAutoDistortionCorrection
   }
-  val skipMetadata = if (options.hasKey("skipMetadata")) options.getBoolean("skipMetadata") else false
 
   val camera2Info = Camera2CameraInfo.from(camera!!.cameraInfo)
   val lensFacing = camera2Info.getCameraCharacteristic(CameraCharacteristics.LENS_FACING)
@@ -92,7 +91,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
     }
     Log.i(CameraView.TAG_PERF, "Finished image saving in ${milliseconds}ms")
     // TODO: Read Exif from existing in-memory photo buffer instead of file?
-    exif = if (skipMetadata) null else ExifInterface(file)
+    exif = ExifInterface(file)
   }
 
   val map = Arguments.createMap()

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakeSnapshot.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakeSnapshot.kt
@@ -43,9 +43,7 @@ suspend fun CameraView.takeSnapshot(options: ReadableMap): WritableMap = corouti
     map.putInt("height", bitmap.height)
     map.putBoolean("isRawPhoto", false)
 
-    val skipMetadata =
-      if (options.hasKey("skipMetadata")) options.getBoolean("skipMetadata") else false
-    val metadata = if (skipMetadata) null else exif.buildMetadataMap()
+    val metadata = exif.buildMetadataMap()
     map.putMap("metadata", metadata)
 
     return@coroutineScope map

--- a/docs/docs/guides/CAPTURING.mdx
+++ b/docs/docs/guides/CAPTURING.mdx
@@ -63,8 +63,7 @@ Compared to iOS, Cameras on Android tend to be slower in image capture. If you c
 
 ```ts
 const snapshot = await camera.current.takeSnapshot({
-  quality: 85,
-  skipMetadata: true
+  quality: 85
 })
 ```
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -325,7 +325,7 @@ PODS:
     - React
   - RNVectorIcons (8.1.0):
     - React-Core
-  - VisionCamera (2.10.0):
+  - VisionCamera (2.11.1):
     - React
     - React-callinvoker
     - React-Core
@@ -505,7 +505,7 @@ SPEC CHECKSUMS:
   RNScreens: 6e1ea5787989f92b0671049b808aef64fa1ef98c
   RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
-  VisionCamera: c18461c30853ba1b4beec2e723098e707c5d938b
+  VisionCamera: 19cc2696de0928bbadae897a127429deca77a42a
   Yoga: c11abbf5809216c91fcd62f5571078b83d9b6720
 
 PODFILE CHECKSUM: 29b1752e05601e9867644e58ce0ed8b9106be6cb

--- a/example/src/views/CaptureButton.tsx
+++ b/example/src/views/CaptureButton.tsx
@@ -64,7 +64,6 @@ const _CaptureButton: React.FC<Props> = ({
       qualityPrioritization: 'speed',
       flash: flash,
       quality: 90,
-      skipMetadata: true,
     }),
     [flash],
   );

--- a/ios/Types/PhotoHostObject.h
+++ b/ios/Types/PhotoHostObject.h
@@ -8,4 +8,20 @@
 
 #pragma once
 
-#import <AVFoundation.h>
+#import <jsi/jsi.h>
+#import <AVFoundation/AVCapturePhoto.h>
+
+using namespace facebook;
+
+class JSI_EXPORT PhotoHostObject: public jsi::HostObject {
+public:
+  explicit PhotoHostObject(AVCapturePhoto* photo): photo(photo) {}
+
+public:
+  jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& rt) override;
+  void close();
+
+public:
+  AVCapturePhoto* photo;
+};

--- a/ios/Types/PhotoHostObject.h
+++ b/ios/Types/PhotoHostObject.h
@@ -1,0 +1,11 @@
+//
+//  PhotoHostObject.h
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 04.01.22.
+//  Copyright © 2022 mrousavy. All rights reserved.
+//
+
+#pragma once
+
+#import <AVFoundation.h>

--- a/ios/Types/PhotoHostObject.mm
+++ b/ios/Types/PhotoHostObject.mm
@@ -6,4 +6,43 @@
 //  Copyright © 2022 mrousavy. All rights reserved.
 //
 
-#include "PhotoHostObject.h"
+#import "PhotoHostObject.h"
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#import <jsi/jsi.h>
+
+std::vector<jsi::PropNameID> PhotoHostObject::getPropertyNames(jsi::Runtime& rt) {
+  std::vector<jsi::PropNameID> result;
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toString")));
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("width")));
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("height")));
+  return result;
+}
+
+jsi::Value PhotoHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {
+  auto name = propName.utf8(runtime);
+
+  if (name == "toString") {
+    auto toString = [this] (jsi::Runtime& runtime, const jsi::Value&, const jsi::Value*, size_t) -> jsi::Value {
+      auto width = [photo width];
+      auto height = [photo height];
+
+      NSMutableString* string = [NSMutableString stringWithFormat:@"%lu x %lu Photo", width, height];
+      return jsi::String::createFromUtf8(runtime, string.UTF8String);
+    };
+    return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "toString"), 0, toString);
+  }
+
+  if (name == "width") {
+    this->assertIsFrameStrong(runtime, name);
+    auto width = [photo width];
+    return jsi::Value((double) width);
+  }
+  if (name == "height") {
+    this->assertIsFrameStrong(runtime, name);
+    auto height = [photo height];
+    return jsi::Value((double) height);
+  }
+
+  return jsi::Value::undefined();
+}

--- a/ios/Types/PhotoHostObject.mm
+++ b/ios/Types/PhotoHostObject.mm
@@ -1,0 +1,9 @@
+//
+//  PhotoHostObject.mm
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 04.01.22.
+//  Copyright © 2022 mrousavy. All rights reserved.
+//
+
+#include "PhotoHostObject.h"

--- a/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		B86DC971260E2D5200FB17B2 /* AVAudioSession+trySetAllowHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86DC970260E2D5200FB17B2 /* AVAudioSession+trySetAllowHaptics.swift */; };
 		B86DC974260E310600FB17B2 /* CameraView+AVAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86DC973260E310600FB17B2 /* CameraView+AVAudioSession.swift */; };
 		B86DC977260E315100FB17B2 /* CameraView+AVCaptureSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86DC976260E315100FB17B2 /* CameraView+AVCaptureSession.swift */; };
+		B86EBA5F2784359400A8AC23 /* PhotoHostObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = B86EBA5D2784359400A8AC23 /* PhotoHostObject.mm */; };
 		B8805067266798B600EAD7F2 /* JSConsoleHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = B8805066266798B600EAD7F2 /* JSConsoleHelper.mm */; };
 		B882721026AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B882720F26AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift */; };
 		B887518525E0102000DB86D6 /* PhotoCaptureDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887515C25E0102000DB86D6 /* PhotoCaptureDelegate.swift */; };
@@ -96,6 +97,8 @@
 		B86DC970260E2D5200FB17B2 /* AVAudioSession+trySetAllowHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAudioSession+trySetAllowHaptics.swift"; sourceTree = "<group>"; };
 		B86DC973260E310600FB17B2 /* CameraView+AVAudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CameraView+AVAudioSession.swift"; sourceTree = "<group>"; };
 		B86DC976260E315100FB17B2 /* CameraView+AVCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CameraView+AVCaptureSession.swift"; sourceTree = "<group>"; };
+		B86EBA5D2784359400A8AC23 /* PhotoHostObject.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PhotoHostObject.mm; sourceTree = "<group>"; };
+		B86EBA5E2784359400A8AC23 /* PhotoHostObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PhotoHostObject.h; sourceTree = "<group>"; };
 		B8805065266798AB00EAD7F2 /* JSConsoleHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSConsoleHelper.h; sourceTree = "<group>"; };
 		B8805066266798B600EAD7F2 /* JSConsoleHelper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSConsoleHelper.mm; sourceTree = "<group>"; };
 		B882720F26AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureConnection+setInterfaceOrientation.swift"; sourceTree = "<group>"; };
@@ -184,11 +187,21 @@
 				B887518125E0102000DB86D6 /* CameraViewManager.swift */,
 				B8DB3BC9263DC4D8004C18D7 /* RecordingSession.swift */,
 				B887515C25E0102000DB86D6 /* PhotoCaptureDelegate.swift */,
+				B86EBA60278435A400A8AC23 /* Types */,
 				B887516125E0102000DB86D6 /* Extensions */,
 				B887517225E0102000DB86D6 /* Parsers */,
 				B887516D25E0102000DB86D6 /* React Utils */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		B86EBA60278435A400A8AC23 /* Types */ = {
+			isa = PBXGroup;
+			children = (
+				B86EBA5E2784359400A8AC23 /* PhotoHostObject.h */,
+				B86EBA5D2784359400A8AC23 /* PhotoHostObject.mm */,
+			);
+			path = Types;
 			sourceTree = "<group>";
 		};
 		B887516125E0102000DB86D6 /* Extensions */ = {
@@ -411,6 +424,7 @@
 				B887519F25E0102000DB86D6 /* AVCaptureDevice.DeviceType+descriptor.swift in Sources */,
 				B8D22CDC2642DB4D00234472 /* AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift in Sources */,
 				B82FBA962614B69D00909718 /* RCTBridge+runOnJS.mm in Sources */,
+				B86EBA5F2784359400A8AC23 /* PhotoHostObject.mm in Sources */,
 				B84760DF2608F57D004C3180 /* CameraQueues.swift in Sources */,
 				B887519025E0102000DB86D6 /* AVCaptureDevice.Format+matchesFilter.swift in Sources */,
 				B887518F25E0102000DB86D6 /* AVCapturePhotoOutput+mirror.swift in Sources */,

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -136,8 +136,7 @@ export class Camera extends React.PureComponent<CameraProps> {
    * @example
    * ```ts
    * const photo = await camera.current.takeSnapshot({
-   *   quality: 85,
-   *   skipMetadata: true
+   *   quality: 85
    * })
    * ```
    */

--- a/src/PhotoFile.ts
+++ b/src/PhotoFile.ts
@@ -36,16 +36,6 @@ export interface TakePhotoOptions {
    * @default false
    */
   enableAutoDistortionCorrection?: boolean;
-  /**
-   * When set to `true`, metadata reading and mapping will be skipped. ({@linkcode PhotoFile.metadata} will be null)
-   *
-   * This might result in a faster capture, as metadata reading and mapping requires File IO.
-   *
-   * @default false
-   *
-   * @platform Android
-   */
-  skipMetadata?: boolean;
 }
 
 /**

--- a/src/Snapshot.ts
+++ b/src/Snapshot.ts
@@ -14,15 +14,4 @@ export interface TakeSnapshotOptions {
    * @default "off"
    */
   flash?: 'on' | 'off';
-
-  /**
-   * When set to `true`, metadata reading and mapping will be skipped. ({@linkcode PhotoFile.metadata} will be `null`)
-   *
-   * This might result in a faster capture, as metadata reading and mapping requires File IO.
-   *
-   * @default false
-   *
-   * @platform Android
-   */
-  skipMetadata?: boolean;
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
