### PR TITLE
Fix Setup document.

### DIFF
--- a/docs/docs/guides/SETUP.mdx
+++ b/docs/docs/guides/SETUP.mdx
@@ -81,6 +81,30 @@ Open your project's `AndroidManifest.xml` and add the following lines inside the
 
 <!-- optionally, if you want to record audio: -->
 <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+  ...
+  <activity
+    ...
+    android:exported="true" <- ADD
+  >
+    ...
+  </activity>
+</application>
+```
+
+Change compileSdkVersion and targetSdkVersion in android/build.gradle to 31.
+
+```gradle
+  buildscript {
+    ext {
+        ...
+        compileSdkVersion = 31
+        targetSdkVersion = 31
+        ...
+    }
+    ...
+  }
 ```
 
 </TabItem>


### PR DESCRIPTION
## What
Fixed Setup document.
The documentation for setting targetSdkVersion to 31 or higher is only in [Troubleshooting](https://mrousavy.com/react-native-vision-camera/docs/guides/troubleshooting#android), so add it to the setup documentation.

## Changes
Added necessary information for android setup.