### PR TITLE
fix: Fix image rotated when flipped in Android

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/ImageProxy.save.kt
@@ -6,6 +6,7 @@ import android.graphics.ImageFormat
 import android.graphics.Matrix
 import android.util.Log
 import androidx.camera.core.ImageProxy
+import androidx.exifinterface.media.ExifInterface
 import com.mrousavy.camera.CameraView
 import com.mrousavy.camera.InvalidFormatError
 import java.io.ByteArrayOutputStream
@@ -43,7 +44,34 @@ fun flip(imageBytes: ByteArray, imageWidth: Int): ByteArray {
 fun flipImage(imageBytes: ByteArray): ByteArray {
   val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
   val matrix = Matrix()
-  matrix.preScale(-1f, 1f)
+
+  val exif = ExifInterface(imageBytes.inputStream())
+  val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+
+  when (orientation) {
+    ExifInterface.ORIENTATION_ROTATE_180 -> {
+      matrix.setRotate(180f)
+      matrix.postScale(-1f, 1f)
+    }
+    ExifInterface.ORIENTATION_FLIP_VERTICAL -> {
+      matrix.setRotate(180f)
+    }
+    ExifInterface.ORIENTATION_TRANSPOSE -> {
+      matrix.setRotate(90f)
+    }
+    ExifInterface.ORIENTATION_ROTATE_90 -> {
+      matrix.setRotate(90f)
+      matrix.postScale(-1f, 1f)
+    }
+    ExifInterface.ORIENTATION_TRANSVERSE -> {
+      matrix.setRotate(-90f)
+    }
+    ExifInterface.ORIENTATION_ROTATE_270 -> {
+      matrix.setRotate(-90f)
+      matrix.postScale(-1f, 1f)
+    }
+  }
+
   val newBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
   val stream = ByteArrayOutputStream()
   newBitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes a bug that causes image to rotate when using a front camera in Android.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes
This PR changes the `flipImage` method in ImageProxy.save.kt to fix the image rotation based on Exif `Orientation` value.

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

Pixel 5, Android 11
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
Fixes #146
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
