### PR TITLE
feat: Processing depth data in real-time

### DIFF
--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -95,15 +95,10 @@ final class CameraViewManager: RCTViewManager {
   @objc
   final func getAvailableCameraDevices(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     withPromise(resolve: resolve, reject: reject) {
-      let discoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: getAllDeviceTypes(), mediaType: .video, position: .unspecified)
-      let devices = discoverySession.devices.filter {
-        if #available(iOS 11.1, *) {
-          // exclude the true-depth camera. The True-Depth camera has YUV and Infrared, can't take photos!
-          return $0.deviceType != .builtInTrueDepthCamera
-        }
-        return true
-      }
-      return devices.map {
+      let discoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: getAllDeviceTypes(),
+                                                              mediaType: .video,
+                                                              position: .unspecified)
+      return discoverySession.devices.map {
         return [
           "id": $0.uniqueID,
           "devices": $0.physicalDevices.map(\.deviceType.descriptor),

--- a/ios/Parsers/AVCaptureDevice.DeviceType+descriptor.swift
+++ b/ios/Parsers/AVCaptureDevice.DeviceType+descriptor.swift
@@ -23,6 +23,14 @@ extension AVCaptureDevice.DeviceType {
         break
       }
     }
+    if #available(iOS 11.1, *) {
+      switch self {
+      case .builtInTrueDepthCamera:
+        return "true-depth-camera"
+      default:
+        break
+      }
+    }
     switch self {
     case .builtInDualCamera:
       return "dual-camera"
@@ -31,7 +39,6 @@ extension AVCaptureDevice.DeviceType {
     case .builtInWideAngleCamera:
       return "wide-angle-camera"
     default:
-      // e.g. `.builtInTrueDepthCamera`
       fatalError("AVCaptureDevice.Position has unknown state.")
     }
   }

--- a/src/CameraDevice.ts
+++ b/src/CameraDevice.ts
@@ -16,8 +16,9 @@ export type PhysicalCameraDeviceType = 'ultra-wide-angle-camera' | 'wide-angle-c
  * * `"dual-camera"`: A combination of wide-angle and telephoto cameras that creates a capture device.
  * * `"dual-wide-camera"`: A device that consists of two cameras of fixed focal length, one ultrawide angle and one wide angle.
  * * `"triple-camera"`: A device that consists of three cameras of fixed focal length, one ultrawide angle, one wide angle, and one telephoto.
+ * * `"true-depth-camera"`: A device that consists of two cameras, one YUV and one Infrared. The infrared camera provides high quality depth information that is synchronized and perspective corrected to frames produced by the YUV camera. While the resolution of the depth data and YUV frames may differ, their field of view and aspect ratio always match.
  */
-export type LogicalCameraDeviceType = 'dual-camera' | 'dual-wide-camera' | 'triple-camera';
+export type LogicalCameraDeviceType = 'dual-camera' | 'dual-wide-camera' | 'triple-camera' | 'true-depth-camera';
 
 /**
  * Parses an array of physical device types into a single {@linkcode PhysicalCameraDeviceType} or {@linkcode LogicalCameraDeviceType}, depending what matches.


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds the possibility of processing depth-data in real-time.

### iOS

On iOS, depth data is received from the `.buildInTrueDepth` Camera Device. The Frame Processor then gets called once with the YUV image, and once with the Depth-Data buffer (Infrared). A `.format` prop on the `Frame` instance will be added, that specifies whether the Frame is in `yuv` or in `infrared` depth data map.

### Android

No idea yet

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

* iPhone 8

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
