### PR TITLE
fix: Log Stacktrace on Frame Processor Error

### DIFF
--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -31,4 +31,5 @@ jobs:
             ,-build/namespaces\
             ,-whitespace/comments\
             ,-build/include_order\
+            ,-build/c++11\
             "

--- a/android/src/main/cpp/CameraView.cpp
+++ b/android/src/main/cpp/CameraView.cpp
@@ -41,7 +41,7 @@ void CameraView::frameProcessorCallback(const alias_ref<JImageProxy::javaobject>
   } catch (const jsi::JSError& error) {
     // TODO: jsi::JSErrors cannot be caught on Hermes. They crash the entire app.
     auto stack = std::regex_replace(error.getStack(), std::regex("\n"), "\n    ");
-    __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw an error! %s\nIn: %s", error.getMessage(), stack);
+    __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw an error! %s\nIn: %s", error.getMessage().c_str(), stack.c_str());
   } catch (const std::exception& exception) {
     __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw a C++ error! %s", exception.what());
   }

--- a/android/src/main/cpp/CameraView.cpp
+++ b/android/src/main/cpp/CameraView.cpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <regex>
 
 namespace vision {
 
@@ -39,7 +40,8 @@ void CameraView::frameProcessorCallback(const alias_ref<JImageProxy::javaobject>
     frameProcessor_(frame);
   } catch (const jsi::JSError& error) {
     // TODO: jsi::JSErrors cannot be caught on Hermes. They crash the entire app.
-    __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw an error! %s\n%s", error.getMessage(), error.getStack());
+    auto stack = std::regex_replace(error.getStack(), std::regex("\n"), "\n    ");
+    __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw an error! %s\nIn: %s", error.getMessage(), stack);
   } catch (const std::exception& exception) {
     __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw a C++ error! %s", exception.what());
   }

--- a/android/src/main/cpp/CameraView.cpp
+++ b/android/src/main/cpp/CameraView.cpp
@@ -6,6 +6,7 @@
 
 #include <jni.h>
 #include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
 
 #include <memory>
 #include <string>
@@ -36,9 +37,11 @@ void CameraView::frameProcessorCallback(const alias_ref<JImageProxy::javaobject>
 
   try {
     frameProcessor_(frame);
-  } catch (const std::exception& exception) {
+  } catch (const jsi::JSError& error) {
     // TODO: jsi::JSErrors cannot be caught on Hermes. They crash the entire app.
-    __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw an error! %s", exception.what());
+    __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw an error! %s\n%s", error.getMessage(), error.getStack());
+  } catch (const std::exception& exception) {
+    __android_log_print(ANDROID_LOG_ERROR, TAG, "Frame Processor threw a C++ error! %s", exception.what());
   }
 }
 

--- a/ios/Frame Processor/FrameProcessorUtils.mm
+++ b/ios/Frame Processor/FrameProcessorUtils.mm
@@ -9,6 +9,7 @@
 #import "FrameProcessorUtils.h"
 #import <chrono>
 #import <memory>
+#import <regex>
 
 #import "FrameHostObject.h"
 #import "Frame.h"
@@ -27,8 +28,8 @@ FrameProcessorCallback convertJSIFunctionToFrameProcessorCallback(jsi::Runtime &
     try {
       cb.callWithThis(runtime, cb, jsi::Object::createFromHostObject(runtime, frameHostObject));
     } catch (jsi::JSError& jsError) {
-      
-      auto message = [NSString stringWithFormat:@"Frame Processor threw an error: %s\n%s", jsError.getMessage().c_str(), jsError.getStack().c_str()];
+      auto stack = std::regex_replace(jsError.getStack(), std::regex("\n"), "\n    ");
+      auto message = [NSString stringWithFormat:@"Frame Processor threw an error: %s\nIn: %s", jsError.getMessage().c_str(), stack.c_str()];
       
       RCTBridge* bridge = [RCTBridge currentBridge];
       if (bridge != nil) {

--- a/ios/Frame Processor/FrameProcessorUtils.mm
+++ b/ios/Frame Processor/FrameProcessorUtils.mm
@@ -19,7 +19,7 @@
 #import "JSConsoleHelper.h"
 #import <ReactCommon/RCTTurboModule.h>
 
-FrameProcessorCallback convertJSIFunctionToFrameProcessorCallback(jsi::Runtime &runtime, const jsi::Function &value) {
+FrameProcessorCallback convertJSIFunctionToFrameProcessorCallback(jsi::Runtime& runtime, const jsi::Function& value) {
   __block auto cb = value.getFunction(runtime);
 
   return ^(Frame* frame) {

--- a/ios/Frame Processor/FrameProcessorUtils.mm
+++ b/ios/Frame Processor/FrameProcessorUtils.mm
@@ -27,15 +27,17 @@ FrameProcessorCallback convertJSIFunctionToFrameProcessorCallback(jsi::Runtime &
     try {
       cb.callWithThis(runtime, cb, jsi::Object::createFromHostObject(runtime, frameHostObject));
     } catch (jsi::JSError& jsError) {
-      auto message = jsError.getMessage();
+      
+      auto message = [NSString stringWithFormat:@"Frame Processor threw an error: %s\n%s", jsError.getMessage().c_str(), jsError.getStack().c_str()];
+      
       RCTBridge* bridge = [RCTBridge currentBridge];
       if (bridge != nil) {
         bridge.jsCallInvoker->invokeAsync([bridge, message]() {
           auto logFn = [JSConsoleHelper getLogFunctionForBridge:bridge];
-          logFn(RCTLogLevelError, [NSString stringWithFormat:@"Frame Processor threw an error: %s", message.c_str()]);
+          logFn(RCTLogLevelError, message);
         });
       } else {
-        NSLog(@"Frame Processor threw an error: %s", message.c_str());
+        NSLog(@"%@", message);
       }
     }
 

--- a/scripts/cpplint.sh
+++ b/scripts/cpplint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if which cpplint >/dev/null; then
-  cpplint --linelength=230 --filter=-legal/copyright,-readability/todo,-build/namespaces,-whitespace/comments,-build/include_order --quiet --recursive --exclude "android/src/main/cpp/reanimated-headers" cpp android/src/main/cpp
+  cpplint --linelength=230 --filter=-legal/copyright,-readability/todo,-build/namespaces,-whitespace/comments,-build/include_order,-build/c++11 --quiet --recursive --exclude "android/src/main/cpp/reanimated-headers" cpp android/src/main/cpp
 else
   echo "warning: cpplint not installed, download from https://github.com/cpplint/cpplint"
 fi


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
