### PR TITLE
fix: build on android when hermes is enabled

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -119,7 +119,7 @@ android {
 
   packagingOptions {
     // Exclude all Libraries that are already present in the user's app (through React Native or by him installing REA)
-    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so", "**/libreactnativejni.so", "**/libfolly_json.so", "**/libreanimated.so", "**/libjscexecutor.so"]
+    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so", "**/libreactnativejni.so", "**/libfolly_json.so", "**/libreanimated.so", "**/libjscexecutor.so", "**/libhermes.so"]
     // META-INF is duplicate by CameraX.
     exclude "META-INF/**"
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes an issue where projects using react-native-vision-camera don't build on android when Hermes (javascript engine) is enabled in react native.

Android build terminates with the following error:
```
Execution failed for task ':app:mergeDebugNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
   > 2 files found with path 'lib/x86/libhermes.so' from inputs:
      - /home/jsmith/Documents/work/csi/campbell-go/node_modules/react-native-vision-camera/android/build/intermediates/library_jni/debug/jni
      - /home/jsmith/.gradle/caches/transforms-3/cb275df1ccea8bb80f865cbbbbaf438d/transformed/jetified-hermes-debug/jni
     If you are using jniLibs and CMake IMPORTED targets, see
     https://developer.android.com/r/tools/jniLibs-vs-imported-targets
```

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

This PR adds the value "**/libhermes.so" to packagingOptions in android/build.gradle

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
Fixes #365 (but for builds with hermes enabled)
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
