### PR TITLE
fix(types): duration is not optional anymore

### DIFF
--- a/src/VideoFile.ts
+++ b/src/VideoFile.ts
@@ -50,10 +50,6 @@ export interface RecordVideoOptions {
 export interface VideoFile extends TemporaryFile {
   /**
    * Represents the duration of the video, in seconds.
-   *
-   * This is `undefined` on Android, see [issue #77](https://github.com/mrousavy/react-native-vision-camera/issues/77)
-   *
-   * @platform iOS
    */
-  duration?: number;
+  duration: number;
 }


### PR DESCRIPTION
Duration is not optional anymore and not limited to iOS. This PR fixes the types.
