### PR TITLE
feat: Add `autoRotateAnalysisImage` prop

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -72,7 +72,7 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
     const val TAG = "CameraView"
     const val TAG_PERF = "CameraView.performance"
 
-    private val propsThatRequireSessionReconfiguration = arrayListOf("cameraId", "format", "fps", "hdr", "lowLightBoost", "photo", "video", "enableFrameProcessor")
+    private val propsThatRequireSessionReconfiguration = arrayListOf("cameraId", "format", "fps", "hdr", "lowLightBoost", "autoRotateAnalysisImage", "photo", "video", "enableFrameProcessor")
     private val arrayListOfZoom = arrayListOf("zoom")
   }
 
@@ -93,6 +93,7 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   var hdr: Boolean? = null // nullable bool
   var colorSpace: String? = null
   var lowLightBoost: Boolean? = null // nullable bool
+  var autoRotateAnalysisImage: Boolean? = null // nullable bool
   // other props
   var isActive = false
   var torch = "off"
@@ -375,6 +376,10 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
         .setTargetRotation(rotation)
         .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
         .setBackgroundExecutor(frameProcessorThread)
+
+      if (autoRotateAnalysisImage == true) {
+        imageAnalysisBuilder.setOutputImageRotationEnabled(true)
+      }
 
       if (format == null) {
         // let CameraX automatically find best resolution for the target aspect ratio

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -129,6 +129,13 @@ class CameraViewManager(reactContext: ReactApplicationContext) : SimpleViewManag
     view.lowLightBoost = lowLightBoost
   }
 
+  @ReactProp(name = "autoRotateAnalysisImage")
+  fun setAutoRotateAnalysisImage(view: CameraView, autoRotateAnalysisImage: Boolean?) {
+    if (view.autoRotateAnalysisImage != autoRotateAnalysisImage)
+      addChangedPropToTransaction(view, "autoRotateAnalysisImage")
+    view.autoRotateAnalysisImage = autoRotateAnalysisImage
+  }
+
   @ReactProp(name = "colorSpace")
   fun setColorSpace(view: CameraView, colorSpace: String?) {
     if (view.colorSpace != colorSpace)

--- a/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleFrameProcessorPlugin.java
+++ b/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleFrameProcessorPlugin.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 public class ExampleFrameProcessorPlugin extends FrameProcessorPlugin {
     @Override
     public Object callback(@NotNull ImageProxy image, @NotNull Object[] params) {
-        Log.d("ExamplePlugin", image.getWidth() + " x " + image.getHeight() + " Image with format #" + image.getFormat() + ". Logging " + params.length + " parameters:");
+        Log.d("ExamplePlugin", image.getWidth() + " x " + image.getHeight() + " Image with format #" + image.getFormat() + " and rotation: " + image.getImageInfo().getRotationDegrees() + ". Logging " + params.length + " parameters:");
 
         for (Object param : params) {
             Log.d("ExamplePlugin", "  -> " + (param == null ? "(null)" : param.toString() + " (" + param.getClass().getName() + ")"));

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -115,6 +115,12 @@ export interface CameraProps extends ViewProps {
    */
   lowLightBoost?: boolean;
   /**
+   * Enables or disables automatic ouput image rotation for frame processor output on Android, see https://developer.android.com/reference/androidx/camera/core/ImageAnalysis.Builder#setOutputImageRotationEnabled(boolean)
+   *
+   * @platform android
+   */
+  autoRotateAnalysisImage?: boolean;
+  /**
    * Specifies the color space to use for this camera device. Make sure the given `format` contains the given `colorSpace`.
    *
    * Requires `format` to be set.


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

- This PR adds an additional android-only prop called `autoRotateAnalysisImage` that if set rotates each frame passed to the frame processor callback to the upright (0 degree) orientation, see https://developer.android.com/reference/androidx/camera/core/ImageAnalysis.Builder#setOutputImageRotationEnabled(boolean).
- This adds an additional overhead per frame to perform the rotation
- This is required when performing any image analysis on Android as the image proxy rotation can vary from device to device based on the orientation of the camera sensor

## Changes

- Adds `autoRotateAnalysisImage` boolean prop

## Tested on

Tested on a OnePlus 6
