### PR TITLE
fix: switch width and height of target resolution if portrait for Android

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -410,9 +410,19 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
         // User has selected a custom format={}. Use that
         val format = DeviceFormat(format!!)
         Log.i(TAG, "Using custom format - photo: ${format.photoSize}, video: ${format.videoSize} @ $fps FPS")
-        previewBuilder.setTargetResolution(format.videoSize)
+        
+        val targetPreviewResolution:Size
+        if (getDisplay().rotation == Surface.ROTATION_0) {
+          val newWidth = format.videoSize.height
+          val newHeight = format.videoSize.width
+          targetPreviewResolution = Size(newWidth, newHeight)
+        } else {
+          targetPreviewResolution = Size(format.videoSize.width, format.videoSize.height)
+        }
+
+        previewBuilder.setTargetResolution(targetPreviewResolution)
         imageCaptureBuilder.setTargetResolution(format.photoSize)
-        imageAnalysisBuilder.setTargetResolution(format.videoSize)
+        imageAnalysisBuilder.setTargetResolution(targetPreviewResolution)
 
         // TODO: Ability to select resolution exactly depending on format? Just like on iOS...
         when (min(format.videoSize.height, format.videoSize.width)) {

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -411,19 +411,15 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
         // User has selected a custom format={}. Use that
         val format = DeviceFormat(format!!)
         Log.i(TAG, "Using custom format - photo: ${format.photoSize}, video: ${format.videoSize} @ $fps FPS")
-        
-        val targetPreviewResolution:Size
-        if (getDisplay().rotation == Surface.ROTATION_0) {
-          val newWidth = format.videoSize.height
-          val newHeight = format.videoSize.width
-          targetPreviewResolution = Size(newWidth, newHeight)
-        } else {
-          targetPreviewResolution = Size(format.videoSize.width, format.videoSize.height)
+        val videoSize:Size
+        if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+          videoSize = Size(format.videoSize.height, format.videoSize.width)
+        }else {
+          videoSize = format.videoSize
         }
-
-        previewBuilder.setTargetResolution(targetPreviewResolution)
+        previewBuilder.setTargetResolution(videoSize)
         imageCaptureBuilder.setTargetResolution(format.photoSize)
-        imageAnalysisBuilder.setTargetResolution(targetPreviewResolution)
+        imageAnalysisBuilder.setTargetResolution(videoSize)
 
         // TODO: Ability to select resolution exactly depending on format? Just like on iOS...
         when (min(format.videoSize.height, format.videoSize.width)) {

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -8,6 +8,7 @@ import android.content.res.Configuration
 import android.hardware.camera2.*
 import android.util.Log
 import android.util.Range
+import android.util.Size
 import android.view.*
 import android.view.View.OnTouchListener
 import android.widget.FrameLayout


### PR DESCRIPTION
## What

This PR fixes the incorrect resolution setting for Android.

## Changes

switch height and width of target resolution if portrait for Android

## Tested on

Sharp S2, Android 8

## Related issues

https://github.com/mrousavy/react-native-vision-camera/issues/770
https://github.com/mrousavy/react-native-vision-camera/pull/325
https://github.com/mrousavy/react-native-vision-camera/issues/281


