### PR TITLE
Fix issue with resolving camera view in Frame Processor

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
@@ -60,7 +60,8 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext, frameProces
   @Keep
   fun findCameraViewById(viewId: Int): CameraView {
     Log.d(TAG, "Finding view $viewId...")
-    val view = mContext?.get()?.currentActivity?.findViewById<CameraView>(viewId)
+    val ctx = mContext?.get()
+    val view = if (ctx != null) UIManagerHelper.getUIManager(ctx, viewId)?.resolveView(viewId) as CameraView? else null
     Log.d(TAG,  if (view != null) "Found view $viewId!" else "Couldn't find view $viewId!")
     return view ?: throw ViewNotFoundError(viewId)
   }

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
@@ -6,6 +6,7 @@ import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import com.facebook.react.uimanager.UIManagerHelper
 import com.mrousavy.camera.CameraView
 import com.mrousavy.camera.ViewNotFoundError
 import java.lang.ref.WeakReference


### PR DESCRIPTION
## What

When a modal is used the Camera view is not in the hierarchy of the current activity.
Therefore we utilize the global React Native View registry to resolve the view instance.

## Changes

Changed way how Camera view is resolved

## Tested on

Android 12 

## Related issues

Fixes #810 
