### PR TITLE
Fix Android focus not using correct focus point

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+Focus.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+Focus.kt
@@ -1,9 +1,9 @@
 package com.mrousavy.camera
 
 import androidx.camera.core.FocusMeteringAction
-import androidx.camera.core.SurfaceOrientedMeteringPointFactory
 import com.facebook.react.bridge.ReadableMap
 import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
 
 suspend fun CameraView.focus(pointMap: ReadableMap) {
@@ -16,8 +16,11 @@ suspend fun CameraView.focus(pointMap: ReadableMap) {
   val x = pointMap.getDouble("x") * dpi
   val y = pointMap.getDouble("y") * dpi
 
-  val factory = SurfaceOrientedMeteringPointFactory(this.width.toFloat(), this.height.toFloat())
-  val point = factory.createPoint(x.toFloat(), y.toFloat())
+  // Getting the point from the previewView needs to be run on the UI thread
+  val point = withContext(coroutineScope.coroutineContext) {
+    previewView.meteringPointFactory.createPoint(x.toFloat(), y.toFloat());
+  }
+
   val action = FocusMeteringAction.Builder(point, FocusMeteringAction.FLAG_AF or FocusMeteringAction.FLAG_AE)
     .setAutoCancelDuration(5, TimeUnit.SECONDS) // auto-reset after 5 seconds
     .build()

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -121,7 +121,7 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   private val cameraExecutor = Executors.newSingleThreadExecutor()
   internal val takePhotoExecutor = Executors.newSingleThreadExecutor()
   internal val recordVideoExecutor = Executors.newSingleThreadExecutor()
-  private var coroutineScope = CoroutineScope(Dispatchers.Main)
+  internal var coroutineScope = CoroutineScope(Dispatchers.Main)
 
   internal var camera: Camera? = null
   internal var imageCapture: ImageCapture? = null


### PR DESCRIPTION
## What

This PR fixes the `focus` function on Android not focusing on the given point (#758). The issue is that when calculating the focus point with `SurfaceOrientedMeteringPointFactory`, it does not factor in any scaling or cropping that has been done to the camera's view (thanks to [this StackOverflow answer](https://stackoverflow.com/a/60585382) for pointing me in the right direction!). I think it's possible this issue is not obvious unless you're resizing the camera view significantly in some way.

## Changes

Rather than manually calculate the focus point, we can get the PreviewView to do it for us. This fixes the issue because the PreviewView factors in any scaling or resizing of the view on the screen. The only potential issue is that this needs to run on the UI thread (which is what the `withContext` is doing), but I've tested it with frame processors enabled and disabled, and have found no issues in either case.

## Tested on

Tested on Pixel 3a running Android 12

## Related issues

Fixes #758
