### PR TITLE
Fix takeSnapshot not working on Android

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakeSnapshot.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakeSnapshot.kt
@@ -22,7 +22,9 @@ suspend fun CameraView.takeSnapshot(options: ReadableMap): WritableMap = corouti
       camera.cameraControl.enableTorch(true).await()
     }
 
-    val bitmap = this@takeSnapshot.previewView.bitmap ?: throw CameraNotReadyError()
+    val bitmap = withContext(coroutineScope.coroutineContext) {
+      previewView.bitmap ?: throw CameraNotReadyError()
+    }
 
     val quality = if (options.hasKey("quality")) options.getInt("quality") else 100
 


### PR DESCRIPTION
## What

Calling `takeSnapshot` on Android throws an error that it needs to run on the main thread (#547).

## Changes

This is similar to something I saw in the PR I made yesterday (#958). The fix is just to wrap the access of `previewView.bitmap` in a `withContext` to ensure it runs on the main thread.

## Tested on

Android 9 emulator
Android 10 device

## Related issues

Fixes #547
