### PR TITLE
fix: Adds Setting compileSdkVersion to 31 in ExpoPlugin

### DIFF
--- a/src/expo-plugin/withVisionCamera.ts
+++ b/src/expo-plugin/withVisionCamera.ts
@@ -31,6 +31,11 @@ const withCamera: ConfigPlugin<Props> = (config, props = {}) => {
     config = withDisableFrameProcessorsIOS(config);
   }
 
+  config = AndroidConfig.Version.withBuildScriptExtMinimumVersion(config, {
+    name: 'compileSdkVersion',
+    minVersion: 31,
+  });
+
   return withPlugins(config, [[AndroidConfig.Permissions.withPermissions, androidPermissions]]);
 };
 


### PR DESCRIPTION
## What

In order for a managed Expo project to build successfully with Expo EAS,
the min compile sdk version value needs to be set to 31.
Default value in Expo 44 is 30.

## Changes

Enhances the config plugin to set the min compile sdk value.

## Tested on
1) 
- Patched in changes logically
- Ran `expo prebuild -p android`
- Verified that value is set as expected

2) 
- Patched in changes logically
- Kicked of Expo EAS build
- Build succeeded

