### PR TITLE
fix: AVAssetWriter status is 1 crash

### DIFF
--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -199,9 +199,9 @@ class RecordingSession {
                           userInfo: [NSLocalizedDescriptionKey: "Stopped Recording Session too early, no frames have been recorded!"])
       completionHandler(.failed, error)
     } else if assetWriter.status == .writing {
-      bufferAdaptor?.assetWriterInput.markAsFinished()
-      audioWriter?.markAsFinished()
       assetWriter.finishWriting {
+        self.bufferAdaptor?.assetWriterInput.markAsFinished()
+        self.audioWriter?.markAsFinished()
         self.completionHandler(self.assetWriter.status, self.assetWriter.error)
       }
     } else {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

`markAsFinished` has to be called within the finishWritingWithCompletionHandler.
Moving that 2 lines allowed me to spam start / stop for hundreds of time without a single crash.

Since I am not a native developer, I can only assume that what I've done is correct. I had no regressions and the issue, which was 100% reproducible every single time on older devices due to performance I guess, has not happened again after applying this little change.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

Moved markedAsFinished into finishWriting.
This article was helpful to track the issue:
https://code-examples.net/en/q/e14f33

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

- iPhone 7, iOS 12.1
- iPhone 12 Pro Max, 15.4.1
- iPhone 13 Pro Max, 15.4.1

## Related issues

Fixes #930

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
