### PR TITLE
fix: AVWriter status 1 crash - follow up

### DIFF
--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -197,7 +197,7 @@ class RecordingSession {
       ReactLogger.log(level: .warning, message: "Tried calling finish() twice while AssetWriter is still writing!")
       return
     }
-    if !isFinishing {
+    if !hasWrittenFirstVideoFrame {
       let error = NSError(domain: "capture/aborted",
                           code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "Stopped Recording Session too early, no frames have been recorded!"])

--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -193,12 +193,12 @@ class RecordingSession {
    */
   func finish() {
     ReactLogger.log(level: .info, message: "Finishing Recording with AssetWriter status \"\(assetWriter.status.descriptor)\"...")
-    
+
     if isFinishing {
       ReactLogger.log(level: .warning, message: "Tried calling finish() twice while AssetWriter is still writing!")
       return
     }
-    
+
     if !hasWrittenFirstVideoFrame {
       let error = NSError(domain: "capture/aborted",
                           code: 1,

--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -33,7 +33,7 @@ class RecordingSession {
   private var initialTimestamp: CMTime?
   private var latestTimestamp: CMTime?
   private var hasWrittenFirstVideoFrame = false
-  private var hasRunningWritingAttempt = false;
+  private var hasRunningWritingAttempt = false
 
   var url: URL {
     return assetWriter.outputURL
@@ -208,7 +208,7 @@ class RecordingSession {
       bufferAdaptor?.assetWriterInput.markAsFinished()
       audioWriter?.markAsFinished()
       assetWriter.finishWriting {
-        self.hasRunningWritingAttempt = false;
+        self.hasRunningWritingAttempt = false
         self.completionHandler(self, self.assetWriter.status, self.assetWriter.error)
       }
     } else {

--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -207,7 +207,7 @@ class RecordingSession {
       bufferAdaptor?.assetWriterInput.markAsFinished()
       audioWriter?.markAsFinished()
       assetWriter.finishWriting {
-        self.hasRunningWritingAttempt = false
+        self.isFinishing = false
         self.completionHandler(self, self.assetWriter.status, self.assetWriter.error)
       }
     } else {

--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -193,10 +193,12 @@ class RecordingSession {
    */
   func finish() {
     ReactLogger.log(level: .info, message: "Finishing Recording with AssetWriter status \"\(assetWriter.status.descriptor)\"...")
+    
     if isFinishing {
       ReactLogger.log(level: .warning, message: "Tried calling finish() twice while AssetWriter is still writing!")
       return
     }
+    
     if !hasWrittenFirstVideoFrame {
       let error = NSError(domain: "capture/aborted",
                           code: 1,

--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -205,6 +205,7 @@ class RecordingSession {
                           userInfo: [NSLocalizedDescriptionKey: "Stopped Recording Session too early, no frames have been recorded!"])
       completionHandler(self, .failed, error)
     } else if assetWriter.status == .writing {
+      hasRunningWritingAttempt = true
       bufferAdaptor?.assetWriterInput.markAsFinished()
       audioWriter?.markAsFinished()
       assetWriter.finishWriting {


### PR DESCRIPTION
This is a follow up for #995 and #930

My last PR did not fix the issue and I found the main cause. 

I realized this by watching the logs:

```
2022-04-15 12:13:02.933455+0200 app[840:267779] [native] VisionCamera.finish(): Finishing Recording with AssetWriter status "writing"...
2022-04-15 12:13:02.940310+0200 app[840:267779] [native] VisionCamera.finish(): Finishing Recording with AssetWriter status "writing"...
2022-04-15 12:13:02.942954+0200 app[840:267779] DevLauncher tries to handle uncaught exception: *** -[AVAssetWriter finishWritingWithCompletionHandler:] Cannot call method when status is 1
```
When you spam start/stop, you might end up calling `finish()` twice. I don't know exactly how it can happen, but it does happen. 

So the real solution would be to prevent calling finish twice in the first place, but this little boolean check is sufficient to prevent the crash. This time, I've tested it more intensively. 

After spamming start/stop to generate nearly 400 video fragments (you can do really cool effects with something like that), I ended up with that amount of entries

```
2022-04-15 12:45:34.766416+0200 app[990:282220] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:45:36.489299+0200 app[990:282130] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:45:40.158120+0200 app[990:282817] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:45:43.825698+0200 app[990:282528] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:45:52.602799+0200 app[990:283148] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:45:53.110238+0200 app[990:282130] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:45:57.600504+0200 app[990:282130] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:45:58.759749+0200 app[990:282528] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:47:17.176342+0200 app[990:282168] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
2022-04-15 12:47:40.303175+0200 app[990:283911] [native] VisionCamera.finish(): Detected two finish() calls on the same AVWriter single-use object, returning to prevent crash
```

So I effectively prevent the app from crashing. I know from beta testers, that this happened to them  without even trying too hard.