### PR TITLE
fix: fix takePhoto not working inside an Modal

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -16,12 +16,18 @@ import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import com.mrousavy.camera.CameraView
+import com.mrousavy.camera.ViewNotFoundError
+import java.lang.ref.WeakReference
+import java.util.concurrent.ExecutorService
 import com.mrousavy.camera.frameprocessor.FrameProcessorRuntimeManager
 import com.mrousavy.camera.parsers.*
 import com.mrousavy.camera.utils.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.guava.await
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 @ReactModule(name = CameraViewModule.TAG)
@@ -75,7 +81,14 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     return TAG
   }
 
-  private fun findCameraView(id: Int): CameraView = reactApplicationContext.currentActivity?.findViewById(id) ?: throw ViewNotFoundError(id)
+  private fun findCameraView(viewId: Int): CameraView {
+    Log.d(TAG, "Finding view $viewId...")
+    val mContext = WeakReference(reactApplicationContext)
+    val ctx = mContext?.get()
+    val view = if (ctx != null) UIManagerHelper.getUIManager(ctx, viewId)?.resolveView(viewId) as CameraView? else null
+    Log.d(TAG,  if (view != null) "Found view $viewId!" else "Couldn't find view $viewId!")
+    return view ?: throw ViewNotFoundError(viewId)
+  }
 
   @ReactMethod
   fun takePhoto(viewTag: Int, options: ReadableMap, promise: Promise) {

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -82,9 +82,8 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
 
   private fun findCameraView(viewId: Int): CameraView {
     Log.d(TAG, "Finding view $viewId...")
-    val ctx = reactApplicationContext
-    val view = if (ctx != null) UIManagerHelper.getUIManager(ctx, viewId)?.resolveView(viewId) as CameraView? else null
-    Log.d(TAG,  if (view != null) "Found view $viewId!" else "Couldn't find view $viewId!")
+    val view = if (reactApplicationContext != null) UIManagerHelper.getUIManager(reactApplicationContext, viewId)?.resolveView(viewId) as CameraView? else null
+    Log.d(TAG,  if (reactApplicationContext != null) "Found view $viewId!" else "Couldn't find view $viewId!")
     return view ?: throw ViewNotFoundError(viewId)
   }
 

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -21,7 +21,6 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.mrousavy.camera.CameraView
 import com.mrousavy.camera.ViewNotFoundError
-import java.lang.ref.WeakReference
 import java.util.concurrent.ExecutorService
 import com.mrousavy.camera.frameprocessor.FrameProcessorRuntimeManager
 import com.mrousavy.camera.parsers.*
@@ -83,8 +82,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
 
   private fun findCameraView(viewId: Int): CameraView {
     Log.d(TAG, "Finding view $viewId...")
-    val mContext = WeakReference(reactApplicationContext)
-    val ctx = mContext?.get()
+    val ctx = reactApplicationContext
     val view = if (ctx != null) UIManagerHelper.getUIManager(ctx, viewId)?.resolveView(viewId) as CameraView? else null
     Log.d(TAG,  if (view != null) "Found view $viewId!" else "Couldn't find view $viewId!")
     return view ?: throw ViewNotFoundError(viewId)


### PR DESCRIPTION
## What

When the camera view is inside of Modal they dont take photo, throws `[system/view-not-found]`.

## Changes

Changed way how Camera view is resolved.
We utilize the global React Native View registry to resolve the view instance.

## Tested on

Android 10 emulator
Android 10 device

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
