### PR TITLE
chore: add session prefix to audio-session-failed-to-activate error

### DIFF
--- a/src/CameraError.ts
+++ b/src/CameraError.ts
@@ -27,7 +27,7 @@ export type SessionError =
   | 'session/camera-not-ready'
   | 'session/audio-session-setup-failed'
   | 'session/audio-in-use-by-other-app'
-  | 'audio-session-failed-to-activate';
+  | 'session/audio-session-failed-to-activate';
 export type CaptureError =
   | 'capture/invalid-photo-format'
   | 'capture/encoder-error'


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

I'm not sure about whether I am missing anything here or if I'm simply confused. I got an error yesterday, that was:
```
 LOG  [session/audio-session-failed-to-activate: Failed to activate Audio Session!]
```

When I was browsing the code to look for other possible errors, I saw that while all other errors had a domain/group prefix, the `audio-session-failed-to-activate` was the only one that had not. Looks like the error itself is being logged by the native code though.

## Changes

This PR fixes the missing error domain for the `audio-session-failed-to-activate` error.

## Tested on

iPhone 13 Pro
