### PR TITLE
fix: Pause on iOS not working correctly

### DIFF
--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -92,7 +92,12 @@ public final class CameraView: UIView {
   internal var audioOutput: AVCaptureAudioDataOutput?
   // CameraView+RecordView (+ FrameProcessorDelegate.mm)
   internal var isRecording = false
+  internal var isPausing = false
   internal var recordingSession: RecordingSession?
+  internal var pauseTimestamp: CMTime = CMTime.zero
+  internal var latestTimestamp: CMTime = CMTime.zero
+  internal var currentDiff: CMTime = CMTime.zero
+  internal var totalDiff: CMTime = CMTime.zero
   @objc public var frameProcessorCallback: FrameProcessorCallback?
   internal var lastFrameProcessorCall = DispatchTime.now()
   // CameraView+TakePhoto


### PR DESCRIPTION
## What

This PR fixes a gap while video on pause

## Changes

This PR stores the difference between the last timestamp and the timestamp when the video was paused. Subsequently, the diff is taken to add new frames.

## Tested on
iPhone 11, iOS 15.4

## Related issues

#973 

## Additional

It works correctly in case of video, but I still have an issue with sound. Any help would be appreciated.