### PR TITLE
feat: Allow control of shutter sound on iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -324,7 +324,7 @@ PODS:
     - React
   - RNVectorIcons (8.1.0):
     - React-Core
-  - VisionCamera (2.13.0):
+  - VisionCamera (2.13.3):
     - React
     - React-callinvoker
     - React-Core
@@ -504,9 +504,9 @@ SPEC CHECKSUMS:
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
-  VisionCamera: 9959a41d3edc36b37e8361a2e6cbc05714f0689b
+  VisionCamera: 7bcf3a81533a1c9ad13930804377ad13a03fcded
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 
 PODFILE CHECKSUM: 29b1752e05601e9867644e58ce0ed8b9106be6cb
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.2

--- a/example/src/views/CaptureButton.tsx
+++ b/example/src/views/CaptureButton.tsx
@@ -65,6 +65,7 @@ const _CaptureButton: React.FC<Props> = ({
       flash: flash,
       quality: 90,
       skipMetadata: true,
+      disableShutterSound: true,
     }),
     [flash],
   );

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -53,6 +53,9 @@ extension CameraView {
         }
       }
 
+      // Create photo capture delegate
+      var photoCaptureDelegate = PhotoCaptureDelegate(promise: promise)
+
       // Create photo settings
       let photoSettings = AVCapturePhotoSettings(format: format)
 
@@ -98,12 +101,19 @@ extension CameraView {
         photoSettings.isAutoStillImageStabilizationEnabled = enableAutoStabilization
       }
 
+      // shutter sound
+      if let disableShutterSound = options["disableShutterSound"] as? Bool {
+        if disableShutterSound {
+          photoCaptureDelegate = SilentPhotoCaptureDelegate(promise: promise)
+        }
+      }
+
       // distortion correction
       if #available(iOS 14.1, *), let enableAutoDistortionCorrection = options["enableAutoDistortionCorrection"] as? Bool {
         photoSettings.isAutoContentAwareDistortionCorrectionEnabled = enableAutoDistortionCorrection
       }
 
-      photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise))
+      photoOutput.capturePhoto(with: photoSettings, delegate: photoCaptureDelegate)
 
       // Assume that `takePhoto` is always called with the same parameters, so prepare the next call too.
       photoOutput.setPreparedPhotoSettingsArray([photoSettings], completionHandler: nil)

--- a/ios/SilentPhotoCaptureDelegate.swift
+++ b/ios/SilentPhotoCaptureDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  SilentPhotoCaptureDelegate.swift
+//  mrousavy
+//
+//  Created by Marc Rousavy on 31.05.22.
+//  Copyright © 2020 mrousavy. All rights reserved.
+//
+
+import AVFoundation
+
+// MARK: - SilentPhotoCaptureDelegate
+
+class SilentPhotoCaptureDelegate: PhotoCaptureDelegate {
+
+  required init(promise: Promise) {
+    super.init(promise: promise)
+  }
+
+  func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+    // dispose system shutter sound
+    AudioServicesDisposeSystemSoundID(1108)
+  }
+}

--- a/src/PhotoFile.ts
+++ b/src/PhotoFile.ts
@@ -31,6 +31,12 @@ export interface TakePhotoOptions {
    */
   enableAutoStabilization?: boolean;
   /**
+   * Indicates whether the shutter sound should be muted when capturing the photo
+   *
+   * @default false
+   */
+  disableShutterSound?: boolean;
+  /**
    * Specifies whether the photo output should use content aware distortion correction on this photo request (at its discretion).
    *
    * @default false


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds functionality to control whether the shutter sound plays or not on iOS

## Changes

* Adds capture setting `disableShutterSound` to prevent shutter sound from playing on iOS
* Uses it on the example project

## Tested on

* iPhone 13 Pro, iOS 15.5

## Related issues
* Fixes #311