### PR TITLE
feat: Support RAW photo capture on iOS

### DIFF
--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -42,6 +42,7 @@ public final class CameraView: UIView {
   @objc var cameraId: NSString?
   @objc var enableDepthData = false
   @objc var enableHighQualityPhotos: NSNumber? // nullable bool
+  @objc var enableRawCapture: NSNumber? // nullable bool
   @objc var enablePortraitEffectsMatteDelivery = false
   @objc var preset: String?
   // use cases
@@ -97,6 +98,7 @@ public final class CameraView: UIView {
   internal var lastFrameProcessorCall = DispatchTime.now()
   // CameraView+TakePhoto
   internal var photoCaptureDelegates: [PhotoCaptureDelegate] = []
+  internal var captureDelegates = [Int64: RAWCaptureDelegate]()
   // CameraView+Zoom
   internal var pinchGestureRecognizer: UIPinchGestureRecognizer?
   internal var pinchScaleOffset: CGFloat = 1.0

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -26,6 +26,7 @@ RCT_EXPORT_VIEW_PROPERTY(isActive, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(cameraId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enableDepthData, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(enableHighQualityPhotos, NSNumber); // nullable bool
+RCT_EXPORT_VIEW_PROPERTY(enableRawCapture, NSNumber); // nullable bool
 RCT_EXPORT_VIEW_PROPERTY(enablePortraitEffectsMatteDelivery, BOOL);
 // use cases
 RCT_EXPORT_VIEW_PROPERTY(photo, NSNumber); // nullable bool

--- a/ios/RAWCaptureDelegate.swift
+++ b/ios/RAWCaptureDelegate.swift
@@ -1,0 +1,107 @@
+import AVFoundation
+import Photos.PHPhotoLibrary
+
+private var delegatesReferences: [NSObject] = []
+
+// MARK: - RAWCaptureDelegate
+
+class RAWCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
+  private let promise: Promise
+  private var rawFileURL: URL?
+  private var compressedData: Data?
+
+  var didFinish: (() -> Void)?
+
+  required init(promise: Promise) {
+    self.promise = promise
+    super.init()
+    delegatesReferences.append(self)
+  }
+
+  // Store the RAW file and compressed photo data until the capture finishes.
+  func photoOutput(_: AVCapturePhotoOutput,
+                   didFinishProcessingPhoto photo: AVCapturePhoto,
+                   error: Error?) {
+    guard error == nil else {
+      print("Error capturing photo: \(error!)")
+      return
+    }
+
+    // Access the file data representation of this photo.
+    guard let photoData = photo.fileDataRepresentation() else {
+      print("No photo data to write.")
+      return
+    }
+
+    if photo.isRawPhoto {
+      // Generate a unique URL to write the RAW file.
+      rawFileURL = makeUniqueDNGFileURL()
+      do {
+        // Write the RAW (DNG) file data to a URL.
+        try photoData.write(to: rawFileURL!)
+
+        let exif = photo.metadata["{Exif}"] as? [String: Any]
+        let width = exif?["PixelXDimension"]
+        let height = exif?["PixelYDimension"]
+        promise.resolve([
+          "path": String(describing: rawFileURL).components(separatedBy: "Optional(file://")[1].components(separatedBy: ")")[0],
+          "width": width as Any,
+          "height": height as Any,
+          "isRawPhoto": photo.isRawPhoto,
+          "metadata": photo.metadata,
+          "thumbnail": photo.embeddedThumbnailPhotoFormat as Any,
+        ])
+      } catch {
+        fatalError("Couldn't write DNG file to the URL.")
+      }
+    } else {
+      // Store compressed bitmap data.
+      compressedData = photoData
+    }
+  }
+
+  private func makeUniqueDNGFileURL() -> URL {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileName = ProcessInfo.processInfo.globallyUniqueString
+    return tempDir.appendingPathComponent(fileName).appendingPathExtension("dng")
+  }
+
+  func photoOutput(_: AVCapturePhotoOutput,
+                   didFinishCaptureFor _: AVCaptureResolvedPhotoSettings,
+                   error: Error?) {
+    // Call the "finished" closure, if set.
+    defer { didFinish?() }
+
+    guard error == nil else {
+      print("Error capturing photo: \(error!)")
+      return
+    }
+
+    // Ensure the RAW and processed photo data exists.
+    guard let rawFileURL = rawFileURL else {
+      print("The expected photo data isn't available.")
+      return
+    }
+
+    // Request add-only access to the user's Photos library (if not already granted).
+    if #available(iOS 14, *) {
+      PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
+        // Don't continue if not authorized.
+        guard status == .authorized else { return }
+
+        PHPhotoLibrary.shared().performChanges {
+          // Save the RAW (DNG) file as the main resource for the Photos asset.
+          let creationRequest = PHAssetCreationRequest.forAsset()
+          let options = PHAssetResourceCreationOptions()
+          options.shouldMoveFile = true
+          creationRequest.addResource(with: .photo,
+                                      fileURL: rawFileURL,
+                                      options: options)
+        } completionHandler: { _, _ in
+          // Process the Photos library error.
+          print("Error while saving the RAW (DNG) file.")
+        }
+      }
+    }
+  }
+}

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -157,6 +157,11 @@ export interface CameraProps extends ViewProps {
    */
   enableHighQualityPhotos?: boolean;
   /**
+   * Enable the Camera to take photos with RAW format.
+   * @platform iOS 10+
+   */
+  enableRawCapture?: boolean;
+  /**
    * Represents the orientation of all Camera Outputs (Photo, Video, and Frame Processor). If this value is not set, the device orientation is used.
    */
   orientation?: 'portrait' | 'portraitUpsideDown' | 'landscapeLeft' | 'landscapeRight';


### PR DESCRIPTION
## What

This PR adds support for capturing photos with RAW format on iOS.

## Changes

* (iOS) Adds `enableRawCapture` boolean prop available in iOS.
* (iOS) Finds a `rawFormat` for the `AVCapturePhotoSettings`
* (iOS) Adds a delegate file called `RAWCaptureDelegate` which is responsible for:
Making a unique DNG file URL.
Saving the photo in the phone gallery. I wanted to save the photo to the phone with the `CameraRoll.save()` function in the react native example, but the **CameraRoll library** doesn’t support saving `dng` files to the phone. Currently, there is a PR for saving `dng` files to the CameraRoll library: https://github.com/react-native-cameraroll/react-native-cameraroll/pull/223/files
Return the photo data: `path`, `width`, `height`, `isRawPhoto`, `metadata`, `thumbnail`
* (iOS) Adds a raw embedded thumbnail photo format to the `photoSettings`

## Tested on

* iPhone 13 pro max, iOS 15.4.1

## Related issues
* Fixes #73
