### PR TITLE
Accessing outputOrientation needs to be done in main thread

### DIFF
--- a/ios/CameraView+Orientation.swift
+++ b/ios/CameraView+Orientation.swift
@@ -52,7 +52,10 @@ extension CameraView {
               connection.automaticallyAdjustsVideoMirroring = false
               connection.isVideoMirrored = isMirrored
             }
-            connection.setInterfaceOrientation(self.outputOrientation)
+            // Need to jump back to main thread to update the orientation
+            DispatchQueue.main.async {
+              connection.setInterfaceOrientation(self.outputOrientation)
+            }
           }
         }
       }

--- a/ios/CameraView+Orientation.swift
+++ b/ios/CameraView+Orientation.swift
@@ -44,19 +44,13 @@ extension CameraView {
 
       self.videoPreviewLayer.connection?.setInterfaceOrientation(self.inputOrientation)
 
-      self.cameraQueue.async {
-        // Run those updates on cameraQueue since they can be blocking.
-        self.captureSession.outputs.forEach { output in
-          output.connections.forEach { connection in
-            if connection.isVideoMirroringSupported {
-              connection.automaticallyAdjustsVideoMirroring = false
-              connection.isVideoMirrored = isMirrored
-            }
-            // Need to jump back to main thread to update the orientation
-            DispatchQueue.main.async {
-              connection.setInterfaceOrientation(self.outputOrientation)
-            }
+      self.captureSession.outputs.forEach { output in
+        output.connections.forEach { connection in
+          if connection.isVideoMirroringSupported {
+            connection.automaticallyAdjustsVideoMirroring = false
+            connection.isVideoMirrored = isMirrored
           }
+          connection.setInterfaceOrientation(self.outputOrientation)
         }
       }
     }


### PR DESCRIPTION
## What

This PR fixes UI being accessed from non main thread on iOS. 

## Changes

When self.outputOrientation is accessed it jumps to main queue for it. 

## Tested on

iPhone 8, iOS 14.4.1

## Related issues

* Relates to #887 