### PR TITLE
Fix: Use of undeclared identifier 'jsi'

### DIFF
--- a/ios/React Utils/JSConsoleHelper.mm
+++ b/ios/React Utils/JSConsoleHelper.mm
@@ -37,18 +37,18 @@
     return nil;
   }
   
-  jsi::Runtime* jsiRuntime = (jsi::Runtime*)cxxBridge.runtime;
+  facebook::jsi::Runtime* jsiRuntime = (facebook::jsi::Runtime*)cxxBridge.runtime;
   
   return ^(RCTLogLevel level, NSString* message) {
     [bridge runOnJS:^{
       if (jsiRuntime != nullptr) {
-        jsi::Runtime& runtime = *jsiRuntime;
+        facebook::jsi::Runtime& runtime = *jsiRuntime;
         auto logFunctionName = [JSConsoleHelper getLogFunctionNameForLogLevel:level];
         try {
           auto console = runtime.global().getPropertyAsObject(runtime, "console");
           auto log = console.getPropertyAsFunction(runtime, logFunctionName);
-          log.call(runtime, jsi::String::createFromAscii(runtime, [message UTF8String]));
-        } catch (jsi::JSError& jsError) {
+          log.call(runtime, facebook::jsi::String::createFromAscii(runtime, [message UTF8String]));
+        } catch (facebook::jsi::JSError& jsError) {
           NSLog(@"%@", message);
           NSLog(@"Failed to call `console.%s`: %s", logFunctionName, jsError.getMessage().c_str());
         }


### PR DESCRIPTION
## What

This pull request fixes the error on React-Native 0.68.x and 0.69.x:
`"Use of undeclared identifier 'jsi'; did you mean 'facebook::jsi'"`

## Changes

This PR changes references of `jsi` to `facebook::jsi'` on file JSConsoleHelper.mm

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

Fixes #1104 
