### PR TITLE
fix: Set initial timestamp on first frame

### DIFF
--- a/ios/RecordingSession.swift
+++ b/ios/RecordingSession.swift
@@ -155,6 +155,7 @@ class RecordingSession {
       }
       // Start the writing session before we write the first video frame
       if !hasStartedWritingSession {
+        initialTimestamp = timestamp
         assetWriter.startSession(atSourceTime: timestamp)
         ReactLogger.log(level: .info, message: "Started RecordingSession at \(timestamp.seconds) seconds.")
         hasStartedWritingSession = true


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Sets the `initialTimestamp` when the first frame gets received in the recording session. This fixes the issue referenced in https://github.com/mrousavy/react-native-vision-camera/issues/1112 with the duration on iOS being reported incorrectly as zero.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

iPhone 13 Pro

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

https://github.com/mrousavy/react-native-vision-camera/issues/1112

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
