### PR TITLE
fix: android build for react native 0.69

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -105,12 +105,22 @@ find_library(
         PATHS ${LIBRN_DIR}
         NO_CMAKE_FIND_ROOT_PATH
 )
-find_library(
-        FOLLY_JSON_LIB
-        folly_json
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
+
+if(${REACT_NATIVE_VERSION} LESS 69)
+    find_library(
+            FOLLY_JSON_LIB
+            folly_json
+            PATHS ${LIBRN_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+else()
+    find_library(
+            FOLLY_JSON_LIB
+            folly_runtime
+            PATHS ${LIBRN_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+endif()
 
 find_library(
         REACT_NATIVE_JNI_LIB

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -235,6 +235,9 @@ dependencies {
       }
     })
     def rnAarMatcher = "**/react-native/**/*${buildType}.aar"
+    if (REACT_NATIVE_VERSION < 69) {
+      rnAarMatcher = "**/**/*.aar"
+    }
     def rnAAR = fileTree("$reactNative/android").matching({ it.include rnAarMatcher }).singleFile
     def jscAAR = fileTree("${nodeModules}/jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -228,7 +228,14 @@ dependencies {
     //noinspection GradleDynamicVersion
     extractJNI("com.facebook.fbjni:fbjni:+")
 
-    def rnAAR = fileTree("${nodeModules}/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
+    def buildType = "debug"
+    tasks.all({ task ->
+      if (task.name == "buildCMakeRelease") {
+        buildType = "release"
+      }
+    })
+    def rnAarMatcher = "**/react-native/**/*${buildType}.aar"
+    def rnAAR = fileTree("$reactNative/android").matching({ it.include rnAarMatcher }).singleFile
     def jscAAR = fileTree("${nodeModules}/jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile
 
     def inputFile = file("${nodeModules}/react-native/package.json")
@@ -285,7 +292,9 @@ if (ENABLE_FRAME_PROCESSORS) {
   }
 
   task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
-    src("https://github.com/react-native-community/boost-for-react-native/releases/download/v${BOOST_VERSION.replace("_", ".")}-0/boost_${BOOST_VERSION}.tar.gz")
+    def transformedVersion = BOOST_VERSION.replace("_", ".")
+    def srcUrl = "https://boostorg.jfrog.io/artifactory/main/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz"
+    src(srcUrl)
     onlyIfNewer(true)
     overwrite(false)
     dest(boost_file)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -297,6 +297,9 @@ if (ENABLE_FRAME_PROCESSORS) {
   task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     def transformedVersion = BOOST_VERSION.replace("_", ".")
     def srcUrl = "https://boostorg.jfrog.io/artifactory/main/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz"
+    if (REACT_NATIVE_VERSION < 69) {
+      srcUrl = "https://github.com/react-native-community/boost-for-react-native/releases/download/v${transformedVersion}-0/boost_${BOOST_VERSION}.tar.gz"
+    }
     src(srcUrl)
     onlyIfNewer(true)
     overwrite(false)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -324,7 +324,7 @@ PODS:
     - React
   - RNVectorIcons (8.1.0):
     - React-Core
-  - VisionCamera (2.13.3):
+  - VisionCamera (2.13.5):
     - React
     - React-callinvoker
     - React-Core
@@ -504,7 +504,7 @@ SPEC CHECKSUMS:
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
-  VisionCamera: 7bcf3a81533a1c9ad13930804377ad13a03fcded
+  VisionCamera: 00bb5862bad9ff69997ed70ddc0861c9b88677b0
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 
 PODFILE CHECKSUM: 29b1752e05601e9867644e58ce0ed8b9106be6cb


### PR DESCRIPTION
## What

This PR fixes build issues on Android for React Native 0.69

## Changes

    * build.gradle adjustments for react-native 0.69
    * CMake adjustments for react-native 0.69


## Tested on

Pixel 3, Android 12, react-native 0.69 with hermes on

