### PR TITLE
docs: add vision-camera-plugin-builder sections in Creating Frame Processor Plugins

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
@@ -14,6 +14,34 @@ In this guide we will create a custom QR Code Scanner Plugin which can be used f
 
 Android Frame Processor Plugins can be written in either **Java**, **Kotlin** or **C++ (JNI)**.
 
+### Mostly automatic setup
+
+1. Run [Vision Camera Plugin Builder CLI](https://github.com/mateusz1913/vision-camera-plugin-builder)
+
+```sh
+npx vision-camera-plugin-builder android
+```
+
+:::info
+The CLI will ask you for the path to project's Android Manifest file, name of the plugin (e.g. `QRCodeFrameProcessor`), name of the exposed method (e.g. `scanQRCodes`) and language you want to use for plugin development (Java or Kotlin).
+For reference see the [CLI's docs](https://github.com/mateusz1913/vision-camera-plugin-builder#%EF%B8%8F-options).
+:::
+
+2. Register the package in MainApplication.java
+
+```java {6}
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          ...
+          packages.add(new QRCodeFrameProcessorPluginPackage()); // <- add
+          return packages;
+        }
+```
+
+### Manual setup
+
 <Tabs
   defaultValue="java"
   values={[

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
@@ -14,6 +14,20 @@ In this guide we will create a custom QR Code Scanner Plugin which can be used f
 
 iOS Frame Processor Plugins can be written in either **Objective-C** or **Swift**.
 
+### Automatic setup
+
+Run [Vision Camera Plugin Builder CLI](https://github.com/mateusz1913/vision-camera-plugin-builder), 
+
+```sh
+npx vision-camera-plugin-builder ios
+```
+
+:::info
+The CLI will ask you for the path to project's .xcodeproj file, name of the plugin (e.g. `QRCodeFrameProcessor`), name of the exposed method (e.g. `scanQRCodes`) and language you want to use for plugin development (Objective-C, Objective-C++ or Swift).
+For reference see the [CLI's docs](https://github.com/mateusz1913/vision-camera-plugin-builder#%EF%B8%8F-options).
+:::
+
+### Manual setup
 
 <Tabs
   defaultValue="objc"


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

👋 I recently made [a small CLI](https://github.com/mateusz1913/vision-camera-plugin-builder) in order to make creation of frame processor plugins quicker. I thought it would be great to add this to docs. Let me know wdyt

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

This PR adds automatic setup section to "Creating Frame Processor Plugins (iOS|Android)" with
vision-camera-plugin-builder CLI

| iOS | Android |
| --- | -------- |
| <img width="992" alt="Screen Shot 2022-07-06 at 20 10 39" src="https://user-images.githubusercontent.com/25980166/177615563-7c5956df-a135-43df-9cf5-84c04300a045.png"> | <img width="996" alt="Screen Shot 2022-07-06 at 20 11 41" src="https://user-images.githubusercontent.com/25980166/177615758-dfe0a78c-e4ec-404d-9d0e-52c6bbb01be1.png"> |

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

Run yarn --cwd docs start

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
