### PR TITLE
fix: Build error "2 files found with path '.../libfolly_runtime.so'"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -119,7 +119,7 @@ android {
 
   packagingOptions {
     // Exclude all Libraries that are already present in the user's app (through React Native or by him installing REA)
-    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so", "**/libreactnativejni.so", "**/libfolly_json.so", "**/libreanimated.so", "**/libjscexecutor.so", "**/libhermes.so"]
+    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libjsi.so", "**/libreactnativejni.so", "**/libfolly_json.so", "**/libreanimated.so", "**/libjscexecutor.so", "**/libhermes.so", "**/libfolly_runtime.so"]
     // META-INF is duplicate by CameraX.
     exclude "META-INF/**"
   }


### PR DESCRIPTION
## What
This PR fixes an build error after upgrading to react-native 0.69.1 after the fix in the issue #1118

## Changes
* Adds libfolly_runtime.so library to exclusion list in build.gradle

## Tested on
* Samsung S20 FE, Android 12

## Related issues
* Fixes #1125
