### PR TITLE
feat: Allow returning of ImageProxy in a Frame Processor

### DIFF
--- a/android/src/main/cpp/JSIJNIConversion.cpp
+++ b/android/src/main/cpp/JSIJNIConversion.cpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <utility>
+#include <memory>
 
 #include <react/jni/NativeMap.h>
 #include <react/jni/ReadableNativeMap.h>
@@ -187,7 +188,6 @@ jsi::Value JSIJNIConversion::convertJNIObjectToJSIValue(jsi::Runtime &runtime, c
     // box into HostObject
     auto hostObject = std::make_shared<FrameHostObject>(frame);
     return jsi::Object::createFromHostObject(runtime, hostObject);
-
   }
 
   auto type = object->getClass()->toString();

--- a/android/src/main/cpp/JSIJNIConversion.cpp
+++ b/android/src/main/cpp/JSIJNIConversion.cpp
@@ -179,6 +179,15 @@ jsi::Value JSIJNIConversion::convertJNIObjectToJSIValue(jsi::Runtime &runtime, c
     auto hashMap = toHashMapFunc(object.get());
     return convertJNIObjectToJSIValue(runtime, hashMap);
 
+  } else if (object->isInstanceOf(JImageProxy::javaClassStatic())) {
+    // ImageProxy
+
+    auto frame = static_ref_cast<JImageProxy>(object);
+
+    // box into HostObject
+    auto hostObject = std::make_shared<FrameHostObject>(frame);
+    return jsi::Object::createFromHostObject(runtime, hostObject);
+
   }
 
   auto type = object->getClass()->toString();

--- a/example/src/PermissionsPage.tsx
+++ b/example/src/PermissionsPage.tsx
@@ -44,7 +44,7 @@ export function PermissionsPage({ navigation }: Props): React.ReactElement {
       <View style={styles.permissionsContainer}>
         {cameraPermissionStatus !== 'authorized' && (
           <Text style={styles.permissionText}>
-            Vision Camera needs <Text style={styles.bold}>Camera permission</Text>.
+            Vision Camera needs <Text style={styles.bold}>Camera permission</Text>.{' '}
             <Text style={styles.hyperlink} onPress={requestCameraPermission}>
               Grant
             </Text>
@@ -52,7 +52,7 @@ export function PermissionsPage({ navigation }: Props): React.ReactElement {
         )}
         {microphonePermissionStatus !== 'authorized' && (
           <Text style={styles.permissionText}>
-            Vision Camera needs <Text style={styles.bold}>Microphone permission</Text>.
+            Vision Camera needs <Text style={styles.bold}>Microphone permission</Text>.{' '}
             <Text style={styles.hyperlink} onPress={requestMicrophonePermission}>
               Grant
             </Text>

--- a/src/hooks/useFrameProcessor.ts
+++ b/src/hooks/useFrameProcessor.ts
@@ -47,7 +47,6 @@ export function useFrameProcessor(frameProcessor: FrameProcessor, dependencies: 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         info: capturableConsole.info.__callAsync,
       };
-      // @ts-expect-error _setGlobalConsole is set by RuntimeDecorator::decorateRuntime
       _setGlobalConsole(console);
       // @ts-expect-error
       global.didSetConsole = true;

--- a/src/hooks/useFrameProcessor.ts
+++ b/src/hooks/useFrameProcessor.ts
@@ -47,6 +47,7 @@ export function useFrameProcessor(frameProcessor: FrameProcessor, dependencies: 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         info: capturableConsole.info.__callAsync,
       };
+      // @ts-expect-error _setGlobalConsole is set by RuntimeDecorator::decorateRuntime
       _setGlobalConsole(console);
       // @ts-expect-error
       global.didSetConsole = true;


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Implements missing feature discussed in https://github.com/mrousavy/react-native-vision-camera/discussions/904

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
