### PR TITLE
Update ERRORS.mdx

### DIFF
--- a/docs/docs/guides/ERRORS.mdx
+++ b/docs/docs/guides/ERRORS.mdx
@@ -17,7 +17,7 @@ Since the Camera library is quite big, there is a lot that can "go wrong". The V
 ```ts
 switch (error.code) {
   case "device/configuration-error":
-    // promt user
+    // prompt user
     break
   case "device/microphone-unavailable":
     // ask for permission


### PR DESCRIPTION
fix typo "promt" to "prompt"

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

 Removed a typo

## Changes

  changed typo "promt" to "prompt"

## Tested on

 

## Related issues

  
