### PR TITLE
fix: android photoFile height and width

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -97,8 +97,8 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
 
   val map = Arguments.createMap()
   map.putString("path", file.absolutePath)
-  map.putInt("width", photo.width)
-  map.putInt("height", photo.height)
+  map.putInt("width", exif?.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, photo.width) ?: photo.width)
+  map.putInt("height", exif?.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, photo.height) ?: photo.height)
   map.putBoolean("isRawPhoto", photo.isRaw)
 
   val metadata = exif?.buildMetadataMap()


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

When taking pictures with front camera on android, width and height are swapped. Using the value from the exif data fixes it.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on
Oneplus Nord + emulator
