### PR TITLE
fix: CameraDevices type can't be imported

### DIFF
--- a/src/hooks/useCameraDevices.ts
+++ b/src/hooks/useCameraDevices.ts
@@ -4,7 +4,7 @@ import { sortDevices } from '../utils/FormatFilter';
 import { Camera } from '../Camera';
 import { CameraDevice, LogicalCameraDeviceType, parsePhysicalDeviceTypes, PhysicalCameraDeviceType } from '../CameraDevice';
 
-type CameraDevices = {
+export type CameraDevices = {
   [key in CameraPosition]: CameraDevice | undefined;
 };
 const DefaultCameraDevices: CameraDevices = {


### PR DESCRIPTION
## What

This PR provides CameraDevices able to be used as type.

ex: ` const devices: CameraDevices = useCameraDevices();`

## Changes

Just added an `export` keyword to the related line.

## Tested on

Pixel 5 XL, Android 10