### PR TITLE
chore(deps): Upgrade CameraX to latest beta

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -287,15 +287,15 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.2"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"
 
-  implementation "androidx.camera:camera-core:1.1.0-beta02"
-  implementation "androidx.camera:camera-camera2:1.1.0-beta02"
-  implementation "androidx.camera:camera-lifecycle:1.1.0-beta02"
-  implementation "androidx.camera:camera-video:1.1.0-beta02"
+  implementation "androidx.camera:camera-core:1.2.0-beta02"
+  implementation "androidx.camera:camera-camera2:1.2.0-beta02"
+  implementation "androidx.camera:camera-lifecycle:1.2.0-beta02"
+  implementation "androidx.camera:camera-video:1.2.0-beta02"
 
-  implementation "androidx.camera:camera-view:1.1.0-beta02"
-  implementation "androidx.camera:camera-extensions:1.1.0-beta02"
+  implementation "androidx.camera:camera-view:1.2.0-beta02"
+  implementation "androidx.camera:camera-extensions:1.2.0-beta02"
 
-  implementation "androidx.exifinterface:exifinterface:1.3.3"
+  implementation "androidx.exifinterface:exifinterface:1.3.4"
 }
 
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,7 +13,7 @@
 #Fri Feb 19 20:46:14 CET 2021
 VisionCamera_buildToolsVersion=30.0.0
 VisionCamera_compileSdkVersion=31
-VisionCamera_kotlinVersion=1.5.30
+VisionCamera_kotlinVersion=1.6.10
 VisionCamera_targetSdkVersion=31
 VisionCamera_ndkVersion=21.4.7075529
 android.enableJetifier=true


### PR DESCRIPTION
fixes some crashes

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
