### PR TITLE
feat: Continue to record audio when receiving a phone call (try to prevent interruptions)

### DIFF
--- a/ios/CameraView+AVAudioSession.swift
+++ b/ios/CameraView+AVAudioSession.swift
@@ -92,6 +92,12 @@ extension CameraView {
                                                                    .allowBluetoothA2DP,
                                                                    .defaultToSpeaker,
                                                                    .allowAirPlay])
+
+      if #available(iOS 14.5, *) {
+        // prevents the audio session from being interrupted by a phone call
+        AVAudioSession.sharedInstance().setPrefersNoInterruptionsFromSystemAlerts(true)
+      }
+
       audioCaptureSession.startRunning()
     } catch let error as NSError {
       switch error.code {

--- a/ios/CameraView+AVAudioSession.swift
+++ b/ios/CameraView+AVAudioSession.swift
@@ -95,7 +95,7 @@ extension CameraView {
 
       if #available(iOS 14.5, *) {
         // prevents the audio session from being interrupted by a phone call
-        AVAudioSession.sharedInstance().setPrefersNoInterruptionsFromSystemAlerts(true)
+        try AVAudioSession.sharedInstance().setPrefersNoInterruptionsFromSystemAlerts(true)
       }
 
       audioCaptureSession.startRunning()


### PR DESCRIPTION
## What

Uses `setPrefersNoInterruptionsFromSystemAlerts` to prevent system alerts (like phone calls) from interrupting the audio session which records audio from the microphone.

## Related Issues

* Resolves https://github.com/mrousavy/react-native-vision-camera/pull/113#issuecomment-1270231969