### PR TITLE
fix: Android build 

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -69,6 +69,14 @@ target_include_directories(
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/LayoutAnimations"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/hidden_headers"
         "src/main/cpp"
+        # TODO: remove this once we have a better solution for the reanimated headers
+        # --- Reanimated ^2.11.0 quickfix ---
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/AnimatedSensor"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/Tools"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/SpecTools"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/SharedItems"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/Registries"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/LayoutAnimations"
 )
 
 # find libraries


### PR DESCRIPTION
## What

This PR fixes `Execution failed for task ':react-native-vision-camera:buildCMakeDebug[arm64-v8a]'` error while building the project for Android platform.

## Changes

Adds additional headers paths for `react-native-reanimated` starting from version 2.11.0.
Old version's header paths are left included, so backward compatibility is preserved.

## Tested on

* Nokia 8.3 5G
* Simulator SDK 31

## Related issues

Fixes [#1283]
