### PR TITLE
fix: Support new Reanimated Headers directory (2.11.10+)

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -61,12 +61,20 @@ target_include_directories(
         ${INCLUDE_JSI_CPP} # only on older RN versions
         ${INCLUDE_JSIDYNAMIC_CPP} # only on older RN versions
         # --- Reanimated ---
+        # Old
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/AnimatedSensor"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/Tools"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/SpecTools"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/SharedItems"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/Registries"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/headers/LayoutAnimations"
+        # New
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/AnimatedSensor"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/Tools"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/SpecTools"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/SharedItems"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/Registries"
+        "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/LayoutAnimations"
         "${NODE_MODULES_DIR}/react-native-reanimated/Common/cpp/hidden_headers"
         "src/main/cpp"
 )


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
