### PR TITLE
Update CLANG_CXX_LANGUAGE_STANDARD to C++17

### DIFF
--- a/VisionCamera.podspec
+++ b/VisionCamera.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   }
   s.compiler_flags = folly_compiler_flags + ' ' + boost_compiler_flags
   s.xcconfig = {
-    "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
     "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\"",
     "OTHER_CFLAGS" => "$(inherited)" + " " + folly_flags
   }


### PR DESCRIPTION
## What

Bumped CLANG_CXX_LANGUAGE_STANDARD to C++17 to fix #1287.

## Changes

Nothing is changed except version is bumped to C++17.

## Tested on

iPhone 12 Pro Max
iPhone Simulators

## Related issues

Fixes #1287
