### PR TITLE
fix: decrease rank of dual-wide-camera cameras in sortDevices function

### DIFF
--- a/src/utils/FormatFilter.ts
+++ b/src/utils/FormatFilter.ts
@@ -30,6 +30,15 @@ export const sortDevices = (left: CameraDevice, right: CameraDevice): number => 
   if (leftHasTelephoto) leftPoints -= 2;
   if (rightHasTelephoto) rightPoints -= 2;
 
+  const leftHasUltraWide = left.devices.includes('ultra-wide-angle-camera') && left.devices.length == 2;
+  const rightHasUltraWide = right.devices.includes('ultra-wide-angle-camera') && right.devices.length == 2;
+  if (leftHasUltraWide) {
+    leftPoints -= 2;
+  }
+  if (rightHasUltraWide) {
+    rightPoints -= 2;
+  }
+
   if (left.devices.length > right.devices.length) leftPoints += 1;
   if (right.devices.length > left.devices.length) rightPoints += 1;
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

Fixes #1390 
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
