### PR TITLE
fix: android build fail on rn < 0.71

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -290,7 +290,7 @@ dependencies {
 
     if (REACT_NATIVE_VERSION < 71) {
       //noinspection GradleDynamicVersion
-      extractHeaders("com.facebook.fbjni:fbjni:headers:+")
+      extractHeaders("com.facebook.fbjni:fbjni:+:headers")
       //noinspection GradleDynamicVersion
       extractJNI("com.facebook.fbjni:fbjni:+")
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
Fix android build error when using react-native-vision-camera with RN < 0.71
`Could not resolve all files for configuration ':react-native-vision-camera:extractHeaders'.`
`Could not find com.facebook.fbjni:fbjni:headers.`

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes
Fixed a (possible) typo in build.gradle

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on
1. OnePlus 5T, Android 9, RN0.69 with code scanner plugin

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
https://github.com/mrousavy/react-native-vision-camera/issues/1443
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
