### PR TITLE
feat: Add `toByteArray()`, `orientation`, `isMirrored` and `timestamp` to `Frame`

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 add_library(
         ${PACKAGE_NAME}
         SHARED
+        ../cpp/JSITypedArray.cpp
         src/main/cpp/VisionCamera.cpp
         src/main/cpp/JSIJNIConversion.cpp
         src/main/cpp/FrameHostObject.cpp
@@ -41,6 +42,7 @@ add_library(
 target_include_directories(
         ${PACKAGE_NAME}
         PRIVATE
+        "../cpp"
         "src/main/cpp"
         "${NODE_MODULES_DIR}/react-native/ReactCommon"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/callinvoker"

--- a/android/src/main/cpp/FrameHostObject.cpp
+++ b/android/src/main/cpp/FrameHostObject.cpp
@@ -33,6 +33,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("planesCount")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("orientation")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("isMirrored")));
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("timestamp")));
   // Conversion
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toString")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toArrayBuffer")));
@@ -129,6 +130,9 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "orientation") {
     auto string = this->frame->getOrientation();
     return jsi::String::createFromUtf8(runtime, string->toStdString());
+  }
+  if (name == "timestamp") {
+    return jsi::Value(static_cast<double>(this->frame->getTimestamp()));
   }
   if (name == "bytesPerRow") {
     return jsi::Value(this->frame->getBytesPerRow());

--- a/android/src/main/cpp/FrameHostObject.cpp
+++ b/android/src/main/cpp/FrameHostObject.cpp
@@ -31,6 +31,8 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("height")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("bytesPerRow")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("planesCount")));
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("orientation")));
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("isMirrored")));
   // Conversion
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toString")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toArrayBuffer")));
@@ -120,6 +122,13 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   }
   if (name == "height") {
     return jsi::Value(this->frame->getHeight());
+  }
+  if (name == "isMirrored") {
+    return jsi::Value(this->frame->getIsMirrored());
+  }
+  if (name == "orientation") {
+    auto string = this->frame->getOrientation();
+    return jsi::String::createFromUtf8(runtime, string->toStdString());
   }
   if (name == "bytesPerRow") {
     return jsi::Value(this->frame->getBytesPerRow());

--- a/android/src/main/cpp/java-bindings/JImageProxy.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxy.cpp
@@ -33,6 +33,18 @@ bool JImageProxy::getIsValid() const {
   return isImageProxyValidMethod(utilsClass, self());
 }
 
+bool JImageProxy::getIsMirrored() const {
+  auto utilsClass = getUtilsClass();
+  static const auto isImageProxyMirroredMethod = utilsClass->getStaticMethod<jboolean(JImageProxy::javaobject)>("isImageProxyMirrored");
+  return isImageProxyMirroredMethod(utilsClass, self());
+}
+
+local_ref<JString> JImageProxy::getOrientation() const {
+  auto utilsClass = getUtilsClass();
+  static const auto getOrientationMethod = utilsClass->getStaticMethod<JString(JImageProxy::javaobject)>("getOrientation");
+  return getOrientationMethod(utilsClass, self());
+}
+
 int JImageProxy::getPlanesCount() const {
   auto utilsClass = getUtilsClass();
   static const auto getPlanesCountMethod = utilsClass->getStaticMethod<jint(JImageProxy::javaobject)>("getPlanesCount");

--- a/android/src/main/cpp/java-bindings/JImageProxy.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxy.cpp
@@ -45,6 +45,13 @@ int JImageProxy::getBytesPerRow() const {
   return getBytesPerRowMethod(utilsClass, self());
 }
 
+local_ref<JArrayByte> JImageProxy::toByteArray() const {
+  auto utilsClass = getUtilsClass();
+
+  static const auto toByteArrayMethod = utilsClass->getStaticMethod<JArrayByte(JImageProxy::javaobject)>("toByteArray");
+  return toByteArrayMethod(utilsClass, self());
+}
+
 void JImageProxy::close() {
   static const auto closeMethod = getClass()->getMethod<void()>("close");
   closeMethod(self());

--- a/android/src/main/cpp/java-bindings/JImageProxy.cpp
+++ b/android/src/main/cpp/java-bindings/JImageProxy.cpp
@@ -39,6 +39,12 @@ bool JImageProxy::getIsMirrored() const {
   return isImageProxyMirroredMethod(utilsClass, self());
 }
 
+jlong JImageProxy::getTimestamp() const {
+    auto utilsClass = getUtilsClass();
+    static const auto getTimestampMethod = utilsClass->getStaticMethod<jlong(JImageProxy::javaobject)>("getTimestamp");
+    return getTimestampMethod(utilsClass, self());
+}
+
 local_ref<JString> JImageProxy::getOrientation() const {
   auto utilsClass = getUtilsClass();
   static const auto getOrientationMethod = utilsClass->getStaticMethod<JString(JImageProxy::javaobject)>("getOrientation");

--- a/android/src/main/cpp/java-bindings/JImageProxy.h
+++ b/android/src/main/cpp/java-bindings/JImageProxy.h
@@ -21,6 +21,7 @@ struct JImageProxy : public JavaClass<JImageProxy> {
   bool getIsValid() const;
   int getPlanesCount() const;
   int getBytesPerRow() const;
+  local_ref<JArrayByte> toByteArray() const;
   void close();
 };
 

--- a/android/src/main/cpp/java-bindings/JImageProxy.h
+++ b/android/src/main/cpp/java-bindings/JImageProxy.h
@@ -19,8 +19,10 @@ struct JImageProxy : public JavaClass<JImageProxy> {
   int getWidth() const;
   int getHeight() const;
   bool getIsValid() const;
+  bool getIsMirrored() const;
   int getPlanesCount() const;
   int getBytesPerRow() const;
+  local_ref<JString> getOrientation() const;
   local_ref<JArrayByte> toByteArray() const;
   void close();
 };

--- a/android/src/main/cpp/java-bindings/JImageProxy.h
+++ b/android/src/main/cpp/java-bindings/JImageProxy.h
@@ -22,6 +22,7 @@ struct JImageProxy : public JavaClass<JImageProxy> {
   bool getIsMirrored() const;
   int getPlanesCount() const;
   int getBytesPerRow() const;
+  long getTimestamp() const;
   local_ref<JString> getOrientation() const;
   local_ref<JArrayByte> toByteArray() const;
   void close();

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/ImageProxyUtils.java
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/ImageProxyUtils.java
@@ -1,11 +1,14 @@
 package com.mrousavy.camera.frameprocessor;
 
 import android.annotation.SuppressLint;
+import android.graphics.ImageFormat;
 import android.media.Image;
 
 import androidx.annotation.Keep;
 import androidx.camera.core.ImageProxy;
 import com.facebook.proguard.annotations.DoNotStrip;
+
+import java.nio.ByteBuffer;
 
 @SuppressWarnings("unused") // used through JNI
 @DoNotStrip
@@ -38,5 +41,30 @@ public class ImageProxyUtils {
     @Keep
     public static int getBytesPerRow(ImageProxy imageProxy) {
         return imageProxy.getPlanes()[0].getRowStride();
+    }
+
+    private static byte[] byteArrayCache;
+
+    @DoNotStrip
+    @Keep
+    public static byte[] toByteArray(ImageProxy imageProxy) {
+        switch (imageProxy.getFormat()) {
+        case ImageFormat.YUV_420_888:
+            ByteBuffer yBuffer = imageProxy.getPlanes()[0].getBuffer();
+            ByteBuffer vuBuffer = imageProxy.getPlanes()[2].getBuffer();
+            int ySize = yBuffer.remaining();
+            int vuSize = vuBuffer.remaining();
+
+            if (byteArrayCache == null || byteArrayCache.length != ySize + vuSize) {
+                byteArrayCache = new byte[ySize + vuSize];
+            }
+
+            yBuffer.get(byteArrayCache, 0, ySize);
+            vuBuffer.get(byteArrayCache, ySize, vuSize);
+
+            return byteArrayCache;
+        default:
+            throw new RuntimeException("Cannot convert Frame with Format " + imageProxy.getFormat() + " to byte array!");
+        }
     }
 }

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/ImageProxyUtils.java
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/ImageProxyUtils.java
@@ -2,6 +2,7 @@ package com.mrousavy.camera.frameprocessor;
 
 import android.annotation.SuppressLint;
 import android.graphics.ImageFormat;
+import android.graphics.Matrix;
 import android.media.Image;
 
 import androidx.annotation.Keep;
@@ -29,6 +30,27 @@ public class ImageProxyUtils {
             // exception thrown, image has already been closed.
             return false;
         }
+    }
+
+    @DoNotStrip
+    @Keep
+    public static boolean isImageProxyMirrored(ImageProxy imageProxy) {
+        Matrix matrix = imageProxy.getImageInfo().getSensorToBufferTransformMatrix();
+        // TODO: Figure out how to get isMirrored from ImageProxy
+        return false;
+    }
+
+    @DoNotStrip
+    @Keep
+    public static String getOrientation(ImageProxy imageProxy) {
+        int rotation = imageProxy.getImageInfo().getRotationDegrees();
+        if (rotation >= 45 && rotation < 135)
+            return "landscapeRight";
+        if (rotation >= 135 && rotation < 225)
+            return "portraitUpsideDown";
+        if (rotation >= 225 && rotation < 315)
+            return "landscapeLeft";
+        return "portrait";
     }
 
     @DoNotStrip

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/ImageProxyUtils.java
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/ImageProxyUtils.java
@@ -55,6 +55,12 @@ public class ImageProxyUtils {
 
     @DoNotStrip
     @Keep
+    public static long getTimestamp(ImageProxy imageProxy) {
+        return imageProxy.getImageInfo().getTimestamp();
+    }
+
+    @DoNotStrip
+    @Keep
     public static int getPlanesCount(ImageProxy imageProxy) {
         return imageProxy.getPlanes().length;
     }

--- a/cpp/JSITypedArray.cpp
+++ b/cpp/JSITypedArray.cpp
@@ -228,6 +228,11 @@ void TypedArray<T>::updateUnsafe(jsi::Runtime &runtime, ContentType<T> *data, si
   memcpy(rawData, data, length);
 }
 
+template <TypedArrayKind T>
+uint8_t* TypedArray<T>::data(jsi::Runtime &runtime) {
+  return getBuffer(runtime).data(runtime) + byteOffset(runtime);
+}
+
 const jsi::PropNameID &PropNameIDCache::getConstructorNameProp(
     jsi::Runtime &runtime,
     TypedArrayKind kind) {

--- a/cpp/JSITypedArray.cpp
+++ b/cpp/JSITypedArray.cpp
@@ -219,6 +219,15 @@ void TypedArray<T>::update(jsi::Runtime &runtime, const std::vector<ContentType<
   std::copy(data.begin(), data.end(), reinterpret_cast<ContentType<T> *>(rawData));
 }
 
+template <TypedArrayKind T>
+void TypedArray<T>::updateUnsafe(jsi::Runtime &runtime, ContentType<T> *data, size_t length) {
+  if (length != size(runtime)) {
+    throw jsi::JSError(runtime, "TypedArray can only be updated with an array of the same size");
+  }
+  uint8_t *rawData = getBuffer(runtime).data(runtime) + byteOffset(runtime);
+  memcpy(rawData, data, length);
+}
+
 const jsi::PropNameID &PropNameIDCache::getConstructorNameProp(
     jsi::Runtime &runtime,
     TypedArrayKind kind) {

--- a/cpp/JSITypedArray.cpp
+++ b/cpp/JSITypedArray.cpp
@@ -1,0 +1,317 @@
+//
+//  JSITypedArray.cpp
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 21.02.23.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+// Copied & Adapted from https://github.com/expo/expo/blob/main/packages/expo-gl/common/EXTypedArrayApi.cpp
+// Credits to Expo
+
+#include "JSITypedArray.h"
+
+#include <unordered_map>
+
+namespace vision {
+
+template <TypedArrayKind T>
+using ContentType = typename typedArrayTypeMap<T>::type;
+
+enum class Prop {
+  Buffer, // "buffer"
+  Constructor, // "constructor"
+  Name, // "name"
+  Proto, // "__proto__"
+  Length, // "length"
+  ByteLength, // "byteLength"
+  ByteOffset, // "offset"
+  IsView, // "isView"
+  ArrayBuffer, // "ArrayBuffer"
+  Int8Array, // "Int8Array"
+  Int16Array, // "Int16Array"
+  Int32Array, // "Int32Array"
+  Uint8Array, // "Uint8Array"
+  Uint8ClampedArray, // "Uint8ClampedArray"
+  Uint16Array, // "Uint16Array"
+  Uint32Array, // "Uint32Array"
+  Float32Array, // "Float32Array"
+  Float64Array, // "Float64Array"
+};
+
+class PropNameIDCache {
+ public:
+  const jsi::PropNameID &get(jsi::Runtime &runtime, Prop prop) {
+    auto key = reinterpret_cast<uintptr_t>(&runtime);
+    if (this->props.find(key) == this->props.end()) {
+      this->props[key] = std::unordered_map<Prop, std::unique_ptr<jsi::PropNameID>>();
+    }
+    if (!this->props[key][prop]) {
+      this->props[key][prop] = std::make_unique<jsi::PropNameID>(createProp(runtime, prop));
+    }
+    return *(this->props[key][prop]);
+  }
+
+  const jsi::PropNameID &getConstructorNameProp(jsi::Runtime &runtime, TypedArrayKind kind);
+
+  void invalidate(uintptr_t key) {
+    if (props.find(key) != props.end()) {
+      props[key].clear();
+    }
+  }
+
+ private:
+  std::unordered_map<uintptr_t, std::unordered_map<Prop, std::unique_ptr<jsi::PropNameID>>> props;
+
+  jsi::PropNameID createProp(jsi::Runtime &runtime, Prop prop);
+};
+
+PropNameIDCache propNameIDCache;
+
+InvalidateCacheOnDestroy::InvalidateCacheOnDestroy(jsi::Runtime &runtime) {
+  key = reinterpret_cast<uintptr_t>(&runtime);
+}
+InvalidateCacheOnDestroy::~InvalidateCacheOnDestroy() {
+  propNameIDCache.invalidate(key);
+}
+
+TypedArrayKind getTypedArrayKindForName(const std::string &name);
+
+TypedArrayBase::TypedArrayBase(jsi::Runtime &runtime, size_t size, TypedArrayKind kind)
+    : TypedArrayBase(
+          runtime,
+          runtime.global()
+              .getProperty(runtime, propNameIDCache.getConstructorNameProp(runtime, kind))
+              .asObject(runtime)
+              .asFunction(runtime)
+              .callAsConstructor(runtime, {static_cast<double>(size)})
+              .asObject(runtime)) {}
+
+TypedArrayBase::TypedArrayBase(jsi::Runtime &runtime, const jsi::Object &obj)
+    : jsi::Object(jsi::Value(runtime, obj).asObject(runtime)) {}
+
+TypedArrayKind TypedArrayBase::getKind(jsi::Runtime &runtime) const {
+  auto constructorName = this->getProperty(runtime, propNameIDCache.get(runtime, Prop::Constructor))
+                             .asObject(runtime)
+                             .getProperty(runtime, propNameIDCache.get(runtime, Prop::Name))
+                             .asString(runtime)
+                             .utf8(runtime);
+  return getTypedArrayKindForName(constructorName);
+};
+
+size_t TypedArrayBase::size(jsi::Runtime &runtime) const {
+  return getProperty(runtime, propNameIDCache.get(runtime, Prop::Length)).asNumber();
+}
+
+size_t TypedArrayBase::length(jsi::Runtime &runtime) const {
+  return getProperty(runtime, propNameIDCache.get(runtime, Prop::Length)).asNumber();
+}
+
+size_t TypedArrayBase::byteLength(jsi::Runtime &runtime) const {
+  return getProperty(runtime, propNameIDCache.get(runtime, Prop::ByteLength)).asNumber();
+}
+
+size_t TypedArrayBase::byteOffset(jsi::Runtime &runtime) const {
+  return getProperty(runtime, propNameIDCache.get(runtime, Prop::ByteOffset)).asNumber();
+}
+
+bool TypedArrayBase::hasBuffer(jsi::Runtime &runtime) const {
+  auto buffer = getProperty(runtime, propNameIDCache.get(runtime, Prop::Buffer));
+  return buffer.isObject() && buffer.asObject(runtime).isArrayBuffer(runtime);
+}
+
+std::vector<uint8_t> TypedArrayBase::toVector(jsi::Runtime &runtime) {
+  auto start = reinterpret_cast<uint8_t *>(getBuffer(runtime).data(runtime) + byteOffset(runtime));
+  auto end = start + byteLength(runtime);
+  return std::vector<uint8_t>(start, end);
+}
+
+jsi::ArrayBuffer TypedArrayBase::getBuffer(jsi::Runtime &runtime) const {
+  auto buffer = getProperty(runtime, propNameIDCache.get(runtime, Prop::Buffer));
+  if (buffer.isObject() && buffer.asObject(runtime).isArrayBuffer(runtime)) {
+    return buffer.asObject(runtime).getArrayBuffer(runtime);
+  } else {
+    throw std::runtime_error("no ArrayBuffer attached");
+  }
+}
+
+bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+  auto jsVal = runtime.global()
+                   .getProperty(runtime, propNameIDCache.get(runtime, Prop::ArrayBuffer))
+                   .asObject(runtime)
+                   .getProperty(runtime, propNameIDCache.get(runtime, Prop::IsView))
+                   .asObject(runtime)
+                   .asFunction(runtime)
+                   .callWithThis(runtime, runtime.global(), {jsi::Value(runtime, jsObj)});
+  if (jsVal.isBool()) {
+    return jsVal.getBool();
+  } else {
+    throw std::runtime_error("value is not a boolean");
+  }
+}
+
+TypedArrayBase getTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+  auto jsVal = runtime.global()
+                   .getProperty(runtime, propNameIDCache.get(runtime, Prop::ArrayBuffer))
+                   .asObject(runtime)
+                   .getProperty(runtime, propNameIDCache.get(runtime, Prop::IsView))
+                   .asObject(runtime)
+                   .asFunction(runtime)
+                   .callWithThis(runtime, runtime.global(), {jsi::Value(runtime, jsObj)});
+  if (jsVal.isBool()) {
+    return TypedArrayBase(runtime, jsObj);
+  } else {
+    throw std::runtime_error("value is not a boolean");
+  }
+}
+
+std::vector<uint8_t> arrayBufferToVector(jsi::Runtime &runtime, jsi::Object &jsObj) {
+  if (!jsObj.isArrayBuffer(runtime)) {
+    throw std::runtime_error("Object is not an ArrayBuffer");
+  }
+  auto jsArrayBuffer = jsObj.getArrayBuffer(runtime);
+
+  uint8_t *dataBlock = jsArrayBuffer.data(runtime);
+  size_t blockSize =
+      jsArrayBuffer.getProperty(runtime, propNameIDCache.get(runtime, Prop::ByteLength)).asNumber();
+  return std::vector<uint8_t>(dataBlock, dataBlock + blockSize);
+}
+
+void arrayBufferUpdate(
+    jsi::Runtime &runtime,
+    jsi::ArrayBuffer &buffer,
+    std::vector<uint8_t> data,
+    size_t offset) {
+  uint8_t *dataBlock = buffer.data(runtime);
+  size_t blockSize = buffer.size(runtime);
+  if (data.size() > blockSize) {
+    throw jsi::JSError(runtime, "ArrayBuffer is to small to fit data");
+  }
+  std::copy(data.begin(), data.end(), dataBlock + offset);
+}
+
+template <TypedArrayKind T>
+TypedArray<T>::TypedArray(jsi::Runtime &runtime, size_t size) : TypedArrayBase(runtime, size, T){};
+
+template <TypedArrayKind T>
+TypedArray<T>::TypedArray(jsi::Runtime &runtime, std::vector<ContentType<T>> data)
+    : TypedArrayBase(runtime, data.size(), T) {
+  update(runtime, data);
+};
+
+template <TypedArrayKind T>
+TypedArray<T>::TypedArray(TypedArrayBase &&base) : TypedArrayBase(std::move(base)) {}
+
+template <TypedArrayKind T>
+std::vector<ContentType<T>> TypedArray<T>::toVector(jsi::Runtime &runtime) {
+  auto start =
+      reinterpret_cast<ContentType<T> *>(getBuffer(runtime).data(runtime) + byteOffset(runtime));
+  auto end = start + size(runtime);
+  return std::vector<ContentType<T>>(start, end);
+}
+
+template <TypedArrayKind T>
+void TypedArray<T>::update(jsi::Runtime &runtime, const std::vector<ContentType<T>> &data) {
+  if (data.size() != size(runtime)) {
+    throw jsi::JSError(runtime, "TypedArray can only be updated with a vector of the same size");
+  }
+  uint8_t *rawData = getBuffer(runtime).data(runtime) + byteOffset(runtime);
+  std::copy(data.begin(), data.end(), reinterpret_cast<ContentType<T> *>(rawData));
+}
+
+const jsi::PropNameID &PropNameIDCache::getConstructorNameProp(
+    jsi::Runtime &runtime,
+    TypedArrayKind kind) {
+  switch (kind) {
+    case TypedArrayKind::Int8Array:
+      return get(runtime, Prop::Int8Array);
+    case TypedArrayKind::Int16Array:
+      return get(runtime, Prop::Int16Array);
+    case TypedArrayKind::Int32Array:
+      return get(runtime, Prop::Int32Array);
+    case TypedArrayKind::Uint8Array:
+      return get(runtime, Prop::Uint8Array);
+    case TypedArrayKind::Uint8ClampedArray:
+      return get(runtime, Prop::Uint8ClampedArray);
+    case TypedArrayKind::Uint16Array:
+      return get(runtime, Prop::Uint16Array);
+    case TypedArrayKind::Uint32Array:
+      return get(runtime, Prop::Uint32Array);
+    case TypedArrayKind::Float32Array:
+      return get(runtime, Prop::Float32Array);
+    case TypedArrayKind::Float64Array:
+      return get(runtime, Prop::Float64Array);
+  }
+}
+
+jsi::PropNameID PropNameIDCache::createProp(jsi::Runtime &runtime, Prop prop) {
+  auto create = [&](const std::string &propName) {
+    return jsi::PropNameID::forUtf8(runtime, propName);
+  };
+  switch (prop) {
+    case Prop::Buffer:
+      return create("buffer");
+    case Prop::Constructor:
+      return create("constructor");
+    case Prop::Name:
+      return create("name");
+    case Prop::Proto:
+      return create("__proto__");
+    case Prop::Length:
+      return create("length");
+    case Prop::ByteLength:
+      return create("byteLength");
+    case Prop::ByteOffset:
+      return create("byteOffset");
+    case Prop::IsView:
+      return create("isView");
+    case Prop::ArrayBuffer:
+      return create("ArrayBuffer");
+    case Prop::Int8Array:
+      return create("Int8Array");
+    case Prop::Int16Array:
+      return create("Int16Array");
+    case Prop::Int32Array:
+      return create("Int32Array");
+    case Prop::Uint8Array:
+      return create("Uint8Array");
+    case Prop::Uint8ClampedArray:
+      return create("Uint8ClampedArray");
+    case Prop::Uint16Array:
+      return create("Uint16Array");
+    case Prop::Uint32Array:
+      return create("Uint32Array");
+    case Prop::Float32Array:
+      return create("Float32Array");
+    case Prop::Float64Array:
+      return create("Float64Array");
+  }
+}
+
+std::unordered_map<std::string, TypedArrayKind> nameToKindMap = {
+    {"Int8Array", TypedArrayKind::Int8Array},
+    {"Int16Array", TypedArrayKind::Int16Array},
+    {"Int32Array", TypedArrayKind::Int32Array},
+    {"Uint8Array", TypedArrayKind::Uint8Array},
+    {"Uint8ClampedArray", TypedArrayKind::Uint8ClampedArray},
+    {"Uint16Array", TypedArrayKind::Uint16Array},
+    {"Uint32Array", TypedArrayKind::Uint32Array},
+    {"Float32Array", TypedArrayKind::Float32Array},
+    {"Float64Array", TypedArrayKind::Float64Array},
+};
+
+TypedArrayKind getTypedArrayKindForName(const std::string &name) {
+  return nameToKindMap.at(name);
+}
+
+template class TypedArray<TypedArrayKind::Int8Array>;
+template class TypedArray<TypedArrayKind::Int16Array>;
+template class TypedArray<TypedArrayKind::Int32Array>;
+template class TypedArray<TypedArrayKind::Uint8Array>;
+template class TypedArray<TypedArrayKind::Uint8ClampedArray>;
+template class TypedArray<TypedArrayKind::Uint16Array>;
+template class TypedArray<TypedArrayKind::Uint32Array>;
+template class TypedArray<TypedArrayKind::Float32Array>;
+template class TypedArray<TypedArrayKind::Float64Array>;
+
+} // namespace vision

--- a/cpp/JSITypedArray.h
+++ b/cpp/JSITypedArray.h
@@ -148,6 +148,7 @@ class TypedArray : public TypedArrayBase {
   std::vector<ContentType<T>> toVector(jsi::Runtime &runtime);
   void update(jsi::Runtime &runtime, const std::vector<ContentType<T>> &data);
   void updateUnsafe(jsi::Runtime &runtime, ContentType<T> *data, size_t length);
+  uint8_t* data(jsi::Runtime &runtime);
 };
 
 template <TypedArrayKind T>

--- a/cpp/JSITypedArray.h
+++ b/cpp/JSITypedArray.h
@@ -147,6 +147,7 @@ class TypedArray : public TypedArrayBase {
 
   std::vector<ContentType<T>> toVector(jsi::Runtime &runtime);
   void update(jsi::Runtime &runtime, const std::vector<ContentType<T>> &data);
+  void updateUnsafe(jsi::Runtime &runtime, ContentType<T> *data, size_t length);
 };
 
 template <TypedArrayKind T>

--- a/cpp/JSITypedArray.h
+++ b/cpp/JSITypedArray.h
@@ -1,0 +1,181 @@
+//
+//  JSITypedArray.h
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 21.02.23.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+
+// Copied & Adapted from https://github.com/expo/expo/blob/main/packages/expo-gl/common/EXTypedArrayApi.h
+// Credits to Expo
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace vision {
+
+enum class TypedArrayKind {
+  Int8Array,
+  Int16Array,
+  Int32Array,
+  Uint8Array,
+  Uint8ClampedArray,
+  Uint16Array,
+  Uint32Array,
+  Float32Array,
+  Float64Array,
+};
+
+template <TypedArrayKind T>
+class TypedArray;
+
+template <TypedArrayKind T>
+struct typedArrayTypeMap;
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Int8Array> {
+  typedef int8_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Int16Array> {
+  typedef int16_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Int32Array> {
+  typedef int32_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Uint8Array> {
+  typedef uint8_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Uint8ClampedArray> {
+  typedef uint8_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Uint16Array> {
+  typedef uint16_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Uint32Array> {
+  typedef uint32_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Float32Array> {
+  typedef float type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Float64Array> {
+  typedef double type;
+};
+
+// Instance of this class will invalidate PropNameIDCache when destructor is called.
+// Attach this object to global in specific jsi::Runtime to make sure lifecycle of
+// the cache object is connected to the lifecycle of the js runtime
+class InvalidateCacheOnDestroy : public jsi::HostObject {
+ public:
+  InvalidateCacheOnDestroy(jsi::Runtime &runtime);
+  virtual ~InvalidateCacheOnDestroy();
+  virtual jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) {
+    return jsi::Value::null();
+  }
+  virtual void set(jsi::Runtime &, const jsi::PropNameID &name, const jsi::Value &value) {}
+  virtual std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) {
+    return {};
+  }
+
+ private:
+  uintptr_t key;
+};
+
+class TypedArrayBase : public jsi::Object {
+ public:
+  template <TypedArrayKind T>
+  using ContentType = typename typedArrayTypeMap<T>::type;
+
+  TypedArrayBase(jsi::Runtime &, size_t, TypedArrayKind);
+  TypedArrayBase(jsi::Runtime &, const jsi::Object &);
+  TypedArrayBase(TypedArrayBase &&) = default;
+  TypedArrayBase &operator=(TypedArrayBase &&) = default;
+
+  TypedArrayKind getKind(jsi::Runtime &runtime) const;
+
+  template <TypedArrayKind T>
+  TypedArray<T> get(jsi::Runtime &runtime) const &;
+  template <TypedArrayKind T>
+  TypedArray<T> get(jsi::Runtime &runtime) &&;
+  template <TypedArrayKind T>
+  TypedArray<T> as(jsi::Runtime &runtime) const &;
+  template <TypedArrayKind T>
+  TypedArray<T> as(jsi::Runtime &runtime) &&;
+
+  size_t size(jsi::Runtime &runtime) const;
+  size_t length(jsi::Runtime &runtime) const;
+  size_t byteLength(jsi::Runtime &runtime) const;
+  size_t byteOffset(jsi::Runtime &runtime) const;
+  bool hasBuffer(jsi::Runtime &runtime) const;
+
+  std::vector<uint8_t> toVector(jsi::Runtime &runtime);
+  jsi::ArrayBuffer getBuffer(jsi::Runtime &runtime) const;
+
+ private:
+  template <TypedArrayKind>
+  friend class TypedArray;
+};
+
+bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
+TypedArrayBase getTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
+
+std::vector<uint8_t> arrayBufferToVector(jsi::Runtime &runtime, jsi::Object &jsObj);
+void arrayBufferUpdate(
+    jsi::Runtime &runtime,
+    jsi::ArrayBuffer &buffer,
+    std::vector<uint8_t> data,
+    size_t offset);
+
+template <TypedArrayKind T>
+class TypedArray : public TypedArrayBase {
+ public:
+  TypedArray(jsi::Runtime &runtime, size_t size);
+  TypedArray(jsi::Runtime &runtime, std::vector<ContentType<T>> data);
+  TypedArray(TypedArrayBase &&base);
+  TypedArray(TypedArray &&) = default;
+  TypedArray &operator=(TypedArray &&) = default;
+
+  std::vector<ContentType<T>> toVector(jsi::Runtime &runtime);
+  void update(jsi::Runtime &runtime, const std::vector<ContentType<T>> &data);
+};
+
+template <TypedArrayKind T>
+TypedArray<T> TypedArrayBase::get(jsi::Runtime &runtime) const & {
+  assert(getKind(runtime) == T);
+  (void)runtime; // when assert is disabled we need to mark this as used
+  return TypedArray<T>(jsi::Value(runtime, jsi::Value(runtime, *this).asObject(runtime)));
+}
+
+template <TypedArrayKind T>
+TypedArray<T> TypedArrayBase::get(jsi::Runtime &runtime) && {
+  assert(getKind(runtime) == T);
+  (void)runtime; // when assert is disabled we need to mark this as used
+  return TypedArray<T>(std::move(*this));
+}
+
+template <TypedArrayKind T>
+TypedArray<T> TypedArrayBase::as(jsi::Runtime &runtime) const & {
+  if (getKind(runtime) != T) {
+    throw jsi::JSError(runtime, "Object is not a TypedArray");
+  }
+  return get<T>(runtime);
+}
+
+template <TypedArrayKind T>
+TypedArray<T> TypedArrayBase::as(jsi::Runtime &runtime) && {
+  if (getKind(runtime) != T) {
+    throw jsi::JSError(runtime, "Object is not a TypedArray");
+  }
+  return std::move(*this).get<T>(runtime);
+}
+} // namespace vision

--- a/ios/Frame Processor/FrameHostObject.mm
+++ b/ios/Frame Processor/FrameHostObject.mm
@@ -137,8 +137,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
         runtime.global().setProperty(runtime, ARRAYBUFFER_CACHE_PROP_NAME, arrayBuffer);
       }
       
-      std::vector<uint8_t> vector(buffer, buffer + arraySize);
-      arrayBuffer.update(runtime, vector);
+      arrayBuffer.updateUnsafe(runtime, buffer, arraySize);
       
       return arrayBuffer;
     };

--- a/ios/Frame Processor/FrameHostObject.mm
+++ b/ios/Frame Processor/FrameHostObject.mm
@@ -20,7 +20,8 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("height")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("bytesPerRow")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("planesCount")));
-  // Debugging
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("orientation")));
+  // Conversion
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toString")));
   // Ref Management
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("isValid")));
@@ -126,6 +127,36 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     auto imageBuffer = CMSampleBufferGetImageBuffer(frame.buffer);
     auto height = CVPixelBufferGetHeight(imageBuffer);
     return jsi::Value((double) height);
+  }
+  if (name == "orientation") {
+    switch (frame.orientation) {
+      case UIImageOrientationUp:
+      case UIImageOrientationUpMirrored:
+        return jsi::String::createFromUtf8(runtime, "portrait");
+      case UIImageOrientationDown:
+      case UIImageOrientationDownMirrored:
+        return jsi::String::createFromUtf8(runtime, "portraitUpsideDown");
+      case UIImageOrientationLeft:
+      case UIImageOrientationLeftMirrored:
+        return jsi::String::createFromUtf8(runtime, "landscapeLeft");
+      case UIImageOrientationRight:
+      case UIImageOrientationRightMirrored:
+        return jsi::String::createFromUtf8(runtime, "landscapeRight");
+    }
+  }
+  if (name == "isMirrored") {
+    switch (frame.orientation) {
+      case UIImageOrientationUp:
+      case UIImageOrientationDown:
+      case UIImageOrientationLeft:
+      case UIImageOrientationRight:
+        return jsi::Value(false);
+      case UIImageOrientationDownMirrored:
+      case UIImageOrientationUpMirrored:
+      case UIImageOrientationLeftMirrored:
+      case UIImageOrientationRightMirrored:
+        return jsi::Value(true);
+    }
   }
   if (name == "bytesPerRow") {
     auto imageBuffer = CMSampleBufferGetImageBuffer(frame.buffer);

--- a/ios/Frame Processor/FrameHostObject.mm
+++ b/ios/Frame Processor/FrameHostObject.mm
@@ -23,6 +23,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("planesCount")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("orientation")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("isMirrored")));
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("timestamp")));
   // Conversion
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toString")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toArrayBuffer")));
@@ -188,6 +189,11 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
       case UIImageOrientationRightMirrored:
         return jsi::Value(true);
     }
+  }
+  if (name == "timestamp") {
+    auto timestamp = CMSampleBufferGetPresentationTimeStamp(frame.buffer);
+    auto seconds = static_cast<double>(CMTimeGetSeconds(timestamp));
+    return jsi::Value(seconds * 1000.0);
   }
   if (name == "bytesPerRow") {
     auto imageBuffer = CMSampleBufferGetImageBuffer(frame.buffer);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "lib/commonjs",
     "lib/module",
     "lib/typescript",
+    "cpp/**/*.h",
+    "cpp/**/*.cpp",
     "android/build.gradle",
     "android/gradle.properties",
     "android/CMakeLists.txt",

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -3,6 +3,7 @@ import type { CameraDevice, CameraDeviceFormat, ColorSpace, VideoStabilizationMo
 import type { CameraRuntimeError } from './CameraError';
 import type { CameraPreset } from './CameraPreset';
 import type { Frame } from './Frame';
+import type { Orientation } from './Orientation';
 
 export interface CameraProps extends ViewProps {
   /**
@@ -161,7 +162,7 @@ export interface CameraProps extends ViewProps {
   /**
    * Represents the orientation of all Camera Outputs (Photo, Video, and Frame Processor). If this value is not set, the device orientation is used.
    */
-  orientation?: 'portrait' | 'portraitUpsideDown' | 'landscapeLeft' | 'landscapeRight';
+  orientation?: Orientation;
   /**
    * Render type of the Camera Preview Layer.
    *

--- a/src/Frame.ts
+++ b/src/Frame.ts
@@ -1,4 +1,5 @@
 import type { SkCanvas, SkPaint } from '@shopify/react-native-skia';
+import type { Orientation } from './Orientation';
 
 /**
  * A single frame, as seen by the camera.
@@ -24,6 +25,17 @@ export interface Frame extends SkCanvas {
    * Returns the number of planes this frame contains.
    */
   planesCount: number;
+  /**
+   * Returns whether the Frame is mirrored (selfie camera) or not.
+   */
+  isMirrored: boolean;
+  /**
+   * Represents the orientation of the Frame.
+   *
+   * Some ML Models are trained for specific orientations, so they need to be taken into
+   * consideration when running a frame processor. See also: `isMirrored`
+   */
+  orientation: Orientation;
 
   /**
    * Returns a string representation of the frame.

--- a/src/Frame.ts
+++ b/src/Frame.ts
@@ -38,6 +38,12 @@ export interface Frame extends SkCanvas {
   orientation: Orientation;
 
   /**
+   * Get the underlying data of the Frame as a uint8 array buffer.
+   *
+   * Note that Frames are allocated on the GPU, so calling `toArrayBuffer()` will copy from the GPU to the CPU.
+   */
+  toArrayBuffer(): Uint8ClampedArray;
+  /**
    * Returns a string representation of the frame.
    * @example
    * ```ts

--- a/src/Frame.ts
+++ b/src/Frame.ts
@@ -30,6 +30,10 @@ export interface Frame extends SkCanvas {
    */
   isMirrored: boolean;
   /**
+   * Returns the timestamp of the Frame relative to the host sytem's clock.
+   */
+  timestamp: number;
+  /**
    * Represents the orientation of the Frame.
    *
    * Some ML Models are trained for specific orientations, so they need to be taken into

--- a/src/Frame.ts
+++ b/src/Frame.ts
@@ -46,7 +46,7 @@ export interface Frame extends SkCanvas {
    *
    * Note that Frames are allocated on the GPU, so calling `toArrayBuffer()` will copy from the GPU to the CPU.
    */
-  toArrayBuffer(): Uint8ClampedArray;
+  toArrayBuffer(): Uint8Array;
   /**
    * Returns a string representation of the frame.
    * @example

--- a/src/Orientation.ts
+++ b/src/Orientation.ts
@@ -1,0 +1,1 @@
+export type Orientation = 'portrait' | 'portraitUpsideDown' | 'landscapeLeft' | 'landscapeRight';


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds three new props and one new function to the `Frame` object:

* `toByteArray()`: Gets the Frame data as a byte array. The type is `Uint8Array` (TypedArray/`ArrayBuffer`). Keep in mind that Frame buffers are usually allocated on the GPU, so this comes with a performance cost of a GPU -> CPU copy operation. I've optimized it a bit to run pretty fast :)
* `orientation`: The orientation of the Frame. e.g. `"portrait"`
* `isMirrored`: Whether the Frame is mirrored (eg in selfie cams)
* `timestamp`: The presentation timestamp of the Frame

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
