### PR TITLE
fix: improve "Native Module 'CameraView' was null!" error message

### DIFF
--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -38,7 +38,7 @@ type RefType = React.Component<NativeCameraViewProps> & Readonly<NativeMethods>;
 // NativeModules automatically resolves 'CameraView' to 'CameraViewModule'
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const CameraModule = NativeModules.CameraView;
-if (CameraModule == null) console.error("Camera: Native Module 'CameraView' was null! Did you run pod install?");
+if (CameraModule == null) console.error("Camera: Native Module 'CameraView' was null! Did you run pod install? Or are you running expo start instead of expo run:ios or expo run:android?");
 
 //#region Camera Component
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

We ran into the error message "Camera: Native Module 'CameraView' was null! Did you run pod install?" while building an app with Expo.

This happened because we were not building a native app directly, but were running the app through the Expo Go app (using the `expo start` command). Running the app with `expo run:ios` or `expo run:android` fixed the problem.

This PR updates the error message to help people who run into the same issue.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

This PR updates the "Native Module 'CameraView' was null!" error message.

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
