### PR TITLE
fix: "Frame Processors are not enabled" error on Android with Hermes disabled (RN 0.71.x)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\
 def FOR_HERMES = System.getenv("FOR_HERMES") == "True"
 rootProject.getSubprojects().forEach({project ->
   if (project.plugins.hasPlugin("com.android.application")) {
-    FOR_HERMES = REACT_NATIVE_VERSION >= 71 && project.hermesEnabled.toBoolean() || project.ext.react.enableHermes.toBoolean()
+    FOR_HERMES = REACT_NATIVE_VERSION >= 71 && project.hermesEnabled.toBoolean() || project.ext.react.enableHermes
   }
 })
 def jsRuntimeDir = {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\
 def FOR_HERMES = System.getenv("FOR_HERMES") == "True"
 rootProject.getSubprojects().forEach({project ->
   if (project.plugins.hasPlugin("com.android.application")) {
-    FOR_HERMES = REACT_NATIVE_VERSION >= 71 && project.hermesEnabled || project.ext.react.enableHermes
+    FOR_HERMES = REACT_NATIVE_VERSION >= 71 && project.hermesEnabled.toBoolean() || project.ext.react.enableHermes.toBoolean()
   }
 })
 def jsRuntimeDir = {

--- a/android/src/main/cpp/MakeJSIRuntime.h
+++ b/android/src/main/cpp/MakeJSIRuntime.h
@@ -12,7 +12,7 @@
   #include <hermes/hermes.h>
 #else
   // JSC
-  #include <jsi/JSCRuntime.h>
+  #include <jsc/JSCRuntime.h>
 #endif
 
 namespace vision {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes the following:
- The error "Frame processors are not enabled" on Android (With Hermes disabled, RN 0.71+)
- Wrongly named import for JSC runtime

In Gradle, the project variable `hermesEnabled` is a string and not a boolean value. In the `build.gradle` file, the comparison for setting `FOR_HERMES` will always evaluate to true whether the `hermesEnabled` string is “True” or “False.” This commit ensures that the variable will be evaluated as a boolean, making it correct.

With Hermes always being enabled for this library, even if the main project has Hermes disabled, it often lead to the following error:

```sh
frame-processor/unavailable: Frame Processors are not enabled. See https://mrousavy.github.io/react-native-vision-camera/docs/guides/troubleshooting
```

In addition, it also fixes a wrongly named import in MakeJSIRuntime.h when using JSC.

## Changes

- This PR changes the `FOR_HERMES` comparison in `android/build.gradle` line 53
- This PR changes `#include <jsi/JSCRuntime.h>` in `android/src/main/cpp/MakeJSIRuntime.h` line 15

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

- Huawai ANE-LX1

## Related issues

- Fixes #1463 
- Fixes #1517 (If on Android, not specified in the issue)
