### PR TITLE
fix: updated orientation calculations

### DIFF
--- a/ios/CameraView+Orientation.swift
+++ b/ios/CameraView+Orientation.swift
@@ -8,11 +8,39 @@
 
 import Foundation
 import UIKit
+import AVFoundation
 
 extension CameraView {
+  
+  private func interfaceOrientation(from: UIDeviceOrientation) -> UIInterfaceOrientation {
+    switch (from) {
+      case .landscapeLeft:
+        return .landscapeRight
+      case .landscapeRight:
+        return .landscapeLeft
+      case .portraitUpsideDown:
+        return .portraitUpsideDown
+      default:
+        return .portrait
+    }
+  }
+  
+  private func captureVideoOrientation(from: UIInterfaceOrientation) -> AVCaptureVideoOrientation {
+    switch (from) {
+      case .landscapeLeft:
+        return .landscapeLeft
+      case .landscapeRight:
+        return .landscapeRight
+      case .portraitUpsideDown:
+        return .portraitUpsideDown
+      default:
+        return .portrait
+    }
+  }
+  
   /// Orientation of the input connection (preview)
   private var inputOrientation: UIInterfaceOrientation {
-    return .portrait
+    return self.interfaceOrientation(from: UIDevice.current.orientation)
   }
 
   // Orientation of the output connections (photo, video, frame processor)
@@ -39,6 +67,17 @@ extension CameraView {
           connection.isVideoMirrored = isMirrored
         }
         connection.setInterfaceOrientation(connectionOrientation)
+      }
+    }
+    
+    // update the preview layer orientation when the user rotates the device
+    // adapted from https://stackoverflow.com/a/36575423
+    DispatchQueue.main.async {
+      if let previewLayerConnection: AVCaptureConnection = self.videoPreviewLayer.connection {
+        if previewLayerConnection.isVideoOrientationSupported {
+          previewLayerConnection.videoOrientation = self.captureVideoOrientation(from: connectionOrientation)
+          self.videoPreviewLayer.frame = self.bounds
+        }
       }
     }
   }


### PR DESCRIPTION
## What

This PR should fix the issues in video orientation (preview and recording) being "fixed" to portrait orientation regardless of device orientation in iOS.

Adapted from https://stackoverflow.com/a/36575423

## Changes

* Changed the CameraView orientation extension so that it takes the UIDevice's reported orientation if the userOrientation is not provided
* On rotation change it will update the preview layer orientation and update the preview layer bounds accordingly

## Tested on

* iPhone 14 Pro
* iPad Mini

## Related issues

* Fixes #1539 
* Fixes #1455 
* Fixes #1445 
