### PR TITLE
fix: pause & resume recording fix on iOS

### DIFF
--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -223,7 +223,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       let bVideo = captureOutput is AVCaptureVideoDataOutput
 
       if (self._discont) {
-        if (bVideo) {
+        if (!bVideo) {
           return
         }
         self._discont = false
@@ -242,7 +242,9 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
           }else{
             self._timeOffset = CMTimeAdd(self._timeOffset, offset)
           }
-          self._lastAudio.flags = []
+          if (_lastAudio != nil) {
+            self._lastAudio.flags = []
+          }
           self._lastVideo.flags = []
           return
         }

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -95,6 +95,11 @@ public final class CameraView: UIView {
   internal var recordingSession: RecordingSession?
   @objc public var frameProcessorCallback: FrameProcessorCallback?
   internal var lastFrameProcessorCall = DispatchTime.now().uptimeNanoseconds
+  // internal state for pause time offset
+  internal var _discont = false
+  internal var _timeOffset : CMTime!
+  internal var _lastVideo : CMTime!
+  internal var _lastAudio : CMTime!
   // CameraView+TakePhoto
   internal var photoCaptureDelegates: [PhotoCaptureDelegate] = []
   // CameraView+Zoom


### PR DESCRIPTION
## What

When pausing and resuming record on iOS the paused timestamp should now be used in adjusting the final record timestamp. So when recording, then pausing, then resuming record the resulting video will correctly "jump ahead" and skip the time during the pause.

## Changes

I implemented the Swift version (https://stackoverflow.com/q/61547473) of the original Objective-C sample (http://www.gdcl.co.uk/2013/02/20/iPhone-Pause.html) intended to correctly adjust the timestamp when pausing record.

Specifically the CameraView RecordVideo extension was modified to track the offset calculated when the record process is first paused. Some ivars were added to the CameraView class to help track this.

## Tested on

* iPhone 14 Pro
* iPad Mini

## Related issues

* Fixes #973 
* Fixes #562
