### PR TITLE
fix: use project.hermesEnabled if present otherwise fallback to project.ext.react.enableHermes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\
 def FOR_HERMES = System.getenv("FOR_HERMES") == "True"
 rootProject.getSubprojects().forEach({project ->
   if (project.plugins.hasPlugin("com.android.application")) {
-    FOR_HERMES = REACT_NATIVE_VERSION >= 71 && project.hermesEnabled || project.ext.react.enableHermes
+    FOR_HERMES = (REACT_NATIVE_VERSION >= 71 && project.hasProperty("hermesEnabled") && project.hermesEnabled) || project.ext.react.enableHermes
   }
 })
 def jsRuntimeDir = {


### PR DESCRIPTION
## What

Starting from RN71, the `project.hermesEnabled` flag in `properties.gradle` supersedes the previous `project.ext.react.enableHermes`. However, the option to use the latter is still available and we use it in our project as it is more customisable.

See the RN gradle plugin: https://github.com/facebook/react-native/blob/0.72-stable/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt#L33

## Changes

This PR implements a similar logic to the gradle plugin to fall back to  `project.ext.react.enableHermes` if `project.hermesEnabled` is not defined.

## Tested on

Project using `project.ext.react.enableHermes`.

## Related issues

None