### PR TITLE
Fix build error with use_frameworks! :linkage => :static

### DIFF
--- a/VisionCamera.podspec
+++ b/VisionCamera.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
   # All source files that should be publicly visible
   # Note how this does not include headers, since those can nameclash.
   s.source_files = [
+    "VisionCamera.h",
     "ios/**/*.{m,mm,swift}",
     "ios/CameraBridge.h",
     "ios/Skia Render Layer/PreviewSkiaView.h",


### PR DESCRIPTION
## What

This PR fixes a compilation error in projects referencing this library on iOS with `use_frameworks! :linkage => :static` in their podfiles. The auto-generated `VisionCamera-Swift.h` includes a line: `#import <VisionCamera/VisionCamera.h>`, but this `VisionCamera.h` file in the framework headers is not also auto-generated by the build process.

<details><summary>Click for raw compilation logs</summary>

```
/Users/rkmackinnon/Development/vision-camera-code-scanner/ios/VisionCameraCodeScanner-Bridging-Header.h:1:9: note: while building module 'VisionCamera' imported from /Users/rkmackinnon/Development/vision-camera-code-scanner/ios/VisionCameraCodeScanner-Bridging-Header.h:1:
#import <VisionCamera/FrameProcessorPlugin.h>
        ^
<module-includes>:2:9: note: in file included from <module-includes>:2:
#import "Headers/VisionCamera-Swift.h"
        ^
/Users/rkmackinnon/Library/Developer/Xcode/DerivedData/VisionCameraCodeScannerExample-ewfyvspevhuqlwgeskrdtyvpbqso/Build/Products/Debug-iphonesimulator/VisionCamera/VisionCamera.framework/Headers/VisionCamera-Swift.h:272:9: error: 'VisionCamera/VisionCamera.h' file not found
#import <VisionCamera/VisionCamera.h>
        ^
/Users/rkmackinnon/Library/Developer/Xcode/DerivedData/VisionCameraCodeScannerExample-ewfyvspevhuqlwgeskrdtyvpbqso/Build/Products/Debug-iphonesimulator/VisionCamera/VisionCamera.framework/Headers/VisionCamera-Swift.h:272:9: note: did not find header 'VisionCamera.h' in framework 'VisionCamera' (loaded from '/Users/rkmackinnon/Library/Developer/Xcode/DerivedData/VisionCameraCodeScannerExample-ewfyvspevhuqlwgeskrdtyvpbqso/Build/Products/Debug-iphonesimulator/VisionCamera')
#import <VisionCamera/VisionCamera.h>
        ^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "Headers/VisionCameraCodeScanner-umbrella.h"
        ^
/Users/rkmackinnon/Development/vision-camera-code-scanner/example/ios/Pods/Target Support Files/VisionCameraCodeScanner/VisionCameraCodeScanner-umbrella.h:13:9: note: in file included from /Users/rkmackinnon/Development/vision-camera-code-scanner/example/ios/Pods/Target Support Files/VisionCameraCodeScanner/VisionCameraCodeScanner-umbrella.h:13:
#import "VisionCameraCodeScanner-Bridging-Header.h"
        ^
/Users/rkmackinnon/Development/vision-camera-code-scanner/ios/VisionCameraCodeScanner-Bridging-Header.h:1:9: error: could not build module 'VisionCamera'
#import <VisionCamera/FrameProcessorPlugin.h>
        ^
<unknown>:0: error: could not build Objective-C module 'VisionCameraCodeScanner'
```
</details>

## Changes

* Adds an empty `VisionCamera.h` file to the root of the repo
* References it in the `VisionCamera.podspec` under `source_files`.

## Tested on

* XCode 14.3 and CocoaPods 1.11.3
  * Requires an additional podfile modification in the referencing project to get around https://github.com/Shopify/react-native-skia/issues/652, but that doesn't have a bearing on the fix for this issue, it's just required to reproduce it.

## Related issues

* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1043.
  * The original submitter already closed the issue, but they opted not to use `use_frameworks :linkage => :static`. So, while the issue was resolved, the underlying compilation error never was.