### PR TITLE
Delay frame processor initialization until view creation on Android

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -12,6 +12,7 @@ class CameraViewManager(reactContext: ReactApplicationContext) : ViewGroupManage
 
   public override fun createViewInstance(context: ThemedReactContext): CameraView {
     val cameraViewModule = context.getNativeModule(CameraViewModule::class.java)!!
+    cameraViewModule.installFrameProcessorBindings()
     return CameraView(context, cameraViewModule.frameProcessorThread)
   }
 

--- a/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -58,16 +58,6 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     frameProcessorManager = null
   }
 
-  override fun initialize() {
-    super.initialize()
-
-    if (frameProcessorManager == null) {
-      frameProcessorThread.execute {
-        frameProcessorManager = FrameProcessorRuntimeManager(reactApplicationContext, frameProcessorThread)
-      }
-    }
-  }
-
   override fun onCatalystInstanceDestroy() {
     super.onCatalystInstanceDestroy()
     cleanup()
@@ -87,6 +77,20 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     val view = if (reactApplicationContext != null) UIManagerHelper.getUIManager(reactApplicationContext, viewId)?.resolveView(viewId) as CameraView? else null
     Log.d(TAG,  if (reactApplicationContext != null) "Found view $viewId!" else "Couldn't find view $viewId!")
     return view ?: throw ViewNotFoundError(viewId)
+  }
+
+  fun installFrameProcessorBindings(): Boolean {
+    return try {
+      if (frameProcessorManager == null) {
+        frameProcessorThread.execute {
+          frameProcessorManager = FrameProcessorRuntimeManager(reactApplicationContext, frameProcessorThread)
+        }
+      }
+      true;
+    } catch (e: Error) {
+      Log.e(TAG, "Failed to install Frame Processor JSI Bindings!", e)
+      false;
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR fixes java.lang.NullPointerException in FrameProcessorRuntimeManager.<init> on Android phones

Although I never was able to reproduce the issue myself, looking at the crashlogs from other users, this should fix it

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes
Moved the creation `FrameProcessorRuntimeManager` to happen in `onCreateViewInstance` instead of inside `CameraViewModule` initialisation. This should make sure that the react context is fully initialised, which apparently is not the case right now

Inspired by @pke in https://github.com/mrousavy/react-native-vision-camera/issues/946#issuecomment-1506825351

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

Not properly tested yet. I'm having trouble building and running the example app from this repo. I have tested it in another app which uses this library. Any help to test and verify the change is greatly appreciated
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
Fixes #946 
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
