### PR TITLE
feat: Implement camera orientation type "device", allows user device orientation to configure camera output

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -3,6 +3,7 @@ package com.mrousavy.camera
 import android.annotation.SuppressLint
 import android.hardware.camera2.*
 import android.util.Log
+import android.view.Surface
 import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageProxy
@@ -95,10 +96,28 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
     exif = if (skipMetadata) null else ExifInterface(file)
   }
 
+  var width = photo.width
+  var height = photo.height
+
+  if (orientation == "device") {
+    when (deviceRotation) {
+      Surface.ROTATION_0, Surface.ROTATION_180 -> {
+        val temp = Math.min(width, height)
+        height = Math.max(width, height)
+        width = temp;
+      }
+      Surface.ROTATION_90, Surface.ROTATION_270 -> {
+        val temp = Math.max(width, height)
+        height = Math.min(width, height)
+        width = temp;
+      }
+    }
+  }
+
   val map = Arguments.createMap()
   map.putString("path", file.absolutePath)
-  map.putInt("width", photo.width)
-  map.putInt("height", photo.height)
+  map.putInt("width", width)
+  map.putInt("height", height)
   map.putBoolean("isRawPhoto", photo.isRaw)
 
   val metadata = exif?.buildMetadataMap()

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -138,7 +138,7 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   private val touchEventListener: OnTouchListener
 
   private val orientationListener: OrientationListener
-  private var deviceRotation: Int = Surface.ROTATION_0
+  var deviceRotation: Int = Surface.ROTATION_0
 
   private val lifecycleRegistry: LifecycleRegistry
   private var hostLifecycleState: Lifecycle.State

--- a/ios/CameraView+Orientation.swift
+++ b/ios/CameraView+Orientation.swift
@@ -15,12 +15,30 @@ extension CameraView {
     return .portrait
   }
 
+  private var deviceOrientation: UIInterfaceOrientation {
+    switch UIDevice.current.orientation {
+      case .landscapeLeft:
+        return .landscapeRight
+      case .landscapeRight:
+        return .landscapeLeft
+      case .portraitUpsideDown:
+        return .portraitUpsideDown
+      default:
+        return .portrait
+    }
+  }
+
   // Orientation of the output connections (photo, video, frame processor)
   private var outputOrientation: UIInterfaceOrientation {
     if let userOrientation = orientation as String?,
        let parsedOrientation = try? UIInterfaceOrientation(withString: userOrientation) {
       // user is overriding output orientation
-      return parsedOrientation
+      switch userOrientation {
+        case "device":
+          return deviceOrientation
+        default:
+          return parsedOrientation
+      }
     } else {
       // use same as input orientation
       return inputOrientation
@@ -28,6 +46,10 @@ extension CameraView {
   }
 
   internal func updateOrientation() {
+    if (self.isRecording) {
+      return
+    }
+
     // Updates the Orientation for all rotable
     let isMirrored = self.videoDeviceInput?.device.position == .front
 

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -115,6 +115,9 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         videoCodec = AVVideoCodecType(withString: codecString)
       }
 
+      // orientation immediately prior to capture
+      self.updateOrientation()
+
       // Init Video
       guard let videoSettings = self.recommendedVideoSettings(videoOutput: videoOutput, fileType: fileType, videoCodec: videoCodec),
             !videoSettings.isEmpty else {

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -106,7 +106,7 @@ extension CameraView {
       // orientation immediately prior to capture
       self.updateOrientation()
 
-      photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise))
+        photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise, userOrientation: self.orientation ?? "portrait"))
 
       // Assume that `takePhoto` is always called with the same parameters, so prepare the next call too.
       photoOutput.setPreparedPhotoSettingsArray([photoSettings], completionHandler: nil)

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -103,6 +103,9 @@ extension CameraView {
         photoSettings.isAutoContentAwareDistortionCorrectionEnabled = enableAutoDistortionCorrection
       }
 
+      // orientation immediately prior to capture
+      self.updateOrientation()
+
       photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise))
 
       // Assume that `takePhoto` is always called with the same parameters, so prepare the next call too.

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -197,7 +197,7 @@ public final class CameraView: UIView {
     let shouldUpdateTorch = willReconfigure || changedProps.contains("torch") || shouldCheckActive
     let shouldUpdateZoom = willReconfigure || changedProps.contains("zoom") || shouldCheckActive
     let shouldUpdateVideoStabilization = willReconfigure || changedProps.contains("videoStabilizationMode")
-    let shouldUpdateOrientation = changedProps.contains("orientation")
+    let shouldUpdateOrientation = changedProps.contains("orientation") && self.orientation != "device"
 
     if shouldReconfigure ||
       shouldReconfigureAudioSession ||
@@ -314,6 +314,11 @@ public final class CameraView: UIView {
 
   @objc
   func onOrientationChanged() {
+    if let userOrientation = orientation as String?,
+      userOrientation == "device" {
+      return
+    }
+
     updateOrientation()
   }
 

--- a/ios/Parsers/UIInterfaceOrientation+descriptor.swift
+++ b/ios/Parsers/UIInterfaceOrientation+descriptor.swift
@@ -24,6 +24,9 @@ extension UIInterfaceOrientation {
     case "landscapeRight":
       self = .landscapeRight
       return
+    case "device":
+      self = .portrait
+      return
     default:
       throw EnumParserError.invalidValue
     }

--- a/ios/PhotoCaptureDelegate.swift
+++ b/ios/PhotoCaptureDelegate.swift
@@ -69,7 +69,7 @@ class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
       }
 
       promise.resolve([
-        "path": url.absoluteString,
+        "path": tempFilePath,
         "width": width as Any,
         "height": height as Any,
         "isRawPhoto": photo.isRawPhoto,

--- a/ios/PhotoCaptureDelegate.swift
+++ b/ios/PhotoCaptureDelegate.swift
@@ -51,7 +51,6 @@ class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
       var width = exif?["PixelXDimension"] as? Int
       var height = exif?["PixelYDimension"] as? Int
 
-        
       if (self.userOrientation == "device") {
         switch UIDevice.current.orientation {
         case .portrait, .portraitUpsideDown:
@@ -59,7 +58,7 @@ class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
           height = max(width!, height!)
           width = temp;
           break
-        case .landscapeLeft,  .landscapeRight:
+        case .landscapeLeft, .landscapeRight:
           let temp = max(width!, height!)
           height = min(width!, height!)
           width = temp;
@@ -70,7 +69,7 @@ class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
       }
 
       promise.resolve([
-        "path": tempFilePath,
+        "path": url.absoluteString,
         "width": width as Any,
         "height": height as Any,
         "isRawPhoto": photo.isRawPhoto,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "clean-ios": "scripts/clean-ios.sh",
     "clean-android": "scripts/clean-android.sh",
     "clean-js": "scripts/clean-js.sh",
-    "docs": "cd docs && yarn build"
+    "docs": "cd docs && yarn build",
+    "prepare": "yarn build"
   },
   "keywords": [
     "react-native",

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -1,8 +1,9 @@
-import type { ViewProps } from 'react-native';
 import type { CameraDevice, CameraDeviceFormat, ColorSpace, VideoStabilizationMode } from './CameraDevice';
-import type { CameraRuntimeError } from './CameraError';
+
 import type { CameraPreset } from './CameraPreset';
+import type { CameraRuntimeError } from './CameraError';
 import type { Frame } from './Frame';
+import type { ViewProps } from 'react-native';
 
 export interface FrameProcessorPerformanceSuggestion {
   type: 'can-use-higher-fps' | 'should-use-lower-fps';
@@ -159,7 +160,7 @@ export interface CameraProps extends ViewProps {
   /**
    * Represents the orientation of all Camera Outputs (Photo, Video, and Frame Processor). If this value is not set, the device orientation is used.
    */
-  orientation?: 'portrait' | 'portraitUpsideDown' | 'landscapeLeft' | 'landscapeRight';
+  orientation?: 'portrait' | 'portraitUpsideDown' | 'landscapeLeft' | 'landscapeRight' | 'device';
 
   //#region Events
   /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
--> 

## What

Implements camera orientation type `device`.

The existing implementation has four main orientations as values to the `orientation` attribute for the `<Camera>`. Using any of these four values informs the camera to provide output in only that specific orientation regardless of how the user has oriented the device to take a photo or video. This change introduces an additional value called `device`. When `orientation={'device'}` the camera responds to the users device orientation during preview and when a photo or video is created the camera will reconfigure itself to use  the device orientation at the moment the photo or video is created.

Other implementations have created a similar solution from the consuming app by detecting rotation using an RN library and then re-rendering the camera with a changed `orientation` attribute. Functionally this works but the user experience is very bad on iOS - the preview freezes and resumes at the moment the camera re-renders. The preview freeze is caused when the camera output connection is removed and reallocated using the changed configuration. The native implementation in this PR provides excellent user experience and a simpler implementation for consuming apps - developer only needs to set `orientation={'device'}`.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

Adds orientation type `device` to the RN component.
Adds re-writing the camera output configuration to be equal to the device rotation at the moment a photo or video is captured. Android and iOS implementations provide the same behavior.

All changes are backward compatible.

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

- iPhone 12 mini
- Samsung Galaxy Note 9

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

This PR should address and enable use cases identified in these issues:

- #1600
- #1572 
- #1544
- #1455 
- #1445
- #1375
- #1327 

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
