### PR TITLE
feat: Support to control mirror video recording on IOS

### DIFF
--- a/ios/CameraView+Orientation.swift
+++ b/ios/CameraView+Orientation.swift
@@ -27,16 +27,13 @@ extension CameraView {
     }
   }
 
-  internal func updateOrientation() {
-    // Updates the Orientation for all rotable
-    let isMirrored = self.videoDeviceInput?.device.position == .front
-
+  internal func updateOrientation(options: NSDictionary? = nil) {
     let connectionOrientation = self.outputOrientation
     self.captureSession.outputs.forEach { output in
       output.connections.forEach { connection in
         if connection.isVideoMirroringSupported {
           connection.automaticallyAdjustsVideoMirroring = false
-          connection.isVideoMirrored = isMirrored
+          connection.isVideoMirrored = options?["isVideoMirrored"] as? Bool ?? true
         }
         connection.setInterfaceOrientation(connectionOrientation)
       }

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -38,6 +38,10 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
       ReactLogger.log(level: .info, message: "File path: \(tempFilePath)")
       let tempURL = URL(string: "file://\(tempFilePath)")!
 
+      if let isVideoMirrored = options["isVideoMirrored"] as? Bool {
+        self.setVideoMirrored(isVideoMirrored)
+      }
+
       if let flashMode = options["flash"] as? String {
         // use the torch as the video's flash
         self.setTorchMode(flashMode)

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -312,6 +312,13 @@ public final class CameraView: UIView {
     }
   }
 
+  internal final func setVideoMirrored(_ isVideoMirrored: Bool) {
+    let updateOrientationOptions: NSDictionary = [
+      "isVideoMirrored": isVideoMirrored,
+    ]
+    updateOrientation(options: updateOrientationOptions)
+  }
+
   @objc
   func onOrientationChanged() {
     updateOrientation()

--- a/src/VideoFile.ts
+++ b/src/VideoFile.ts
@@ -40,6 +40,13 @@ export interface RecordVideoOptions {
    * @platform iOS
    */
   videoCodec?: CameraVideoCodec;
+  /**
+   * Set the mirror recording of the video
+   *
+   * @default true
+   * @platform iOS
+   */
+  isVideoMirrored?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->
This PR adds support to control mirror video recording on IOS.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the configure() function to cache results.
-->
This PR changes the updateOrientation function in ios/CameraView+Orientation.swift file by adding options such isVideoMirrored which is responsible to control mirror video recording.


## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 13
    * Huawai P20, Android 10
-->
iPhone 13 (IOS 16.5.1)

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
[[iOS]: Resulting video recording is mirrored](https://github.com/mrousavy/react-native-vision-camera/issues/1196)
