### PR TITLE
Kotlin version upgrade

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,7 +13,7 @@
 #Fri Feb 19 20:46:14 CET 2021
 VisionCamera_buildToolsVersion=30.0.0
 VisionCamera_compileSdkVersion=31
-VisionCamera_kotlinVersion=1.8.20
+VisionCamera_kotlinVersion=1.6.20
 VisionCamera_targetSdkVersion=31
 VisionCamera_ndkVersion=21.4.7075529
 android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,7 +13,7 @@
 #Fri Feb 19 20:46:14 CET 2021
 VisionCamera_buildToolsVersion=30.0.0
 VisionCamera_compileSdkVersion=31
-VisionCamera_kotlinVersion=1.5.30
+VisionCamera_kotlinVersion=1.8.20
 VisionCamera_targetSdkVersion=31
 VisionCamera_ndkVersion=21.4.7075529
 android.enableJetifier=true


### PR DESCRIPTION
This PR bumps up the Kotlin version to 1.6.2 in gradle.properties.


## Changes

This PR changes the VisionCamera_kotlinVersion value in android/gradle.properties

## Tested on

    * Samsung Tab S7 , android 12.

