### PR TITLE
feat: Camera Event Emitter -  fix naming

### DIFF
--- a/ios/CameraBridge.h
+++ b/ios/CameraBridge.h
@@ -18,6 +18,7 @@
 #import "Frame.h"
 #import "RCTBridge+runOnJS.h"
 #import "JSConsoleHelper.h"
+#import "RCTEventEmitter.h"
 
 #ifdef VISION_CAMERA_DISABLE_FRAME_PROCESSORS
 static bool VISION_CAMERA_ENABLE_FRAME_PROCESSORS = false;

--- a/ios/CameraEventEmitter.swift
+++ b/ios/CameraEventEmitter.swift
@@ -1,0 +1,23 @@
+//
+//  CameraEventEmitter.swift
+//  VisionCamera
+//
+//  Created by Fergal Eccles on 14/07/2023.
+//
+
+import Foundation
+
+@objc(CameraEventEmitter)
+open class CameraEventEmitter: RCTEventEmitter {
+
+  public static var emitter: RCTEventEmitter!
+
+  override init() {
+    super.init()
+    RNEventEmitter.emitter = self
+  }
+
+  open override func supportedEvents() -> [String] {
+    ["onChanged"]
+  }
+}

--- a/ios/CameraEventEmitter.swift
+++ b/ios/CameraEventEmitter.swift
@@ -14,7 +14,7 @@ open class CameraEventEmitter: RCTEventEmitter {
 
   override init() {
     super.init()
-    RNEventEmitter.emitter = self
+		CameraEventEmitter.emitter = self
   }
 
   open override func supportedEvents() -> [String] {

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -210,6 +210,33 @@ extension CameraView {
       invokeOnError(.device(.configureError), cause: error)
       return
     }
+
+    if device.isExposureModeSupported(AVCaptureDevice.ExposureMode.custom) {
+      ReactLogger.log(level: .info, message: "Exposure mode custom");
+      ReactLogger.log(level: .info, message: NSString(format: "min ISO %.2f", device.activeFormat.minISO) as String)
+      ReactLogger.log(level: .info, message: NSString(format: "max ISO%.2f", device.activeFormat.maxISO) as String)
+      ReactLogger.log(level: .info, message: NSString(format: "CURR ISO%.2f", device.iso) as String)
+      ReactLogger.log(level: .info, message: NSString(format: "APERTURE %.2f", device.lensAperture) as String)
+        
+      ReactLogger.log(level: .info, message: NSString(format: "Exposure %.2f", device.exposureDuration.value) as String)
+
+      cameraObserver = device.observe(\AVCaptureDevice.isAdjustingExposure, options: [.initial, .new]) {object, change in
+        
+        ReactLogger.log(level: .info, message: change.newValue ?? false ? "TRUE" : "FALSE")
+        let body: NSDictionary = [
+          "iso": device.iso,
+          "aperture": device.lensAperture,
+          "ev": device.exposureDuration.value,
+          "ev offset": device.exposureTargetOffset,
+          "white balance gains": device.deviceWhiteBalanceGains,
+          "shutterSpeed": device.exposureDuration.value,
+          "exposureBias": device.exposureTargetBias
+        ]
+        if !!change.newValue {
+          RNEventEmitter.emitter.sendEvent(withName: "onFinished", body: body)
+        }
+      }
+    }
   }
 
   // pragma MARK: Configure Format

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -232,8 +232,9 @@ extension CameraView {
           "shutterSpeed": device.exposureDuration.value,
           "exposureBias": device.exposureTargetBias
         ]
-        if !!change.newValue {
-          RNEventEmitter.emitter.sendEvent(withName: "onFinished", body: body)
+				if !Bool(change.newValue ?? false) {
+					ReactLogger.log(level: .info, message: "Sending event");
+					CameraEventEmitter.emitter.sendEvent(withName: "onChanged", body: body)
         }
       }
     }

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -57,6 +57,9 @@ public final class CameraView: UIView {
   @objc var lowLightBoost: NSNumber? // nullable bool
   @objc var colorSpace: NSString?
   @objc var orientation: NSString?
+  @objc var iso: NSNumber?
+  @objc var exposureTime: NSNumber?
+  @objc var cameraMode: NSString?
   // other props
   @objc var isActive = false
   @objc var torch = "off"
@@ -111,6 +114,9 @@ public final class CameraView: UIView {
   internal var actualFrameProcessorFps = 30.0
   internal var lastSuggestedFrameProcessorFps = 0.0
   internal var lastFrameProcessorPerformanceEvaluation = DispatchTime.now()
+
+  // CameraEventEmitter
+	internal var cameraObserver: NSKeyValueObservation!;
 
   /// Returns whether the AVCaptureSession is currently running (reflected by isActive)
   var isRunning: Bool {

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -10,6 +10,8 @@
 
 #import <React/RCTViewManager.h>
 #import <React/RCTUtils.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
 @interface RCT_EXTERN_REMAP_MODULE(CameraView, CameraViewManager, RCTViewManager)
 
@@ -51,6 +53,10 @@ RCT_EXPORT_VIEW_PROPERTY(onError, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onInitialized, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onFrameProcessorPerformanceSuggestionAvailable, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onViewReady, RCTDirectEventBlock);
+// Camera Event Emitter props
+RCT_EXPORT_VIEW_PROPERTY(iso, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(exposureTime, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(cameraMode, NSNumber);
 
 // Camera View Functions
 RCT_EXTERN_METHOD(startRecording:(nonnull NSNumber *)node options:(NSDictionary *)options onRecordCallback:(RCTResponseSenderBlock)onRecordCallback);
@@ -61,5 +67,11 @@ RCT_EXTERN_METHOD(takePhoto:(nonnull NSNumber *)node options:(NSDictionary *)opt
 RCT_EXTERN_METHOD(focus:(nonnull NSNumber *)node point:(NSDictionary *)point resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(getAvailableVideoCodecs:(nonnull NSNumber *)node fileType:(NSString *)fileType resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
+
+@end
+
+@interface RCT_EXTERN_MODULE(CameraEventEmitter, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(supportedEvents)
 
 @end

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -9,6 +9,11 @@ export interface FrameProcessorPerformanceSuggestion {
   suggestedFrameProcessorFps: number;
 }
 
+export enum CameraModeType {
+  AUTO = 'AUTO',
+  MANUAL = 'MANUAL'
+} 
+
 export interface CameraProps extends ViewProps {
   /**
    * The Camera Device to use.
@@ -209,4 +214,25 @@ export interface CameraProps extends ViewProps {
    */
   frameProcessorFps?: number | 'auto';
   //#endregion
+  /**
+   * Custom Props
+   */
+  /**
+   * Specifies a specific ISO value.
+   * 
+   * If the specified ISO is out of range of the Cameras' allowable range it will be automatically
+   * set nearest valid value.
+   */
+  iso?: Number;
+  /**
+   * Manually specify an exposure
+   */
+  exposureTime?: Number;
+  /**
+   * Sets the camera to 'AUTO' or 'MANUAL' mode. Defaults to 'AUTO'.
+   * 
+   * If the Camera is in auto-exposure mode the iso, exposure time and EV will be constantly updated.
+   * Updated values will be returned by the CameraView Event Emitter.
+   */
+  cameraMode?: CameraModeType;
 }


### PR DESCRIPTION

This PR fixes incorrect references to an old class name.

## Changes

- This PR moves event emitter set up to `CameraView+AVCaptureSession`
- - A new instance is created when the device is changed.

## Tested on
-  iPhone 13 Pro, iOS 16.0