### PR TITLE
fix: Fixed crash issue for video enabled in android devices

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -313,13 +313,13 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.2"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"
 
-  implementation "androidx.camera:camera-core:1.1.0-beta02"
-  implementation "androidx.camera:camera-camera2:1.1.0-beta02"
-  implementation "androidx.camera:camera-lifecycle:1.1.0-beta02"
-  implementation "androidx.camera:camera-video:1.1.0-beta02"
+  implementation "androidx.camera:camera-core:1.1.0"
+  implementation "androidx.camera:camera-camera2:1.1.0"
+  implementation "androidx.camera:camera-lifecycle:1.1.0"
+  implementation "androidx.camera:camera-video:1.1.0"
 
-  implementation "androidx.camera:camera-view:1.1.0-beta02"
-  implementation "androidx.camera:camera-extensions:1.1.0-beta02"
+  implementation "androidx.camera:camera-view:1.1.0"
+  implementation "androidx.camera:camera-extensions:1.1.0"
 
   implementation "androidx.exifinterface:exifinterface:1.3.3"
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

The plugin-used apps are crashing on Android devices while the video is enabled due to beta version usage of native android camera package.

## Changes

changed the package versions of camera from beta to stable.

## Tested on

Oppo Reno 7 5G, android 13

## Related issues

Fixes #1425
Closes #1425
Resolve #1425
