### PR TITLE
Replaced dynamic versioning of fbjni in build.gradle with version 4 e…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -290,9 +290,9 @@ dependencies {
 
     if (REACT_NATIVE_VERSION < 71) {
       //noinspection GradleDynamicVersion
-      extractHeaders("com.facebook.fbjni:fbjni:+:headers")
+      extractHeaders("com.facebook.fbjni:fbjni:0.4.0:headers")
       //noinspection GradleDynamicVersion
-      extractJNI("com.facebook.fbjni:fbjni:+")
+      extractJNI("com.facebook.fbjni:fbjni:0.4.0")
 
       def rnAarMatcher = "**/react-native/**/*${resolveBuildType()}.aar"
       if (REACT_NATIVE_VERSION < 69) {


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes the issue whereby all projects consuming this project right now are failing, due to fbjni releasing version 5.0. 

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

Fixes the dynamic import version of the fbjni dependency on android, explicitly depending on version 4. This fixes any consuming app that includes this library failing to build due to the following error: 

```sh
Could not find fbjni-0.5.0-headers.jar (com.facebook.fbjni:fbjni:0.5.0).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/com/facebook/fbjni/fbjni/0.5.0/fbjni-0.5.0-headers.jar
```


<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

This PR updates the import of fbjni within the build.gradle file to explicitly depend on version 4, rather than having a dynamic import, which just pulls in the latest version.

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

Google Pixel, Android 13.

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

Fixes #1664 
