### PR TITLE
fix: camera session is bound and idle on unmount [Android]

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -302,6 +302,10 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   }
 
   override fun onDetachedFromWindow() {
+    coroutineScope.launch {
+      val cameraProvider = ProcessCameraProvider.getInstance(reactContext).await()
+      cameraProvider.unbindAll()
+    }
     super.onDetachedFromWindow()
     updateLifecycleState()
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR fixes camera device and session resource cleanup when unmounted for Android devices.
<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes
Adds camera provider unbinding in `onDetachedFromWindow`.
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on
Samsung S10-S22, Samsung XCover Pro V3-6, Pixel 3a-6
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
Resolves #1685
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
