### PR TITLE
Try pixmaps

### DIFF
--- a/android/src/main/cpp/skia/SkiaRenderer.cpp
+++ b/android/src/main/cpp/skia/SkiaRenderer.cpp
@@ -245,11 +245,11 @@ void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer,
   SkImageInfo yInfo = SkImageInfo::MakeA8(_inputWidth, _inputHeight);
   SkPixmap yPixmap(yInfo, yBuffer.getDirectAddress(), bytesPerRow);
 
-  SkImageInfo uInfo = SkImageInfo::MakeA8(_inputWidth / 4, _inputHeight / 2);
-  SkPixmap uPixmap(uInfo, uBuffer.getDirectAddress(), bytesPerRow / 4);
+  SkImageInfo uInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
+  SkPixmap uPixmap(uInfo, uBuffer.getDirectAddress(), bytesPerRow / 2);
 
-  SkImageInfo vInfo = SkImageInfo::MakeA8(_inputWidth / 4, _inputHeight / 2);
-  SkPixmap vPixmap(vInfo, vBuffer.getDirectAddress(), bytesPerRow / 4);
+  SkImageInfo vInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
+  SkPixmap vPixmap(vInfo, vBuffer.getDirectAddress(), bytesPerRow / 2);
 
   SkYUVAInfo info(SkISize::Make(_inputWidth, _inputHeight),
                   SkYUVAInfo::PlaneConfig::kY_U_V,

--- a/android/src/main/cpp/skia/SkiaRenderer.cpp
+++ b/android/src/main/cpp/skia/SkiaRenderer.cpp
@@ -229,9 +229,9 @@ void SkiaRenderer::renderLatestFrameToPreview() {
 }
 
 
-void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, jni::JByteBuffer uBuffer, jni::JByteBuffer vBuffer) {
-  __android_log_print(ANDROID_LOG_INFO, TAG, "renderCameraFrameToOffscreenCanvas()");
-
+void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer,
+                                                      jni::JByteBuffer uBuffer,
+                                                      jni::JByteBuffer vBuffer) {
   ensureOpenGL(_previewSurface);
   if (_skiaContext == nullptr) {
     _skiaContext = GrDirectContext::MakeGL();
@@ -243,7 +243,6 @@ void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, 
                   SkYUVAInfo::Subsampling::k420,
                   SkYUVColorSpace::kRec709_Limited_SkYUVColorSpace);
   size_t bytesPerRow = sizeof(uint8_t) * _inputWidth;
-  __android_log_print(ANDROID_LOG_INFO, TAG, "Creating image... %i x %i @ %i bpr", _inputWidth, _inputHeight, bytesPerRow);
   SkYUVAPixmapInfo pixmapInfo(info, SkYUVAPixmapInfo::DataType::kUnorm8, &bytesPerRow);
 
   SkImageInfo yInfo = SkImageInfo::MakeA8(_inputWidth, _inputHeight);
@@ -258,10 +257,7 @@ void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, 
   SkPixmap externalPixmaps[3] = { yPixmap, uPixmap, vPixmap };
   SkYUVAPixmaps pixmaps = SkYUVAPixmaps::FromExternalPixmaps(info, externalPixmaps);
 
-  __android_log_print(ANDROID_LOG_INFO, TAG, "Got pixmaps! %i", pixmaps.isValid());
   sk_sp<SkImage> image = SkImages::TextureFromYUVAPixmaps(_skiaContext.get(), pixmaps);
-
-  __android_log_print(ANDROID_LOG_INFO, TAG, "Got image! %i x %i", image->width(), image->height());
 }
 
 

--- a/android/src/main/cpp/skia/SkiaRenderer.cpp
+++ b/android/src/main/cpp/skia/SkiaRenderer.cpp
@@ -229,7 +229,7 @@ void SkiaRenderer::renderLatestFrameToPreview() {
 }
 
 
-void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, jni::JByteBuffer uvBuffer) {
+void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, jni::JByteBuffer uBuffer, jni::JByteBuffer vBuffer) {
   __android_log_print(ANDROID_LOG_INFO, TAG, "renderCameraFrameToOffscreenCanvas()");
 
   ensureOpenGL(_previewSurface);
@@ -239,7 +239,7 @@ void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, 
   _skiaContext->resetContext();
 
   SkYUVAInfo info(SkISize::Make(_inputWidth, _inputHeight),
-                  SkYUVAInfo::PlaneConfig::kY_UV,
+                  SkYUVAInfo::PlaneConfig::kY_U_V,
                   SkYUVAInfo::Subsampling::k420,
                   SkYUVColorSpace::kRec709_Limited_SkYUVColorSpace);
   size_t bytesPerRow = sizeof(uint8_t) * _inputWidth;
@@ -249,10 +249,13 @@ void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, 
   SkImageInfo yInfo = SkImageInfo::MakeA8(_inputWidth, _inputHeight);
   SkPixmap yPixmap(yInfo, yBuffer.getDirectAddress(), bytesPerRow);
 
-  SkImageInfo uvInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
-  SkPixmap uvPixmap(uvInfo, uvBuffer.getDirectAddress(), bytesPerRow / 2);
+  SkImageInfo uInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
+  SkPixmap uPixmap(uInfo, uBuffer.getDirectAddress(), bytesPerRow / 2);
 
-  SkPixmap externalPixmaps[2] = { yPixmap, uvPixmap };
+  SkImageInfo vInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
+  SkPixmap vPixmap(vInfo, vBuffer.getDirectAddress(), bytesPerRow / 2);
+
+  SkPixmap externalPixmaps[3] = { yPixmap, uPixmap, vPixmap };
   SkYUVAPixmaps pixmaps = SkYUVAPixmaps::FromExternalPixmaps(info, externalPixmaps);
 
   __android_log_print(ANDROID_LOG_INFO, TAG, "Got pixmaps! %i", pixmaps.isValid());

--- a/android/src/main/cpp/skia/SkiaRenderer.cpp
+++ b/android/src/main/cpp/skia/SkiaRenderer.cpp
@@ -239,12 +239,7 @@ void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer,
   }
   _skiaContext->resetContext();
 
-  SkYUVAInfo info(SkISize::Make(_inputWidth, _inputHeight),
-                  SkYUVAInfo::PlaneConfig::kY_U_V,
-                  SkYUVAInfo::Subsampling::k420,
-                  SkYUVColorSpace::kRec709_Limited_SkYUVColorSpace);
   size_t bytesPerRow = sizeof(uint8_t) * _inputWidth;
-  SkYUVAPixmapInfo pixmapInfo(info, SkYUVAPixmapInfo::DataType::kUnorm8, &bytesPerRow);
 
   SkImageInfo yInfo = SkImageInfo::MakeA8(_inputWidth, _inputHeight);
   SkPixmap yPixmap(yInfo, yBuffer.getDirectAddress(), bytesPerRow);
@@ -255,6 +250,10 @@ void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer,
   SkImageInfo vInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
   SkPixmap vPixmap(vInfo, vBuffer.getDirectAddress(), bytesPerRow / 2);
 
+  SkYUVAInfo info(SkISize::Make(_inputWidth, _inputHeight),
+                  SkYUVAInfo::PlaneConfig::kY_U_V,
+                  SkYUVAInfo::Subsampling::k420,
+                  SkYUVColorSpace::kRec709_Limited_SkYUVColorSpace);
   SkPixmap externalPixmaps[3] = { yPixmap, uPixmap, vPixmap };
   SkYUVAPixmaps pixmaps = SkYUVAPixmaps::FromExternalPixmaps(info, externalPixmaps);
 

--- a/android/src/main/cpp/skia/SkiaRenderer.cpp
+++ b/android/src/main/cpp/skia/SkiaRenderer.cpp
@@ -239,16 +239,17 @@ void SkiaRenderer::renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer,
   }
   _skiaContext->resetContext();
 
+  // See https://en.wikipedia.org/wiki/Chroma_subsampling - we're in 4:2:0
   size_t bytesPerRow = sizeof(uint8_t) * _inputWidth;
 
   SkImageInfo yInfo = SkImageInfo::MakeA8(_inputWidth, _inputHeight);
   SkPixmap yPixmap(yInfo, yBuffer.getDirectAddress(), bytesPerRow);
 
-  SkImageInfo uInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
-  SkPixmap uPixmap(uInfo, uBuffer.getDirectAddress(), bytesPerRow / 2);
+  SkImageInfo uInfo = SkImageInfo::MakeA8(_inputWidth / 4, _inputHeight / 2);
+  SkPixmap uPixmap(uInfo, uBuffer.getDirectAddress(), bytesPerRow / 4);
 
-  SkImageInfo vInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
-  SkPixmap vPixmap(vInfo, vBuffer.getDirectAddress(), bytesPerRow / 2);
+  SkImageInfo vInfo = SkImageInfo::MakeA8(_inputWidth / 4, _inputHeight / 2);
+  SkPixmap vPixmap(vInfo, vBuffer.getDirectAddress(), bytesPerRow / 4);
 
   SkYUVAInfo info(SkISize::Make(_inputWidth, _inputHeight),
                   SkYUVAInfo::PlaneConfig::kY_U_V,

--- a/android/src/main/cpp/skia/SkiaRenderer.h
+++ b/android/src/main/cpp/skia/SkiaRenderer.h
@@ -6,6 +6,7 @@
 
 #include <jni.h>
 #include <fbjni/fbjni.h>
+#include <fbjni/ByteBuffer.h>
 
 #include <GLES2/gl2.h>
 #include <EGL/egl.h>
@@ -34,7 +35,6 @@ class SkiaRenderer: public jni::HybridClass<SkiaRenderer> {
 
  private:
   // Input Texture (Camera)
-  int prepareInputTexture();
   void setInputTextureSize(int width, int height);
   // Output Surface (Preview)
   void setOutputSurface(jobject previewSurface);
@@ -48,7 +48,7 @@ class SkiaRenderer: public jni::HybridClass<SkiaRenderer> {
   /**
    * Renders the latest Camera Frame into it's Input Texture and run the Skia Frame Processor (1..240 FPS)
    */
-  void renderCameraFrameToOffscreenCanvas();
+  void renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, jni::JByteBuffer uvBuffer);
 
  private:
   // OpenGL Context

--- a/android/src/main/cpp/skia/SkiaRenderer.h
+++ b/android/src/main/cpp/skia/SkiaRenderer.h
@@ -48,7 +48,7 @@ class SkiaRenderer: public jni::HybridClass<SkiaRenderer> {
   /**
    * Renders the latest Camera Frame into it's Input Texture and run the Skia Frame Processor (1..240 FPS)
    */
-  void renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, jni::JByteBuffer uvBuffer);
+  void renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, jni::JByteBuffer uBuffer, jni::JByteBuffer vBuffer);
 
  private:
   // OpenGL Context

--- a/android/src/main/cpp/skia/SkiaRenderer.h
+++ b/android/src/main/cpp/skia/SkiaRenderer.h
@@ -48,7 +48,9 @@ class SkiaRenderer: public jni::HybridClass<SkiaRenderer> {
   /**
    * Renders the latest Camera Frame into it's Input Texture and run the Skia Frame Processor (1..240 FPS)
    */
-  void renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer, jni::JByteBuffer uBuffer, jni::JByteBuffer vBuffer);
+  void renderCameraFrameToOffscreenCanvas(jni::JByteBuffer yBuffer,
+                                          jni::JByteBuffer uBuffer,
+                                          jni::JByteBuffer vBuffer);
 
  private:
   // OpenGL Context

--- a/android/src/main/java/com/mrousavy/camera/extensions/Handler+postAndWait.kt
+++ b/android/src/main/java/com/mrousavy/camera/extensions/Handler+postAndWait.kt
@@ -7,8 +7,7 @@ import java.util.concurrent.Semaphore
  * Posts a Message to this Handler and blocks the calling Thread until the Handler finished executing the given job.
  */
 fun Handler.postAndWait(job: () -> Unit) {
-  val semaphore = Semaphore(1)
-  semaphore.drainPermits()
+  val semaphore = Semaphore(0)
 
   this.post {
     try {

--- a/android/src/main/java/com/mrousavy/camera/extensions/Handler+postAndWait.kt
+++ b/android/src/main/java/com/mrousavy/camera/extensions/Handler+postAndWait.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.Semaphore
  */
 fun Handler.postAndWait(job: () -> Unit) {
   val semaphore = Semaphore(1)
-  semaphore.acquire()
+  semaphore.drainPermits()
 
   this.post {
     try {

--- a/android/src/main/java/com/mrousavy/camera/skia/SkiaPreviewView.kt
+++ b/android/src/main/java/com/mrousavy/camera/skia/SkiaPreviewView.kt
@@ -37,12 +37,12 @@ class SkiaPreviewView(context: Context,
 
   override fun surfaceCreated(holder: SurfaceHolder) {
     synchronized(this) {
-      isAlive = true
       Log.i(TAG, "onSurfaceCreated(..)")
 
       skiaRenderer.thread.postAndWait {
         // Create C++ part (OpenGL/Skia context)
         skiaRenderer.setPreviewSurface(holder.surface)
+        isAlive = true
 
         // Start updating the Preview View (~60 FPS)
         startLooping(Choreographer.getInstance())

--- a/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
+++ b/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
@@ -27,6 +27,7 @@ class SkiaRenderer: Closeable {
   private var hasNewFrame = false
 
   val thread = CameraQueues.previewQueue.handler
+  var hasOutputSurface = false
 
   init {
     mHybridData = initHybrid()
@@ -45,6 +46,7 @@ class SkiaRenderer: Closeable {
   fun setPreviewSurface(surface: Surface) {
     synchronized(this) {
       setOutputSurface(surface)
+      hasOutputSurface = true
     }
   }
 
@@ -57,6 +59,7 @@ class SkiaRenderer: Closeable {
   fun destroyPreviewSurface() {
     synchronized(this) {
       destroyOutputSurface()
+      hasOutputSurface = false
     }
   }
 
@@ -71,6 +74,7 @@ class SkiaRenderer: Closeable {
    */
   fun onCameraFrame(frame: Frame) {
     synchronized(this) {
+      if (!hasOutputSurface) return
       val (y, u, v) = frame.image.planes
       renderCameraFrameToOffscreenCanvas(y.buffer, u.buffer, v.buffer)
       hasNewFrame = true

--- a/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
+++ b/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
@@ -1,5 +1,6 @@
 package com.mrousavy.camera.skia
 
+import android.graphics.ImageFormat
 import android.view.Surface
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
@@ -63,6 +64,9 @@ class SkiaRenderer: Closeable {
   fun onCameraFrame(frame: Frame) {
     synchronized(this) {
       if (!hasOutputSurface) return
+      if (frame.image.format != ImageFormat.YUV_420_888) {
+        throw Error("Failed to render Camera Frame! Expected Image format #${ImageFormat.YUV_420_888} (ImageFormat.YUV_420_888), received #${frame.image.format}.")
+      }
       val (y, u, v) = frame.image.planes
       renderCameraFrameToOffscreenCanvas(y.buffer, u.buffer, v.buffer)
       hasNewFrame = true

--- a/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
+++ b/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
@@ -72,10 +72,12 @@ class SkiaRenderer: Closeable {
   fun onCameraFrame(frame: Frame) {
     synchronized(this) {
       val yBuffer = frame.image.planes[0].buffer
-      val uvBuffer = frame.image.planes[2].buffer
+      val uBuffer = frame.image.planes[1].buffer
+      val vBuffer = frame.image.planes[2].buffer
       Log.i(TAG, "Y Buffer: rowStride: ${frame.image.planes[0].rowStride} | pixelStride: ${frame.image.planes[0].pixelStride}")
-      Log.i(TAG, "UV Buffer: rowStride: ${frame.image.planes[2].rowStride} | pixelStride: ${frame.image.planes[2].pixelStride}")
-      renderCameraFrameToOffscreenCanvas(yBuffer, uvBuffer)
+      Log.i(TAG, "U Buffer: rowStride: ${frame.image.planes[1].rowStride} | pixelStride: ${frame.image.planes[1].pixelStride}")
+      Log.i(TAG, "V Buffer: rowStride: ${frame.image.planes[2].rowStride} | pixelStride: ${frame.image.planes[2].pixelStride}")
+      renderCameraFrameToOffscreenCanvas(yBuffer, uBuffer, vBuffer)
       hasNewFrame = true
     }
   }
@@ -92,7 +94,7 @@ class SkiaRenderer: Closeable {
 
   private external fun initHybrid(): HybridData
 
-  private external fun renderCameraFrameToOffscreenCanvas(yBuffer: ByteBuffer, uvBuffer: ByteBuffer)
+  private external fun renderCameraFrameToOffscreenCanvas(yBuffer: ByteBuffer, uBuffer: ByteBuffer, vBuffer: ByteBuffer)
   private external fun renderLatestFrameToPreview()
   private external fun setInputTextureSize(width: Int, height: Int)
   private external fun setOutputSurface(surface: Any)

--- a/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
+++ b/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
@@ -1,33 +1,21 @@
 package com.mrousavy.camera.skia
 
-import android.graphics.SurfaceTexture
-import android.os.Build
-import android.os.Looper
-import android.util.Log
 import android.view.Surface
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
-import com.mrousavy.camera.CameraError
 import com.mrousavy.camera.CameraQueues
-import com.mrousavy.camera.UnknownCameraError
 import com.mrousavy.camera.frameprocessor.Frame
 import java.io.Closeable
-import java.lang.RuntimeException
 import java.nio.ByteBuffer
-import java.util.concurrent.locks.ReentrantLock
 
 @Suppress("KotlinJniMissingFunction")
 class SkiaRenderer: Closeable {
-  companion object {
-    private const val TAG = "SkiaRenderer"
-  }
-
   @DoNotStrip
   private var mHybridData: HybridData
   private var hasNewFrame = false
+  private var hasOutputSurface = false
 
   val thread = CameraQueues.previewQueue.handler
-  var hasOutputSurface = false
 
   init {
     mHybridData = initHybrid()
@@ -86,6 +74,8 @@ class SkiaRenderer: Closeable {
    */
   fun onPreviewFrame() {
     synchronized(this) {
+      if (!hasOutputSurface) return
+      if (!hasNewFrame) return
       renderLatestFrameToPreview()
       hasNewFrame = false
     }

--- a/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
+++ b/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
@@ -10,8 +10,10 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.mrousavy.camera.CameraError
 import com.mrousavy.camera.CameraQueues
 import com.mrousavy.camera.UnknownCameraError
+import com.mrousavy.camera.frameprocessor.Frame
 import java.io.Closeable
 import java.lang.RuntimeException
+import java.nio.ByteBuffer
 import java.util.concurrent.locks.ReentrantLock
 
 @Suppress("KotlinJniMissingFunction")
@@ -19,40 +21,21 @@ class SkiaRenderer: Closeable {
   companion object {
     private const val TAG = "SkiaRenderer"
   }
-  data class InputTexture(var isAttached: Boolean, val surfaceTexture: SurfaceTexture, val surface: Surface)
 
   @DoNotStrip
   private var mHybridData: HybridData
   private var hasNewFrame = false
-  private val inputTexture: InputTexture
-
-  val inputSurface: Surface
-    get() = inputTexture.surface
 
   val thread = CameraQueues.previewQueue.handler
 
   init {
     mHybridData = initHybrid()
-
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      throw Error("VisionCamera Skia integration is only available on Android API 26 and above!")
-    }
-
-    val surfaceTexture = SurfaceTexture(false)
-    surfaceTexture.setOnFrameAvailableListener({ texture ->
-      onCameraFrame(texture)
-    }, thread)
-    val surface = Surface(surfaceTexture)
-    inputTexture = InputTexture(false, surfaceTexture, surface)
   }
 
   override fun close() {
     hasNewFrame = false
     thread.post {
       synchronized(this) {
-        if (inputTexture.isAttached) detachInputTexture()
-        inputTexture.surface.release()
-        inputTexture.surfaceTexture.release()
         destroyOutputSurface()
         mHybridData.resetNative()
       }
@@ -61,7 +44,6 @@ class SkiaRenderer: Closeable {
 
   fun setPreviewSurface(surface: Surface) {
     synchronized(this) {
-      if (inputTexture.isAttached) detachInputTexture()
       setOutputSurface(surface)
     }
   }
@@ -74,7 +56,6 @@ class SkiaRenderer: Closeable {
 
   fun destroyPreviewSurface() {
     synchronized(this) {
-      if (inputTexture.isAttached) detachInputTexture()
       destroyOutputSurface()
     }
   }
@@ -88,11 +69,13 @@ class SkiaRenderer: Closeable {
   /**
    * Called on every Camera Frame (1..240 FPS)
    */
-  private fun onCameraFrame(texture: SurfaceTexture) {
+  fun onCameraFrame(frame: Frame) {
     synchronized(this) {
-      if (!inputTexture.isAttached) return
-      texture.updateTexImage()
-      renderCameraFrameToOffscreenCanvas()
+      val yBuffer = frame.image.planes[0].buffer
+      val uvBuffer = frame.image.planes[2].buffer
+      Log.i(TAG, "Y Buffer: rowStride: ${frame.image.planes[0].rowStride} | pixelStride: ${frame.image.planes[0].pixelStride}")
+      Log.i(TAG, "UV Buffer: rowStride: ${frame.image.planes[2].rowStride} | pixelStride: ${frame.image.planes[2].pixelStride}")
+      renderCameraFrameToOffscreenCanvas(yBuffer, uvBuffer)
       hasNewFrame = true
     }
   }
@@ -102,30 +85,15 @@ class SkiaRenderer: Closeable {
    */
   fun onPreviewFrame() {
     synchronized(this) {
-      if (!inputTexture.isAttached) attachInputTexture()
       renderLatestFrameToPreview()
       hasNewFrame = false
     }
   }
 
-  private fun detachInputTexture() {
-    Log.i(TAG, "Detaching input Surface from OpenGL Context...")
-    inputTexture.surfaceTexture.detachFromGLContext()
-    inputTexture.isAttached = false
-  }
-
-  private fun attachInputTexture() {
-    Log.i(TAG, "Attaching input Surface to OpenGL Context...")
-    val glTextureId = prepareInputTexture()
-    inputTexture.surfaceTexture.attachToGLContext(glTextureId)
-    inputTexture.isAttached = true
-  }
-
   private external fun initHybrid(): HybridData
 
-  private external fun renderCameraFrameToOffscreenCanvas()
+  private external fun renderCameraFrameToOffscreenCanvas(yBuffer: ByteBuffer, uvBuffer: ByteBuffer)
   private external fun renderLatestFrameToPreview()
-  private external fun prepareInputTexture(): Int
   private external fun setInputTextureSize(width: Int, height: Int)
   private external fun setOutputSurface(surface: Any)
   private external fun setOutputSurfaceSize(width: Int, height: Int)

--- a/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
+++ b/android/src/main/java/com/mrousavy/camera/skia/SkiaRenderer.kt
@@ -71,13 +71,8 @@ class SkiaRenderer: Closeable {
    */
   fun onCameraFrame(frame: Frame) {
     synchronized(this) {
-      val yBuffer = frame.image.planes[0].buffer
-      val uBuffer = frame.image.planes[1].buffer
-      val vBuffer = frame.image.planes[2].buffer
-      Log.i(TAG, "Y Buffer: rowStride: ${frame.image.planes[0].rowStride} | pixelStride: ${frame.image.planes[0].pixelStride}")
-      Log.i(TAG, "U Buffer: rowStride: ${frame.image.planes[1].rowStride} | pixelStride: ${frame.image.planes[1].pixelStride}")
-      Log.i(TAG, "V Buffer: rowStride: ${frame.image.planes[2].rowStride} | pixelStride: ${frame.image.planes[2].pixelStride}")
-      renderCameraFrameToOffscreenCanvas(yBuffer, uBuffer, vBuffer)
+      val (y, u, v) = frame.image.planes
+      renderCameraFrameToOffscreenCanvas(y.buffer, u.buffer, v.buffer)
       hasNewFrame = true
     }
   }
@@ -94,7 +89,9 @@ class SkiaRenderer: Closeable {
 
   private external fun initHybrid(): HybridData
 
-  private external fun renderCameraFrameToOffscreenCanvas(yBuffer: ByteBuffer, uBuffer: ByteBuffer, vBuffer: ByteBuffer)
+  private external fun renderCameraFrameToOffscreenCanvas(yBuffer: ByteBuffer,
+                                                          uBuffer: ByteBuffer,
+                                                          vBuffer: ByteBuffer)
   private external fun renderLatestFrameToPreview()
   private external fun setInputTextureSize(width: Int, height: Int)
   private external fun setOutputSurface(surface: Any)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Implements Frame rendering by creating `ByteBuffer` Pixmaps.

Before in the Camera2 Rewrite I attempted multiple things to draw the Camera Frame to the Skia Preview View:

### OpenGL Texture

1. Create an OpenGL Texture (`glGenTextures`)
2. Wrap that in a `SurfaceTexture(..)` and add an onFrameAvailable listener
3. Wrap the `SurfaceTexture` in a `Surface(..)`
4. Pass that `Surface` to the Camera & start it

The Camera was able to write Frames to that Surface, and I could perfectly get the Camera Frame from the Surface and create an `SkImage` from it (`AdoptFromBackendTextures` w/ the OpenGL texture ID)

The problem here was that I no longer had the `android.media.Image` as that is coming from the `ImageReader` which itself has to be attached to the Camera directly, so I could draw to Skia but I couldn't call the JS Frame Processor because that expects an `Image` parameter.

### ImageReader HardwareBuffer

Back to the original ImageReader approach;

1. Create `ImageReader.newInstance(1280, 720, YUV_420_888)`
2. Add an `onImageAvailableListener` which sends me an `Image` instance
3. I then access the `Image.hardwareBuffer` property and send that to native (`AHardwareBuffer*`)
4. I then try to create an `SkImage` by using the `SkImages::DeferredFromAHardwareBuffer(..)` function

Turns out, this function is only available on Android API 26. Usually this wouldn't be a problem, I can just make Skia Frame Processors require API 26 and throw if the phone isn't on 26, but since this is in Skia C++ NDK sources, this is compiled into the `libskia.so` binary. Since it's compiled, you can't have such version checks and you would need to recompile with API 26 - in other words; this would require react-native-skia to have **min**Sdk set to 26, not **compile**Sdk. We're currently on minSdk 21, so until we're on minSdk 26 it'll take a few years I guess.

### ImageReader try reading from Surface

Instead of accessing the HardwareBuffer, I thought let's just access the `Surface` from the `ImageReader` directly (`ANativeWindow*`).

Since OpenGL only allows you to attach a Surface to one Context, this didn't work and just crashes. Also it's probably not a good idea since ImageReader probably uses double buffering and the Surface is not safe to access.

### ImageReader planes (this is the approach in this PR)

Same as with the ImageReader HardwareBuffer approach:

1. Create `ImageReader.newInstance(1280, 720, YUV_420_888)`
2. Add an `onImageAvailableListener` which sends me an `Image` instance
3. I then access the `Image.planes` properties: `[0]` for Y, `[1]` for U and `[2]` V buffer.
4. I send the three `ByteBuffer`s to native - luckily without a copy since those are direct buffers that can be accessed directly from C++
5. I now create an `SkImage` from a `SkYUVAPixmap`:

```cpp
// See https://en.wikipedia.org/wiki/Chroma_subsampling - we're in 4:2:0
size_t bytesPerRow = sizeof(uint8_t) * _inputWidth;

SkImageInfo yInfo = SkImageInfo::MakeA8(_inputWidth, _inputHeight);
SkPixmap yPixmap(yInfo, yBuffer.getDirectAddress(), bytesPerRow);

SkImageInfo uInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
SkPixmap uPixmap(uInfo, uBuffer.getDirectAddress(), bytesPerRow / 2);

SkImageInfo vInfo = SkImageInfo::MakeA8(_inputWidth / 2, _inputHeight / 2);
SkPixmap vPixmap(vInfo, vBuffer.getDirectAddress(), bytesPerRow / 2);

SkYUVAInfo info(SkISize::Make(_inputWidth, _inputHeight),
              SkYUVAInfo::PlaneConfig::kY_U_V,
              SkYUVAInfo::Subsampling::k420,
              SkYUVColorSpace::kRec709_Limited_SkYUVColorSpace);
SkPixmap externalPixmaps[3] = { yPixmap, uPixmap, vPixmap };
SkYUVAPixmaps pixmaps = SkYUVAPixmaps::FromExternalPixmaps(info, externalPixmaps);

sk_sp<SkImage> image = SkImages::TextureFromYUVAPixmaps(_skiaContext.get(), pixmaps);
```

This only works for YUV 4:2:0 Frames, I haven't tested this on NV21 frames yet - also not sure if it needs to work for any other frames or if YUV 4:2:0 works on every device anyways.

##### YUV 4:2:0 Conversion 

On the Simulator this breaks for some reason. No idea why, maybe the width/height calculation is off? Is it `/ 2` or `/ 4`? Still figuring that part out...

Those are the individual planes:

```
Image.planes.y: { width: 1280, pixelStride: 1, rowStride: 1280, bufferSize: 921600 }
Image.planes.u: { width: 640, pixelStride: 1, rowStride: 620, bufferSize: 230400 }
Image.planes.v: { width: 640, pixelStride: 1, rowStride: 620, bufferSize: 230400 }
```

..from that, you can calculate that the height for Y is 720 and for U+V it's 360.

For YUV it's always 3 separate buffers. For NV21 it would be two interleaved buffers probably. And the size is a 4th of the Y size, so it needs to be width / 2 and height / 2 afaik. cc @thomas-coldwell maybe you know more

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
