### PR TITLE
feat: Add `enableShutterSound` prop to `takePhoto()` 🔊

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraSession.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraSession.kt
@@ -178,6 +178,7 @@ class CameraSession(private val context: Context,
 
   suspend fun takePhoto(qualityPrioritization: QualityPrioritization,
                         flashMode: Flash,
+                        enableShutterSound: Boolean,
                         enableRedEyeReduction: Boolean,
                         enableAutoStabilization: Boolean,
                         outputOrientation: Orientation): CapturedPhoto {
@@ -197,7 +198,7 @@ class CameraSession(private val context: Context,
                                                                          enableAutoStabilization,
                                                                          orientation)
     Log.i(TAG, "Photo capture 0/2 - starting capture...")
-    val result = captureSession.capture(captureRequest)
+    val result = captureSession.capture(captureRequest, enableShutterSound)
     val timestamp = result[CaptureResult.SENSOR_TIMESTAMP]!!
     Log.i(TAG, "Photo capture 1/2 complete - received metadata with timestamp $timestamp")
     try {

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -30,12 +30,14 @@ suspend fun CameraView.takePhoto(optionsMap: ReadableMap): WritableMap {
   val flash = options["flash"] as? String ?: "off"
   val enableAutoRedEyeReduction = options["enableAutoRedEyeReduction"] == true
   val enableAutoStabilization = options["enableAutoStabilization"] == true
+  val enableShutterSound = options["enableShutterSound"] as? Boolean ?: true
 
   val flashMode = Flash.fromUnionValue(flash)
   val qualityPrioritizationMode = QualityPrioritization.fromUnionValue(qualityPrioritization)
 
   val photo = cameraSession.takePhoto(qualityPrioritizationMode,
                                       flashMode,
+                                      enableShutterSound,
                                       enableAutoRedEyeReduction,
                                       enableAutoStabilization,
                                       outputOrientation)

--- a/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+capture.kt
+++ b/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+capture.kt
@@ -4,6 +4,7 @@ import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CaptureFailure
 import android.hardware.camera2.CaptureRequest
 import android.hardware.camera2.TotalCaptureResult
+import android.media.MediaActionSound
 import com.mrousavy.camera.CameraQueues
 import com.mrousavy.camera.CaptureAbortedError
 import com.mrousavy.camera.UnknownCaptureError
@@ -11,7 +12,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
-suspend fun CameraCaptureSession.capture(captureRequest: CaptureRequest): TotalCaptureResult {
+suspend fun CameraCaptureSession.capture(captureRequest: CaptureRequest, enableShutterSound: Boolean): TotalCaptureResult {
   return suspendCoroutine { continuation ->
     this.capture(captureRequest, object: CameraCaptureSession.CaptureCallback() {
       override fun onCaptureCompleted(
@@ -20,7 +21,17 @@ suspend fun CameraCaptureSession.capture(captureRequest: CaptureRequest): TotalC
         result: TotalCaptureResult
       ) {
         super.onCaptureCompleted(session, request, result)
+
         continuation.resume(result)
+      }
+
+      override fun onCaptureStarted(session: CameraCaptureSession, request: CaptureRequest, timestamp: Long, frameNumber: Long) {
+        super.onCaptureStarted(session, request, timestamp, frameNumber)
+
+        if (enableShutterSound) {
+          val mediaActionSound = MediaActionSound()
+          mediaActionSound.play(MediaActionSound.SHUTTER_CLICK)
+        }
       }
 
       override fun onCaptureFailed(

--- a/example/src/views/CaptureButton.tsx
+++ b/example/src/views/CaptureButton.tsx
@@ -64,6 +64,7 @@ const _CaptureButton: React.FC<Props> = ({
       qualityPrioritization: 'speed',
       flash: flash,
       quality: 90,
+      enableShutterSound: false,
     }),
     [flash],
   );

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -44,6 +44,9 @@ extension CameraView {
         }
         photoSettings.flashMode = flashMode
       }
+      
+      // shutter sound
+      let enableShutterSound = options["enableShutterSound"] as? Bool ?? true
 
       // depth data
       photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
@@ -75,7 +78,7 @@ extension CameraView {
         photoSettings.isAutoContentAwareDistortionCorrectionEnabled = enableAutoDistortionCorrection
       }
 
-      photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise))
+      photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise, enableShutterSound: enableShutterSound))
 
       // Assume that `takePhoto` is always called with the same parameters, so prepare the next call too.
       photoOutput.setPreparedPhotoSettingsArray([photoSettings], completionHandler: nil)

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -44,7 +44,7 @@ extension CameraView {
         }
         photoSettings.flashMode = flashMode
       }
-      
+
       // shutter sound
       let enableShutterSound = options["enableShutterSound"] as? Bool ?? true
 

--- a/ios/PhotoCaptureDelegate.swift
+++ b/ios/PhotoCaptureDelegate.swift
@@ -22,8 +22,8 @@ class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
     super.init()
     delegatesReferences.append(self)
   }
-  
-  func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+
+  func photoOutput(_: AVCapturePhotoOutput, willCapturePhotoFor _: AVCaptureResolvedPhotoSettings) {
     if !enableShutterSound {
       // disable system shutter sound (see https://stackoverflow.com/a/55235949/5281431)
       AudioServicesDisposeSystemSoundID(1108)

--- a/ios/PhotoCaptureDelegate.swift
+++ b/ios/PhotoCaptureDelegate.swift
@@ -14,11 +14,20 @@ private var delegatesReferences: [NSObject] = []
 
 class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
   private let promise: Promise
+  private let enableShutterSound: Bool
 
-  required init(promise: Promise) {
+  required init(promise: Promise, enableShutterSound: Bool) {
     self.promise = promise
+    self.enableShutterSound = enableShutterSound
     super.init()
     delegatesReferences.append(self)
+  }
+  
+  func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+    if !enableShutterSound {
+      // disable system shutter sound (see https://stackoverflow.com/a/55235949/5281431)
+      AudioServicesDisposeSystemSoundID(1108)
+    }
   }
 
   func photoOutput(_: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {

--- a/src/PhotoFile.ts
+++ b/src/PhotoFile.ts
@@ -38,6 +38,12 @@ export interface TakePhotoOptions {
    * @default false
    */
   enableAutoDistortionCorrection?: boolean;
+  /**
+   * Whether to play the default shutter "click" sound when taking a picture or not.
+   *
+   * @default true
+   */
+  enableShutterSound?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds option to control the shutter sound on both iOS and Android to the `takePhoto(..)` function.

Default value is `true`. 

This will play:

- [`MediaActionSound.SHUTTER_CLICK`](https://developer.android.com/reference/android/media/MediaActionSound#SHUTTER_CLICK) on Android
- [`photoShutter.caf` (1108)](https://github.com/TUNER88/iOSSystemSoundsLibrary#list-of-systemsoundids) on iOS

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* resolves https://github.com/mrousavy/react-native-vision-camera/issues/1044
* resolves https://github.com/mrousavy/react-native-vision-camera/issues/311
* resolves https://github.com/mrousavy/react-native-vision-camera/issues/713
* resolves https://github.com/mrousavy/react-native-vision-camera/issues/565

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
