### PR TITLE
feat: Faster `toArrayBuffer()` with `AHardwareBuffer`s :fire:

### DIFF
--- a/android/src/main/cpp/java-bindings/JFrame.cpp
+++ b/android/src/main/cpp/java-bindings/JFrame.cpp
@@ -6,6 +6,9 @@
 
 #include <jni.h>
 #include <fbjni/fbjni.h>
+#include <fbjni/ByteBuffer.h>
+#include <android/hardware_buffer.h>
+#include <android/hardware_buffer_jni.h>
 
 namespace vision {
 
@@ -61,6 +64,11 @@ local_ref<JByteBuffer> JFrame::toByteBuffer() const {
   static const auto toByteBufferMethod = getClass()->getMethod<JByteBuffer()>("toByteBuffer");
   return toByteBufferMethod(self());
 }
+
+AHardwareBuffer* JFrame::getHardwareBuffer() const {
+  static const auto getHardwareBufferMethod = getClass()->getMethod<jobject()>("getHardwareBuffer");
+  auto boxed = getHardwareBufferMethod(self());
+  return AHardwareBuffer_fromHardwareBuffer(jni::Environment::current(), boxed.get());
 }
 
 void JFrame::incrementRefCount() {

--- a/android/src/main/cpp/java-bindings/JFrame.h
+++ b/android/src/main/cpp/java-bindings/JFrame.h
@@ -6,6 +6,8 @@
 
 #include <jni.h>
 #include <fbjni/fbjni.h>
+#include <fbjni/ByteBuffer.h>
+#include <android/hardware_buffer.h>
 
 namespace vision {
 
@@ -26,6 +28,7 @@ struct JFrame : public JavaClass<JFrame> {
   local_ref<JString> getOrientation() const;
   local_ref<JString> getPixelFormat() const;
   local_ref<JByteBuffer> toByteBuffer() const;
+  AHardwareBuffer* getHardwareBuffer() const;
   void incrementRefCount();
   void decrementRefCount();
   void close();

--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
@@ -1,7 +1,12 @@
 package com.mrousavy.camera.frameprocessor;
 
 import android.graphics.ImageFormat;
+import android.hardware.HardwareBuffer;
 import android.media.Image;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.mrousavy.camera.parsers.PixelFormat;
 import com.mrousavy.camera.parsers.Orientation;
@@ -14,6 +19,7 @@ public class Frame {
     private final long timestamp;
     private final Orientation orientation;
     private int refCount = 0;
+    private HardwareBuffer hardwareBuffer;
 
     public Frame(Image image, long timestamp, Orientation orientation, boolean isMirrored) {
         this.image = image;
@@ -89,6 +95,17 @@ public class Frame {
         return image.getPlanes()[0].getRowStride();
     }
 
+    @SuppressWarnings("unused")
+    @DoNotStrip
+    public Object getHardwareBuffer() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            if (hardwareBuffer == null) hardwareBuffer = image.getHardwareBuffer();
+            return hardwareBuffer;
+        } else {
+            throw new RuntimeException("Hardware Buffers are only available on Android API 28 or above!");
+        }
+    }
+
     private static ByteBuffer byteArrayCache;
 
     @SuppressWarnings("unused")
@@ -143,5 +160,6 @@ public class Frame {
     @DoNotStrip
     private void close() {
         image.close();
+        if (hardwareBuffer != null) hardwareBuffer.close();
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 26
         compileSdkVersion = 33
         targetSdkVersion = 33
         ndkVersion = "23.1.7779620"


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR replaces the old `byte[]`/`ByteBuffer` implementation of `frame.toArrayBuffer()` with a new HardwareBuffer approach.

The HardwareBuffer approach should be faster since Hardware Buffers point to the raw GPU memory, and also more flexible as they are able to read in any format.

Previously only RGB and YUV were supported, now also PRIVATE formats are supported. (PRIVATE is the default format of a Camera)

Blockers:

- Requires **min**Sdk 26 (not **compile**Sdk 26)
- For some reason it's 5x slower. I think I'm doing something wrong.

### Benchmarks


With plain old `byte[]` (YUV):

```
LOG 'frame.toArrayBuffer() took 4.8647690042853355ms Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 5.287000000476837ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 2.7955000028014183ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 10.20465400069952ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 2.826884001493454ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 8.763691999018192ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 3.183499999344349ms! Buffer: 1280x720 (2.7MB)'
```

With direct `ByteBuffer` (YUV):

```
LOG 'frame.toArrayBuffer() took 3.5782300010323524ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 7.583999998867512ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 3.6786149963736534ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 8.754384003579617ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 3.7007689997553825ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 12.17653900384903ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 3.8979609981179237ms! Buffer: 1280x720 (2.7MB)'
```

With `HardwareBuffer` (PRIVATE):

```
LOG 'frame.toArrayBuffer() took 22.618268996477127ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 22.58872999995947ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 22.458115004003048ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 23.559306994080544ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 17.347346000373363ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 1.958115004003048ms! Buffer: 1280x720 (2.7MB)'
LOG 'frame.toArrayBuffer() took 25.279076002538204ms! Buffer: 1280x720 (2.7MB)'
```

 I get a lot of these logs: `LOG mali_gralloc_lock:335 Buffers with YUV compatible formats should be locked using GRALLOC1_FUNCTION_LOCK_FLEX. Requested format is:0x22`

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
