### PR TITLE
feat: Faster cached CameraDevice access

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraSession.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraSession.kt
@@ -31,6 +31,7 @@ import com.mrousavy.camera.parsers.QualityPrioritization
 import com.mrousavy.camera.parsers.VideoCodec
 import com.mrousavy.camera.parsers.VideoFileType
 import com.mrousavy.camera.parsers.VideoStabilizationMode
+import com.mrousavy.camera.utils.CameraDeviceDetails
 import com.mrousavy.camera.utils.PhotoOutputSynchronizer
 import com.mrousavy.camera.utils.RecordingSession
 import com.mrousavy.camera.utils.outputs.CameraOutputs
@@ -64,7 +65,7 @@ class CameraSession(private val context: Context,
   }
 
   // setInput(..)
-  private var cameraId: String? = null
+  private var cameraDeviceDetails: CameraDeviceDetails? = null
 
   // setOutputs(..)
   private var outputs: CameraOutputs? = null
@@ -107,30 +108,25 @@ class CameraSession(private val context: Context,
   }
 
   val orientation: Orientation
-    get() {
-      val cameraId = cameraId ?: return Orientation.PORTRAIT
-      val characteristics = cameraManager.getCameraCharacteristics(cameraId)
-      val sensorRotation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
-      return Orientation.fromRotationDegrees(sensorRotation)
-    }
+    get() = cameraDeviceDetails?.orientation ?: Orientation.PORTRAIT
 
-  fun configureSession(cameraId: String,
+  fun configureSession(cameraDeviceDetails: CameraDeviceDetails,
                        preview: CameraOutputs.PreviewOutput? = null,
                        photo: CameraOutputs.PhotoOutput? = null,
                        video: CameraOutputs.VideoOutput? = null) {
-    Log.i(TAG, "Configuring Session for Camera $cameraId...")
-    val outputs = CameraOutputs(cameraId,
+    Log.i(TAG, "Configuring Session for Camera $cameraDeviceDetails...")
+    val outputs = CameraOutputs(cameraDeviceDetails,
       cameraManager,
       preview,
       photo,
       video,
       hdr == true,
       this)
-    if (this.cameraId == cameraId && this.outputs == outputs && isActive == isRunning) {
+    if (this.cameraDeviceDetails == cameraDeviceDetails && this.outputs == outputs && isActive == isRunning) {
       Log.i(TAG, "Nothing changed in configuration, canceling..")
     }
 
-    this.cameraId = cameraId
+    this.cameraDeviceDetails = cameraDeviceDetails
     this.outputs = outputs
     launch {
       startRunning()

--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -23,6 +23,7 @@ private const val TAG = "CameraView.takePhoto"
 
 @SuppressLint("UnsafeOptInUsageError")
 suspend fun CameraView.takePhoto(optionsMap: ReadableMap): WritableMap {
+  val cameraDevice = cameraDevice ?: throw NoCameraDeviceError()
   val options = optionsMap.toHashMap()
   Log.i(TAG, "Taking photo... Options: $options")
 
@@ -45,9 +46,7 @@ suspend fun CameraView.takePhoto(optionsMap: ReadableMap): WritableMap {
   photo.use {
     Log.i(TAG, "Successfully captured ${photo.image.width} x ${photo.image.height} photo!")
 
-    val cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId!!)
-
-    val path = savePhotoToFile(context, cameraCharacteristics, photo)
+    val path = savePhotoToFile(context, cameraDevice, photo)
 
     Log.i(TAG, "Successfully saved photo to file! $path")
 
@@ -76,7 +75,7 @@ private fun writeImageToStream(imageBytes: ByteArray, stream: OutputStream, isMi
 }
 
 private suspend fun savePhotoToFile(context: Context,
-                                    cameraCharacteristics: CameraCharacteristics,
+                                    cameraDevice: CameraDeviceDetails,
                                     photo: CameraSession.CapturedPhoto): String {
   return withContext(Dispatchers.IO) {
     when (photo.format) {

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -24,6 +24,7 @@ import com.mrousavy.camera.parsers.Torch
 import com.mrousavy.camera.parsers.VideoStabilizationMode
 import com.mrousavy.camera.skia.SkiaPreviewView
 import com.mrousavy.camera.skia.SkiaRenderer
+import com.mrousavy.camera.utils.CameraDeviceDetails
 import com.mrousavy.camera.utils.outputs.CameraOutputs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -91,6 +92,12 @@ class CameraView(context: Context) : FrameLayout(context) {
   internal val cameraSession: CameraSession
   private var previewView: View? = null
   private var previewSurface: Surface? = null
+  internal var cameraDevice: CameraDeviceDetails? = null
+    get() {
+      val cameraId = cameraId ?: return null
+      if (field?.cameraId != cameraId) field = CameraDeviceDetails(cameraManager, cameraId)
+      return field
+    }
 
   private var skiaRenderer: SkiaRenderer? = null
   internal var frameProcessor: FrameProcessor? = null

--- a/android/src/main/java/com/mrousavy/camera/extensions/DynamicRangeProfiles+bestProfile.kt
+++ b/android/src/main/java/com/mrousavy/camera/extensions/DynamicRangeProfiles+bestProfile.kt
@@ -21,7 +21,7 @@ private val bestProfiles = setOf(
 )
 
 val DynamicRangeProfiles.bestProfile: Long?
-  @RequiresApi(Build.VERSION_CODES.TIRAMISU)
   get() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
     return supportedProfiles.firstMatch(bestProfiles)
   }

--- a/android/src/main/java/com/mrousavy/camera/utils/outputs/CameraOutputs.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/outputs/CameraOutputs.kt
@@ -14,9 +14,10 @@ import com.mrousavy.camera.extensions.closestToOrMax
 import com.mrousavy.camera.extensions.getPhotoSizes
 import com.mrousavy.camera.extensions.getPreviewSize
 import com.mrousavy.camera.extensions.getVideoSizes
+import com.mrousavy.camera.utils.CameraDeviceDetails
 import java.io.Closeable
 
-class CameraOutputs(val cameraId: String,
+class CameraOutputs(val cameraDeviceDetails: CameraDeviceDetails,
                     cameraManager: CameraManager,
                     val preview: PreviewOutput? = null,
                     val photo: PhotoOutput? = null,
@@ -60,7 +61,7 @@ class CameraOutputs(val cameraId: String,
 
   override fun equals(other: Any?): Boolean {
     if (other !is CameraOutputs) return false
-    return this.cameraId == other.cameraId
+    return this.cameraDeviceDetails == other.cameraDeviceDetails
       && this.preview?.surface == other.preview?.surface
       && this.photo?.targetSize == other.photo?.targetSize
       && this.photo?.format == other.photo?.format
@@ -71,7 +72,7 @@ class CameraOutputs(val cameraId: String,
   }
 
   override fun hashCode(): Int {
-    var result = cameraId.hashCode()
+    var result = cameraDeviceDetails.hashCode()
     result += (preview?.hashCode() ?: 0)
     result += (photo?.hashCode() ?: 0)
     result += (video?.hashCode() ?: 0)
@@ -92,9 +93,7 @@ class CameraOutputs(val cameraId: String,
   }
 
   init {
-    val characteristics = cameraManager.getCameraCharacteristics(cameraId)
-
-    Log.i(TAG, "Preparing Outputs for Camera $cameraId...")
+    Log.i(TAG, "Preparing Outputs for Camera $cameraDeviceDetails...")
 
     // Preview output: Low resolution repeating images (SurfaceView)
     if (preview != null) {

--- a/android/src/main/java/com/mrousavy/camera/utils/outputs/SurfaceOutput.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/outputs/SurfaceOutput.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.util.Size
 import android.view.Surface
 import androidx.annotation.RequiresApi
+import com.mrousavy.camera.utils.CameraDeviceDetails
 import java.io.Closeable
 
 /**
@@ -20,30 +21,17 @@ open class SurfaceOutput(val surface: Surface,
                          private val closeSurfaceOnEnd: Boolean = false): Closeable {
   companion object {
     const val TAG = "SurfaceOutput"
-
-    private fun supportsOutputType(characteristics: CameraCharacteristics, outputType: OutputType): Boolean {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        val availableUseCases = characteristics.get(CameraCharacteristics.SCALER_AVAILABLE_STREAM_USE_CASES)
-        if (availableUseCases != null) {
-          if (availableUseCases.contains(outputType.toOutputType().toLong())) {
-            return true
-          }
-        }
-      }
-
-      return false
-    }
   }
 
   @RequiresApi(Build.VERSION_CODES.N)
-  fun toOutputConfiguration(characteristics: CameraCharacteristics): OutputConfiguration {
+  fun toOutputConfiguration(device: CameraDeviceDetails): OutputConfiguration {
     val result = OutputConfiguration(surface)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       if (dynamicRangeProfile != null) {
         result.dynamicRangeProfile = dynamicRangeProfile
         Log.i(TAG, "Using dynamic range profile ${result.dynamicRangeProfile} for $outputType output.")
       }
-      if (supportsOutputType(characteristics, outputType)) {
+      if (device.supportsOutputType(outputType)) {
         result.streamUseCase = outputType.toOutputType().toLong()
         Log.i(TAG, "Using optimized stream use case ${result.streamUseCase} for $outputType output.")
       }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Refactors the codebase to no longer use `CameraManager.getCameraCharacteristics`/`CameraCharacteristics` directly, but instead put all of that logic into a single `CameraDeviceDetails` class. 

Instances of this class should be created once (when the `cameraId` changes) and then re-used throughout the session. This caches results such as HDR modes, flash capabilities, stream config maps, highest output sizes, and more effectively speeding up calculations of some methods (e.g. `updateRepeatingRequest()` and `configureSession()`).

Additionally this could make the code a lot cleaner and abstract away API level checks (e.g. for HDR modes).

This class also has helper methods such as `getPreviewSizes()` and `getPhotoSizes()`.

We could also use this class to open and close Cameras in the future.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
