### PR TITLE
chore: add frame processor plugins examples for Kotlin & Swift

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            example/ios/Pods
+            package/example/ios/Pods
             ~/Library/Caches/CocoaPods
             ~/.cocoapods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            example/ios/Pods
+            package/example/ios/Pods
             ~/Library/Caches/CocoaPods
             ~/.cocoapods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_FINAL.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_FINAL.mdx
@@ -16,8 +16,9 @@ const plugin = VisionCameraProxy.getFrameProcessorPlugin('scanFaces')
 /**
  * Scans faces.
  */
-export function scanFaces(frame: Frame): object {
+export function scanFaces(frame: Frame) {
   'worklet'
+  if (plugin == null) throw new Error("Failed to load Frame Processor Plugin!")
   return plugin.call(frame)
 }
 ```

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
@@ -29,12 +29,13 @@ For reference see the [CLI's docs](https://github.com/mateusz1913/vision-camera-
 
 2. Register the package in MainApplication.java
 
-```java {6}
+```java
         @Override
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
-          ...
+          // ...
+// highlight-next-line
           packages.add(new FaceDetectorFrameProcessorPluginPackage()); // <- add
           return packages;
         }
@@ -54,14 +55,14 @@ For reference see the [CLI's docs](https://github.com/mateusz1913/vision-camera-
 2. Create a Java source file, for the Face Detector Plugin this will be called `FaceDetectorFrameProcessorPlugin.java`.
 3. Add the following code:
 
-```java {8}
+```java
 import com.mrousavy.camera.frameprocessor.Frame;
 import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin;
 
 public class FaceDetectorFrameProcessorPlugin extends FrameProcessorPlugin {
-
   @Override
   public Object callback(Frame frame, Map<String, Object> arguments) {
+// highlight-next-line
     // code goes here
     return null;
   }
@@ -75,26 +76,24 @@ The Frame Processor Plugin will be exposed to JS through the `VisionCameraProxy`
 4. **Implement your Frame Processing.** See the [Example Plugin (Java)](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleFrameProcessorPlugin.java) for reference.
 5. Create a new Java file which registers the Frame Processor Plugin in a React Package, for the Face Detector plugin this file will be called `FaceDetectorFrameProcessorPluginPackage.java`:
 
-```java {12}
+```java
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin;
 import com.mrousavy.camera.frameprocessor.FrameProcessorPluginRegistry;
-import javax.annotation.Nonnull;
 
 public class FaceDetectorFrameProcessorPluginPackage implements ReactPackage {
-  @NonNull
   @Override
-  public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+// highlight-next-line
     FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces", options -> new FaceDetectorFrameProcessorPlugin());
     return Collections.emptyList();
   }
 
-  @Nonnull
   @Override
-  public List<ViewManager> createViewManagers(@Nonnull ReactApplicationContext reactContext) {
+  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Collections.emptyList();
   }
 }
@@ -102,12 +101,13 @@ public class FaceDetectorFrameProcessorPluginPackage implements ReactPackage {
 
 6. Register the package in MainApplication.java
 
-```java {6}
+```java
         @Override
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
-          ...
+          // ...
+// highlight-next-line
           packages.add(new FaceDetectorFrameProcessorPluginPackage()); // <- add
           return packages;
         }
@@ -120,13 +120,14 @@ public class FaceDetectorFrameProcessorPluginPackage implements ReactPackage {
 2. Create a Kotlin source file, for the Face Detector Plugin this will be called `FaceDetectorFrameProcessorPlugin.kt`.
 3. Add the following code:
 
-```kotlin {7}
+```kotlin
 import com.mrousavy.camera.frameprocessor.Frame
 import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
 
 class FaceDetectorFrameProcessorPlugin: FrameProcessorPlugin() {
 
-  override fun callback(frame: Frame, arguments: Map<String, Object>): Any? {
+  override fun callback(frame: Frame, arguments: Map<String, Object>?): Any? {
+// highlight-next-line
     // code goes here
     return null
   }
@@ -137,10 +138,10 @@ class FaceDetectorFrameProcessorPlugin: FrameProcessorPlugin() {
 The Frame Processor Plugin will be exposed to JS through the `VisionCameraProxy` object. In this case, it would be `VisionCameraProxy.getFrameProcessorPlugin("detectFaces")`.
 :::
 
-4. **Implement your Frame Processing.** See the [Example Plugin (Java)](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleFrameProcessorPlugin.java) for reference.
+4. **Implement your Frame Processing.** See the [Example Plugin (Kotlin)](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleKotlinFrameProcessorPlugin.kt) for reference.
 5. Create a new Kotlin file which registers the Frame Processor Plugin in a React Package, for the Face Detector plugin this file will be called `FaceDetectorFrameProcessorPluginPackage.kt`:
 
-```kotlin {9}
+```kotlin
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
@@ -149,9 +150,11 @@ import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
 
 class FaceDetectorFrameProcessorPluginPackage : ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+// highlight-start
     FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces") { options ->
       FaceDetectorFrameProcessorPlugin()
     }
+// highlight-end
     return emptyList()
   }
 
@@ -163,12 +166,13 @@ class FaceDetectorFrameProcessorPluginPackage : ReactPackage {
 
 6. Register the package in MainApplication.java
 
-```java {6}
+```java
         @Override
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
-          ...
+          // ...
+// highlight-next-line
           packages.add(new FaceDetectorFrameProcessorPluginPackage()); // <- add
           return packages;
         }

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
@@ -60,7 +60,7 @@ For reference see the [CLI's docs](https://github.com/mateusz1913/vision-camera-
   CMSampleBufferRef buffer = frame.buffer;
   UIImageOrientation orientation = frame.orientation;
   // code goes here
-  return @[];
+  return nil;
 }
 
 + (void) load {
@@ -77,7 +77,7 @@ For reference see the [CLI's docs](https://github.com/mateusz1913/vision-camera-
 The Frame Processor Plugin will be exposed to JS through the `VisionCameraProxy` object. In this case, it would be `VisionCameraProxy.getFrameProcessorPlugin("detectFaces")`.
 :::
 
-4. **Implement your Frame Processing.** See the [Example Plugin (Objective-C)](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/ios/Frame%20Processor%20Plugins/Example%20Plugin%20%28Objective%2DC%29) for reference.
+4. **Implement your Frame Processing.** See the [Example Plugin (Objective-C)](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/ios/Frame%20Processor%20Plugins/Example%20Plugin) for reference.
 
 </TabItem>
 <TabItem value="swift">
@@ -87,52 +87,47 @@ The Frame Processor Plugin will be exposed to JS through the `VisionCameraProxy`
 
 ![Xcode "Create Bridging Header" alert](https://docs-assets.developer.apple.com/published/7ebca7212c/2a065d1a-7e53-4907-a889-b7fa4f2206c9.png)
 
-3. Inside the newly created Bridging Header, add the following code:
-
-```objc
-#import <VisionCamera/FrameProcessorPlugin.h>
-#import <VisionCamera/Frame.h>
-```
-
-4. In the Swift file, add the following code:
+3. In the Swift file, add the following code:
 
 ```swift
+import VisionCamera
+
 @objc(FaceDetectorFrameProcessorPlugin)
 public class FaceDetectorFrameProcessorPlugin: FrameProcessorPlugin {
-  public override func callback(_ frame: Frame!, withArguments arguments: [String:Any]) -> Any {
+  public override func callback(_ frame: Frame, withArguments arguments: [AnyHashable : Any]?) -> Any {
     let buffer = frame.buffer
     let orientation = frame.orientation
     // code goes here
-    return []
+    return nil
   }
 }
 ```
 
-5. In your `AppDelegate.m`, add the following imports:
+4. Create an Objective-C source file that will be used to automatically register your plugin
 
 ```objc
-#import "YOUR_XCODE_PROJECT_NAME-Swift.h"
 #import <VisionCamera/FrameProcessorPlugin.h>
 #import <VisionCamera/FrameProcessorPluginRegistry.h>
-```
 
-6. In your `AppDelegate.m`, add the following code to `application:didFinishLaunchingWithOptions:`:
+#import "YOUR_XCODE_PROJECT_NAME-Swift.h" // <--- replace "YOUR_XCODE_PROJECT_NAME" with the actual value of your xcode project name
 
-```objc {5}
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+@interface FaceDetectorFrameProcessorPlugin (FrameProcessorPluginLoader)
+@end
+
+@implementation FaceDetectorFrameProcessorPlugin (FrameProcessorPluginLoader)
+
++ (void)load
 {
-  ...
-
   [FrameProcessorPluginRegistry addFrameProcessorPlugin:@"detectFaces"
-                                        withInitializer:^FrameProcessorPlugin*(NSDictionary* options) {
+                                        withInitializer:^FrameProcessorPlugin* (NSDictionary* options) {
     return [[FaceDetectorFrameProcessorPlugin alloc] initWithOptions:options];
   }];
-
-  return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
+
+@end
 ```
 
-7. **Implement your frame processing.** See [Example Plugin (Swift)](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/ios/Frame%20Processor%20Plugins/Example%20Plugin%20%28Swift%29) for reference.
+5. **Implement your frame processing.** See [Example Plugin (Swift)](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/ios/Frame%20Processor%20Plugins/Example%20Swift%20Plugin) for reference.
 
 
 </TabItem>

--- a/package/example/android/app/build.gradle
+++ b/package/example/android/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 

--- a/package/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleKotlinFrameProcessorPlugin.kt
+++ b/package/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleKotlinFrameProcessorPlugin.kt
@@ -1,0 +1,35 @@
+package com.mrousavy.camera.example
+
+import android.util.Log
+import com.mrousavy.camera.frameprocessor.Frame
+import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
+
+class ExampleKotlinFrameProcessorPlugin: FrameProcessorPlugin() {
+    override fun callback(frame: Frame, params: Map<String, Any>?): Any? {
+        if (params == null) {
+            return null
+        }
+
+        val image = frame.image
+        Log.d(
+            "ExampleKotlinPlugin",
+            image.width.toString() + " x " + image.height + " Image with format #" + image.format + ". Logging " + params.size + " parameters:"
+        )
+
+        for (key in params.keys) {
+            val value = params[key]
+            Log.d("ExampleKotlinPlugin", "  -> " + if (value == null) "(null)" else value.toString() + " (" + value.javaClass.name + ")")
+        }
+
+        return hashMapOf<String, Any>(
+            "example_str" to "KotlinTest",
+            "example_bool" to false,
+            "example_double" to 6.7,
+            "example_array" to arrayListOf<Any>(
+                "Good bye",
+                false,
+                21.37
+            )
+        )
+    }
+}

--- a/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.java
+++ b/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.java
@@ -66,5 +66,6 @@ public class MainApplication extends Application implements ReactApplication {
     }
 
     FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin", options -> new ExampleFrameProcessorPlugin());
+    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_kotlin_swift_plugin", options -> new ExampleKotlinFrameProcessorPlugin());
   }
 }

--- a/package/example/android/build.gradle
+++ b/package/example/android/build.gradle
@@ -15,5 +15,6 @@ buildscript {
     dependencies {
         classpath('com.android.tools.build:gradle:7.4.1')
         classpath("com.facebook.react:react-native-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.22")
     }
 }

--- a/package/example/ios/Frame Processor Plugins/Example Plugin/ExampleFrameProcessorPlugin.m
+++ b/package/example/ios/Frame Processor Plugins/Example Plugin/ExampleFrameProcessorPlugin.m
@@ -18,7 +18,7 @@
 
 @implementation ExampleFrameProcessorPlugin
 
-- (id)callback:(Frame *)frame withArguments:(NSArray<id> *)arguments {
+- (id)callback:(Frame *)frame withArguments:(NSDictionary *)arguments {
   CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(frame.buffer);
   NSLog(@"ExamplePlugin: %zu x %zu Image. Logging %lu parameters:", CVPixelBufferGetWidth(imageBuffer), CVPixelBufferGetHeight(imageBuffer), (unsigned long)arguments.count);
 
@@ -28,11 +28,11 @@
 
   return @{
     @"example_str": @"Test",
-    @"example_bool": @true,
+    @"example_bool": @(YES),
     @"example_double": @5.3,
     @"example_array": @[
       @"Hello",
-      @true,
+      @(YES),
       @17.38
     ]
   };

--- a/package/example/ios/Frame Processor Plugins/Example Swift Plugin/ExampleSwiftFrameProcessor.m
+++ b/package/example/ios/Frame Processor Plugins/Example Swift Plugin/ExampleSwiftFrameProcessor.m
@@ -1,0 +1,31 @@
+//
+//  ExampleSwiftFrameProcessor.m
+//  VisionCameraExample
+//
+//  Created by Mateusz Mędrek on 02/09/2023.
+//
+
+#if __has_include(<VisionCamera/FrameProcessorPlugin.h>)
+#import <Foundation/Foundation.h>
+#import <VisionCamera/FrameProcessorPlugin.h>
+#import <VisionCamera/FrameProcessorPluginRegistry.h>
+#import <VisionCamera/Frame.h>
+
+#import "VisionCameraExample-Swift.h"
+
+// Example for a Swift Frame Processor plugin automatic registration
+@interface ExampleSwiftFrameProcessorPlugin (FrameProcessorPluginLoader)
+@end
+
+@implementation ExampleSwiftFrameProcessorPlugin (FrameProcessorPluginLoader)
+
++ (void)load
+{
+  [FrameProcessorPluginRegistry addFrameProcessorPlugin:@"example_kotlin_swift_plugin" withInitializer:^FrameProcessorPlugin * _Nonnull(NSDictionary * _Nullable options) {
+    return [[ExampleSwiftFrameProcessorPlugin alloc] init];
+  }];
+}
+
+@end
+
+#endif

--- a/package/example/ios/Frame Processor Plugins/Example Swift Plugin/ExampleSwiftFrameProcessor.swift
+++ b/package/example/ios/Frame Processor Plugins/Example Swift Plugin/ExampleSwiftFrameProcessor.swift
@@ -1,0 +1,43 @@
+//
+//  ExampleSwiftFrameProcessor.swift
+//  VisionCameraExample
+//
+//  Created by Mateusz Mędrek on 02/09/2023.
+//
+
+#if VISION_CAMERA_ENABLE_FRAME_PROCESSORS
+import VisionCamera
+
+// Example for a Swift Frame Processor plugin
+
+@objc(ExampleSwiftFrameProcessorPlugin)
+public class ExampleSwiftFrameProcessorPlugin: FrameProcessorPlugin {
+  public override func callback(_ frame: Frame, withArguments arguments: [AnyHashable: Any]?) -> Any? {
+    let imageBuffer = CMSampleBufferGetImageBuffer(frame.buffer)
+
+    if let arguments, let imageBuffer {
+      let width = CVPixelBufferGetWidth(imageBuffer)
+      let height = CVPixelBufferGetHeight(imageBuffer)
+      let count = arguments.count
+
+      print(
+        "ExampleSwiftPlugin: \(width) x \(height) Image. Logging \(count) parameters:"
+      )
+
+      for key in arguments.keys {
+        let value = arguments[key]
+        let valueString = String(describing: value)
+        let valueClassString = String(describing: value.self)
+        print("ExampleSwiftPlugin:   -> \(valueString) (\(valueClassString))")
+      }
+    }
+
+    return [
+      "example_str": "SwiftTest",
+      "example_bool": false,
+      "example_double": 6.7,
+      "example_array": ["Good bye", false, 21.37]
+    ]
+  }
+}
+#endif

--- a/package/example/ios/Podfile
+++ b/package/example/ios/Podfile
@@ -46,5 +46,48 @@ target 'VisionCameraExample' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    # Define Swift flag if frame processor are enabled
+    enable_frame_processor_swift_flag_in_example_project(installer)
   end
+end
+
+# In order to compile the project with disabled frame processors mode
+# the code base of example swift frame processor plugin needs to be put
+# behind the swift flag
+# 
+# Let's set the flag based on the same logic like in library's podspec file
+def enable_frame_processor_swift_flag_in_example_project(installer)
+  forceDisableFrameProcessors = false
+  if defined?($VCDisableFrameProcessors)
+    forceDisableFrameProcessors = true
+  end
+  has_worklets = installer.pods_project.pod_group("react-native-worklets-core") != nil && !forceDisableFrameProcessors
+  installer.aggregate_targets
+    .map{ |t| t.user_project }
+    .uniq{ |p| p.path }
+    .push(installer.pods_project)
+    .each do |project|
+      project.build_configurations.each do |config|
+        key = "OTHER_SWIFT_FLAGS"
+        flag = "-DVISION_CAMERA_ENABLE_FRAME_PROCESSORS"
+
+        current_other_swift_flag_setting = config.build_settings[key] ? config.build_settings[key] : "$(inherited)"
+
+        if current_other_swift_flag_setting.kind_of?(Array)
+          current_other_swift_flag_setting = current_other_swift_flag_setting
+            .map { |s| s.gsub('"', '') }
+            .map { |s| s.gsub('\"', '') }
+            .join(" ")
+        end
+
+        if has_worklets && !current_other_swift_flag_setting.include?(flag)
+          current_other_swift_flag_setting = "#{current_other_swift_flag_setting} #{flag}"
+        elsif !has_worklets && current_other_swift_flag_setting.include?(flag)
+          current_other_swift_flag_setting.slice! flag
+        end
+
+        config.build_settings[key] = current_other_swift_flag_setting
+      end
+      project.save()
+    end
 end

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -501,7 +501,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (3.0.0-rc.9):
+  - VisionCamera (3.0.0):
     - React
     - React-callinvoker
     - React-Core
@@ -733,9 +733,9 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 77e12500568c495e71914aacf52ccd7b9d3c5478
+  VisionCamera: 9be9a96959550faba434896a60fc1be843fca5af
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
 
-PODFILE CHECKSUM: ab9c06b18c63e741c04349c0fd630c6d3145081c
+PODFILE CHECKSUM: bef2849258b014f599a11fb632687da8905feb20
 
 COCOAPODS: 1.12.1

--- a/package/example/ios/VisionCameraExample-Bridging-Header.h
+++ b/package/example/ios/VisionCameraExample-Bridging-Header.h
@@ -1,8 +1,3 @@
 //
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
-
-#if VISION_CAMERA_ENABLE_FRAME_PROCESSORS
-#import <VisionCamera/FrameProcessorPlugin.h>
-#import <VisionCamera/Frame.h>
-#endif

--- a/package/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
+++ b/package/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
@@ -11,7 +11,8 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		B8DB3BD5263DE8B7004C18D7 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		83A48E4E2AA34C1F00C41660 /* ExampleSwiftFrameProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A48E4D2AA34C1F00C41660 /* ExampleSwiftFrameProcessor.swift */; };
+		83A48E502AA34C4200C41660 /* ExampleSwiftFrameProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 83A48E4F2AA34C4200C41660 /* ExampleSwiftFrameProcessor.m */; };
 		B8DB3BDC263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BD8263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m */; };
 		B8F0E10825E0199F00586F16 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F0E10725E0199F00586F16 /* File.swift */; };
 		C0B129659921D2EA967280B2 /* libPods-VisionCameraExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CDCFE89C25C89320B98945E /* libPods-VisionCameraExample.a */; };
@@ -27,6 +28,8 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = VisionCameraExample/main.m; sourceTree = "<group>"; };
 		3CDCFE89C25C89320B98945E /* libPods-VisionCameraExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VisionCameraExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = VisionCameraExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		83A48E4D2AA34C1F00C41660 /* ExampleSwiftFrameProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleSwiftFrameProcessor.swift; sourceTree = "<group>"; };
+		83A48E4F2AA34C4200C41660 /* ExampleSwiftFrameProcessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExampleSwiftFrameProcessor.m; sourceTree = "<group>"; };
 		B8DB3BD8263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExampleFrameProcessorPlugin.m; sourceTree = "<group>"; };
 		B8F0E10625E0199F00586F16 /* VisionCameraExample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VisionCameraExample-Bridging-Header.h"; sourceTree = "<group>"; };
 		B8F0E10725E0199F00586F16 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
@@ -91,6 +94,15 @@
 			name = Libraries;
 			sourceTree = "<group>";
 		};
+		83A48E4C2AA34BFC00C41660 /* Example Swift Plugin */ = {
+			isa = PBXGroup;
+			children = (
+				83A48E4D2AA34C1F00C41660 /* ExampleSwiftFrameProcessor.swift */,
+				83A48E4F2AA34C4200C41660 /* ExampleSwiftFrameProcessor.m */,
+			);
+			path = "Example Swift Plugin";
+			sourceTree = "<group>";
+		};
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
@@ -116,6 +128,7 @@
 		B8DB3BD6263DEA31004C18D7 /* Frame Processor Plugins */ = {
 			isa = PBXGroup;
 			children = (
+				83A48E4C2AA34BFC00C41660 /* Example Swift Plugin */,
 				B8DB3BD7263DEA31004C18D7 /* Example Plugin */,
 			);
 			path = "Frame Processor Plugins";
@@ -374,8 +387,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
+				83A48E4E2AA34C1F00C41660 /* ExampleSwiftFrameProcessor.swift in Sources */,
 				B8DB3BDC263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m in Sources */,
-				B8DB3BD5263DE8B7004C18D7 /* (null) in Sources */,
+				83A48E502AA34C4200C41660 /* ExampleSwiftFrameProcessor.m in Sources */,
 				B8F0E10825E0199F00586F16 /* File.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
@@ -396,6 +410,7 @@
 				INFOPLIST_FILE = VisionCameraExample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Vision Camera";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -426,6 +441,7 @@
 				INFOPLIST_FILE = VisionCameraExample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Vision Camera";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -504,6 +520,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)   -DVISION_CAMERA_ENABLE_FRAME_PROCESSORS";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -561,6 +578,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)   -DVISION_CAMERA_ENABLE_FRAME_PROCESSORS";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/package/example/ios/VisionCameraExample/AppDelegate.mm
+++ b/package/example/ios/VisionCameraExample/AppDelegate.mm
@@ -1,10 +1,6 @@
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
-#import "VisionCameraExample-Swift.h"
-#if VISION_CAMERA_ENABLE_FRAME_PROCESSORS
-#import <VisionCamera/FrameProcessorPlugin.h>
-#endif
 
 @implementation AppDelegate
 
@@ -14,10 +10,6 @@
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
-
-#if VISION_CAMERA_ENABLE_FRAME_PROCESSORS
-  [FrameProcessorPlugin registerPlugin:[[ExamplePluginSwift alloc] init]];
-#endif
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/package/example/src/frame-processors/ExampleKotlinSwiftPlugin.ts
+++ b/package/example/src/frame-processors/ExampleKotlinSwiftPlugin.ts
@@ -1,0 +1,17 @@
+import { VisionCameraProxy, Frame } from 'react-native-vision-camera';
+
+const plugin = VisionCameraProxy.getFrameProcessorPlugin('example_kotlin_swift_plugin');
+
+export function exampleKotlinSwiftPlugin(frame: Frame): string[] {
+  'worklet';
+
+  if (plugin == null) throw new Error('Failed to load Frame Processor Plugin "example_kotlin_swift_plugin"!');
+
+  return plugin.call(frame, {
+    someString: 'hello!',
+    someBoolean: true,
+    someNumber: 42,
+    someObject: { test: 0, second: 'test' },
+    someArray: ['another test', 5],
+  }) as string[];
+}


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

Right now I'm working on [support for VisionCamera v3 plugins in vision-camera-plugin-builder](https://github.com/mateusz1913/vision-camera-plugin-builder/pull/39) and I found that ~`v3`~ `main` branch does not have examples for Kotlin & Swift plugins

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

This PR adds Kotlin & Swift example for Frame Processor plugin. It also slightly enhances Frame Processor docs section

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

- iPhone 12 Pro, iOS 16.6
- Xiaomi Mi Note 10 Lite, Android 12

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
