### PR TITLE
fix: savePhotoToFile would write empty files

### DIFF
--- a/package/android/.editorconfig
+++ b/package/android/.editorconfig
@@ -1,5 +1,6 @@
 [*.{kt,kts}]
 indent_size=2
+indent_style=space
 insert_final_newline=true
 max_line_length=off
 disabled_rules=no-wildcard-imports


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

this fixes the `savePhotoToFile` function in v3 which on my device, would write empty files to the disk.
Closing the stream fixed that but I also believe I made it a little more efficient thanks to removing a buffer allocation in case of non-selfie images

also added one more entry to `android/.editorconfig` because android studio was formatting the code differently from the rest, not sure why but it's always annoying 😅 

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

Honor 20 Pro 

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
