### PR TITLE
pass options to frame processors on iOS

### DIFF
--- a/package/ios/Frame Processor/FrameProcessorPluginHostObject.mm
+++ b/package/ios/Frame Processor/FrameProcessorPluginHostObject.mm
@@ -39,7 +39,7 @@ jsi::Value FrameProcessorPluginHostObject::get(jsi::Runtime& runtime, const jsi:
           }
 
           // Call actual Frame Processor Plugin
-          id result = [_plugin callback:frame withArguments:nil];
+          id result = [_plugin callback:frame withArguments:options];
 
           // Convert result value to jsi::Value (possibly undefined)
           return JSINSObjectConversion::convertObjCObjectToJSIValue(runtime, result);


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

This PR allows iOS frame processors to access passed-in options.
## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

This PR changes the frame processor callback arguments in FrameProcessorPluginHostObject.mm to pass in the options dictionary constructed prior instead of nil.
## Tested on
iPhone Xs
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
I didn't see any.
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
