### PR TITLE
fix: Consider everything between 24mm and 43mm a wide-angle lense

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -110,6 +110,7 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
         l in 24f..43f -> deviceTypes.pushString("wide-angle-camera")
         // https://en.wikipedia.org/wiki/Telephoto_lens
         l > 43f -> deviceTypes.pushString("telephoto-camera")
+        else -> throw Error("Invalid focal length! (${focalLength}mm)")
       }
     }
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -100,19 +100,18 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
 
     val deviceTypes = Arguments.createArray()
 
-    // https://en.wikipedia.org/wiki/Telephoto_lens
-    val containsTelephoto = focalLengths.any { l -> (l * cropFactor) > 43 } // TODO: Telephoto lenses are > 85mm, but we don't have anything between that range..
-    // https://en.wikipedia.org/wiki/Wide-angle_lens
-    val containsWideAngle = focalLengths.any { l -> (l * cropFactor) >= 24 && (l * cropFactor) <= 43 }
-    // https://en.wikipedia.org/wiki/Ultra_wide_angle_lens
-    val containsUltraWideAngle = focalLengths.any { l -> (l * cropFactor) < 24 }
-
-    if (containsTelephoto)
-      deviceTypes.pushString("telephoto-camera")
-    if (containsWideAngle)
-      deviceTypes.pushString("wide-angle-camera")
-    if (containsUltraWideAngle)
-      deviceTypes.pushString("ultra-wide-angle-camera")
+    focalLengths.forEach { focalLength ->
+      // scale to the 35mm film standard
+      val l = focalLength * cropFactor
+      when {
+        // https://en.wikipedia.org/wiki/Ultra_wide_angle_lens
+        l < 24 -> deviceTypes.pushString("ultra-wide-angle-camera")
+        // https://en.wikipedia.org/wiki/Wide-angle_lens
+        l in 24..43 -> deviceTypes.pushString("wide-angle-camera")
+        // https://en.wikipedia.org/wiki/Telephoto_lens
+        l > 43 -> deviceTypes.pushString("telephoto-camera")
+      }
+    }
 
     return deviceTypes
   }

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -95,18 +95,15 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
   private val size35mm = Size(36, 24)
 
   private fun getDeviceTypes(): ReadableArray {
-    // TODO: Check if getDeviceType() works correctly, even for logical multi-cameras
-
     // To get valid focal length standards we have to upscale to the 35mm measurement (film standard)
     val cropFactor = size35mm.bigger / sensorSize.bigger
 
     val deviceTypes = Arguments.createArray()
 
     // https://en.wikipedia.org/wiki/Telephoto_lens
-    val containsTelephoto = focalLengths.any { l -> (l * cropFactor) > 35 } // TODO: Telephoto lenses are > 85mm, but we don't have anything between that range..
-    // val containsNormalLens = focalLengths.any { l -> (l * cropFactor) > 35 && (l * cropFactor) <= 55 }
+    val containsTelephoto = focalLengths.any { l -> (l * cropFactor) > 43 } // TODO: Telephoto lenses are > 85mm, but we don't have anything between that range..
     // https://en.wikipedia.org/wiki/Wide-angle_lens
-    val containsWideAngle = focalLengths.any { l -> (l * cropFactor) >= 24 && (l * cropFactor) <= 35 }
+    val containsWideAngle = focalLengths.any { l -> (l * cropFactor) >= 24 && (l * cropFactor) <= 43 }
     // https://en.wikipedia.org/wiki/Ultra_wide_angle_lens
     val containsUltraWideAngle = focalLengths.any { l -> (l * cropFactor) < 24 }
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -105,11 +105,11 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
       val l = focalLength * cropFactor
       when {
         // https://en.wikipedia.org/wiki/Ultra_wide_angle_lens
-        l < 24 -> deviceTypes.pushString("ultra-wide-angle-camera")
+        l < 24f -> deviceTypes.pushString("ultra-wide-angle-camera")
         // https://en.wikipedia.org/wiki/Wide-angle_lens
-        l in 24..43 -> deviceTypes.pushString("wide-angle-camera")
+        l in 24f..43f -> deviceTypes.pushString("wide-angle-camera")
         // https://en.wikipedia.org/wiki/Telephoto_lens
-        l > 43 -> deviceTypes.pushString("telephoto-camera")
+        l > 43f -> deviceTypes.pushString("telephoto-camera")
       }
     }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

[On Wikipedia, a lens is considered to be wide-angle if it is smaller than 35mm and bigger than 24mm in focal length](https://en.wikipedia.org/wiki/Wide-angle_lens), but there are some devices like the Xiaomi A3 that have a focal length of 37mm on their "default" camera.

Previously, that code made that specific device be detected as a telephoto, while it really doesn't look like a telephoto Camera. This meant, that code that used `useCameraDevices('wide-angle')` would break, since there is no matching Camera on that device, so it would show a blackscreen. In a future PR I want to rework that hook to make it easier and logical to get a Camera device without such mistakes.

So now I increased this value from `35` to `43`, a value which seemed more logical to me. If a lens has a focal length of `43`, I would still say this is a wide-angle camera, not a telephoto.

These are now the new values for device types / focal lengths:

* 0mm-24mm: `ultra-wide-angle` device
* 24mm-43mm: `wide-angle` device
* 43mm-∞mm: `telephoto` device

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->
* Xiaomi A3

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
