### PR TITLE
fix: missing plugin name in assertion

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorPluginRegistry.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorPluginRegistry.java
@@ -15,7 +15,7 @@ public class FrameProcessorPluginRegistry {
     @Keep
     public static void addFrameProcessorPlugin(String name, PluginInitializer pluginInitializer) {
         assert !Plugins.containsKey(name) : "Tried to add a Frame Processor Plugin with a name that already exists! " +
-                "Either choose unique names, or remove the unused plugin. Name: ";
+                "Either choose unique names, or remove the unused plugin. Name: " + name;
         Plugins.put(name, pluginInitializer);
     }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->
The assertion message that ensures frame processors name uniqueness on Android is missing the name to be shown.

**Before**
![Capture d’écran 2023-09-08 à 17 00 39](https://github.com/mrousavy/react-native-vision-camera/assets/515603/02f85c9a-0cea-4518-95de-23a06205973b)

**After**
![Capture d’écran 2023-09-08 à 17 38 10](https://github.com/mrousavy/react-native-vision-camera/assets/515603/ad16e163-aa0d-4381-a67c-ea6e2be5927b)


## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->


## Tested on
Pixel 5/API 33 emulator

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
