### PR TITLE
fix: Find closest matching aspect ratio for Preview

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -41,7 +41,7 @@ class CameraView(context: Context) : FrameLayout(context) {
   companion object {
     const val TAG = "CameraView"
 
-    private val propsThatRequirePreviewReconfiguration = arrayListOf("cameraId")
+    private val propsThatRequirePreviewReconfiguration = arrayListOf("cameraId", "format")
     private val propsThatRequireSessionReconfiguration = arrayListOf("cameraId", "format", "photo", "video", "enableFrameProcessor", "pixelFormat")
     private val propsThatRequireFormatReconfiguration = arrayListOf("fps", "hdr", "videoStabilizationMode", "lowLightBoost")
   }
@@ -116,7 +116,7 @@ class CameraView(context: Context) : FrameLayout(context) {
     this.previewSurface = null
 
     val cameraId = cameraId ?: return
-    val previewView = PreviewView(context, cameraManager, cameraId) { surface ->
+    val previewView = PreviewView(context, cameraManager, cameraId, format) { surface ->
       previewSurface = surface
       configureSession()
     }

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -8,6 +8,7 @@ import android.util.Size
 import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.SurfaceView
+import com.facebook.react.bridge.ReadableMap
 import com.mrousavy.camera.extensions.getPreviewSize
 import kotlin.math.roundToInt
 
@@ -15,6 +16,7 @@ import kotlin.math.roundToInt
 class PreviewView(context: Context,
                   cameraManager: CameraManager,
                   cameraId: String,
+                  format: ReadableMap? = null,
                   private val onSurfaceChanged: (surface: Surface?) -> Unit): SurfaceView(context) {
   private val targetSize: Size
   private val aspectRatio: Float
@@ -22,7 +24,14 @@ class PreviewView(context: Context,
 
   init {
     val characteristics = cameraManager.getCameraCharacteristics(cameraId)
-    targetSize = characteristics.getPreviewSize()
+    if (format != null) {
+      val videoWidth = format.getInt("videoWidth")
+      val videoHeight = format.getInt("videoHeight")
+      val targetAspectRatio = videoWidth / videoHeight
+      targetSize = characteristics.getPreviewSize(targetAspectRatio)
+    } else {
+      targetSize = characteristics.getPreviewSize()
+    }
 
     Log.i(TAG, "Using Preview Size ${targetSize.width} x ${targetSize.height}.")
     holder.setFixedSize(targetSize.width, targetSize.height)

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -27,7 +27,7 @@ class PreviewView(context: Context,
     if (format != null) {
       val videoWidth = format.getInt("videoWidth")
       val videoHeight = format.getInt("videoHeight")
-      val targetAspectRatio = videoWidth / videoHeight
+      val targetAspectRatio = videoWidth.toDouble() / videoHeight.toDouble()
       targetSize = characteristics.getPreviewSize(targetAspectRatio)
     } else {
       targetSize = characteristics.getPreviewSize()

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getOutputSizes.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getOutputSizes.kt
@@ -25,14 +25,14 @@ private fun getMaximumPreviewSize(): Size {
  * Gets the maximum Preview Resolution this device is capable of streaming at. (For [SurfaceView])
  * If a [targetAspectRatio] is set, instead find a preview size closest matching to the target aspect ratio.
  */
-fun CameraCharacteristics.getPreviewSize(targetAspectRatio: Int? = null): Size {
+fun CameraCharacteristics.getPreviewSize(targetAspectRatio: Double? = null): Size {
   val config = this.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)!!
   val previewSize = getMaximumPreviewSize()
   var outputSizes = config.getOutputSizes(SurfaceHolder::class.java).sortedByDescending { it.width * it.height }
   outputSizes = outputSizes.filter { it.bigger <= previewSize.bigger && it.smaller <= previewSize.smaller }
   if (targetAspectRatio != null) {
     outputSizes = outputSizes.subList(0, outputSizes.size / 2)
-    outputSizes = outputSizes.sortedByDescending { abs((it.width / it.height) - targetAspectRatio) }
+    outputSizes = outputSizes.sortedByDescending { abs((it.width.toDouble() / it.height.toDouble()) - targetAspectRatio) }
   }
   return outputSizes.first()
 }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getOutputSizes.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getOutputSizes.kt
@@ -32,7 +32,7 @@ fun CameraCharacteristics.getPreviewSize(targetAspectRatio: Double? = null): Siz
   outputSizes = outputSizes.filter { it.bigger <= previewSize.bigger && it.smaller <= previewSize.smaller }
   if (targetAspectRatio != null) {
     outputSizes = outputSizes.subList(0, outputSizes.size / 2)
-    outputSizes = outputSizes.sortedByDescending { abs((it.width.toDouble() / it.height.toDouble()) - targetAspectRatio) }
+    outputSizes = outputSizes.sortedBy { abs((it.width.toDouble() / it.height.toDouble()) - targetAspectRatio) }
   }
   return outputSizes.first()
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
