### PR TITLE
fix: typo for RecordVideoOptions.videoCodec

### DIFF
--- a/package/src/VideoFile.ts
+++ b/package/src/VideoFile.ts
@@ -23,7 +23,7 @@ export interface RecordVideoOptions {
    * - `h264`: Widely supported, but might be less efficient, especially with larger sizes or framerates.
    * - `h265`: The HEVC (High-Efficient-Video-Codec) for higher efficient video recordings.
    */
-  videoCodec?: 'h265' | 'h265';
+  videoCodec?: 'h264' | 'h265';
 }
 
 /**


### PR DESCRIPTION
## What

This PR fixes a typo in a RecordVideoOptions.videoCodec

## Changes

Fix `videoCodec?: 'h265' | 'h265'` to `videoCodec?: 'h264' | 'h265'`

## Tested on

output of ffprobe

for h264 -> get `"codec_name": "h264"`
```
information {"chapters": [], "format": {"bit_rate": "17467549", "duration": "1.794000", "filename": "/data/user/0/dev.sideeffect.livelens/cache/mrousavy6967511533737184097.mp4", "format_name": "mov,mp4,m4a,3gp,3g2,mj2", "nb_programs": 0, "nb_streams": 2, "probe_score": 100, "size": "3917098", "start_time": "0.000000", "tags": {"com.android.version": "10", "compatible_brands": "isommp42", "creation_time": "2023-09-17T16:01:53.000000Z", "major_brand": "mp42", "minor_version": "0"}}, "streams": [{"avg_frame_rate": "4860000/161471", "bit_rate": "17357194", "bits_per_raw_sample": "8", "chroma_location": "left", "closed_captions": 0, "codec_long_name": "unknown", "codec_name": "h264", "codec_tag": "0x31637661", "codec_tag_string": "avc1", "codec_type": "video", "coded_height": 2976, "coded_width": 2976, "color_primaries": "bt470bg", "color_range": "tv", "color_space": "smpte170m", "color_transfer": "smpte170m", "display_aspect_ratio": "1:1", "disposition": [Object], "duration": "1.794111", "duration_ts": 161470, "extradata_size": 34, "field_order": "progressive", "film_grain": 0, "has_b_frames": 0, "height": 2976, "id": "0x1", "index": 0, "is_avc": "true", "level": 51, "nal_length_size": "4", "nb_frames": "54", "pix_fmt": "yuv420p", "profile": "100", "r_frame_rate": "30/1", "refs": 1, "sample_aspect_ratio": "1:1", "start_pts": 0, "start_time": "0.000000", "tags": [Object], "time_base": "1/90000", "width": 2976}, {"avg_frame_rate": "0/0", "bit_rate": "95122", "bits_per_sample": 0, "channel_layout": "mono", "channels": 1, "codec_long_name": "unknown", "codec_name": "aac", "codec_tag": "0x6134706d", "codec_tag_string": "mp4a", "codec_type": "audio", "disposition": [Object], "duration": "1.789864", "duration_ts": 78933, "extradata_size": 2, "id": "0x2", "index": 1, "nb_frames": "76", "profile": "1", "r_frame_rate": "0/0", "sample_fmt": "fltp", "sample_rate": "44100", "start_pts": 0, "start_time": "0.000000", "tags": [Object], "time_base": "1/44100"}]}
```

for h265 -> get `"codec_name": "hevc"`
```
information {"chapters": [], "format": {"bit_rate": "14906136", "duration": "2.108000", "filename": "/data/user/0/dev.sideeffect.livelens/cache/mrousavy1468742623534012361.mp4", "format_name": "mov,mp4,m4a,3gp,3g2,mj2", "nb_programs": 0, "nb_streams": 2, "probe_score": 100, "size": "3927767", "start_time": "0.000000", "tags": {"com.android.version": "10", "compatible_brands": "isommp42", "creation_time": "2023-09-17T16:03:40.000000Z", "major_brand": "mp42", "minor_version": "0"}}, "streams": [{"avg_frame_rate": "189000/6323", "bit_rate": "14800716", "chroma_location": "left", "closed_captions": 0, "codec_long_name": "unknown", "codec_name": "hevc", "codec_tag": "0x31637668", "codec_tag_string": "hvc1", "codec_type": "video", "coded_height": 2976, "coded_width": 2976, "color_primaries": "bt470bg", "color_range": "tv", "color_space": "smpte170m", "color_transfer": "smpte170m", "display_aspect_ratio": "1:1", "disposition": [Object], "duration": "2.107667", "duration_ts": 189690, "extradata_size": 110, "film_grain": 0, "has_b_frames": 0, "height": 2976, "id": "0x1", "index": 0, "level": 150, "nb_frames": "63", "pix_fmt": "yuv420p", "profile": "1", "r_frame_rate": "30000/1001", "refs": 1, "sample_aspect_ratio": "1:1", "start_pts": 0, "start_time": "0.000000", "tags": [Object], "time_base": "1/90000", "width": 2976}, {"avg_frame_rate": "0/0", "bit_rate": "96141", "bits_per_sample": 0, "channel_layout": "mono", "channels": 1, "codec_long_name": "unknown", "codec_name": "aac", "codec_tag": "0x6134706d", "codec_tag_string": "mp4a", "codec_type": "audio", "disposition": [Object], "duration": "2.094490", "duration_ts": 92367, "extradata_size": 2, "id": "0x2", "index": 1, "nb_frames": "90", "profile": "1", "r_frame_rate": "0/0", "sample_fmt": "fltp", "sample_rate": "44100", "start_pts": 0, "start_time": "0.000000", "tags": [Object], "time_base": "1/44100"}]}
```

## Related issues

N/A

---

I see there is a lot of potential in this project! Thanks for the great work on this.