### PR TITLE
feat: Add support for new External, Continuity and LiDAR Cameras

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -501,7 +501,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (3.0.0-rc.9):
+  - VisionCamera (3.0.0):
     - React
     - React-callinvoker
     - React-Core
@@ -733,7 +733,7 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 77e12500568c495e71914aacf52ccd7b9d3c5478
+  VisionCamera: 9be9a96959550faba434896a60fc1be843fca5af
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
 
 PODFILE CHECKSUM: ab9c06b18c63e741c04349c0fd630c6d3145081c

--- a/package/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
+++ b/package/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		B8DB3BD5263DE8B7004C18D7 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B8DB3BD5263DE8B7004C18D7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B8DB3BDC263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BD8263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m */; };
 		B8F0E10825E0199F00586F16 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F0E10725E0199F00586F16 /* File.swift */; };
 		C0B129659921D2EA967280B2 /* libPods-VisionCameraExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CDCFE89C25C89320B98945E /* libPods-VisionCameraExample.a */; };
@@ -375,7 +375,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				B8DB3BDC263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m in Sources */,
-				B8DB3BD5263DE8B7004C18D7 /* (null) in Sources */,
+				B8DB3BD5263DE8B7004C18D7 /* BuildFile in Sources */,
 				B8F0E10825E0199F00586F16 /* File.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);

--- a/package/ios/CameraViewManager.swift
+++ b/package/ios/CameraViewManager.swift
@@ -153,14 +153,22 @@ final class CameraViewManager: RCTViewManager {
 
   private final func getAllDeviceTypes() -> [AVCaptureDevice.DeviceType] {
     var deviceTypes: [AVCaptureDevice.DeviceType] = []
+    deviceTypes.append(.builtInDualCamera)
+    deviceTypes.append(.builtInWideAngleCamera)
+    deviceTypes.append(.builtInTelephotoCamera)
+    deviceTypes.append(.builtInTrueDepthCamera)
     if #available(iOS 13.0, *) {
       deviceTypes.append(.builtInTripleCamera)
       deviceTypes.append(.builtInDualWideCamera)
       deviceTypes.append(.builtInUltraWideCamera)
     }
-    deviceTypes.append(.builtInDualCamera)
-    deviceTypes.append(.builtInWideAngleCamera)
-    deviceTypes.append(.builtInTelephotoCamera)
+    if #available(iOS 15.4, *) {
+      deviceTypes.append(.builtInLiDARDepthCamera)
+    }
+    if #available(iOS 17.0, *) {
+      deviceTypes.append(.external)
+      deviceTypes.append(.continuityCamera)
+    }
     return deviceTypes
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR adds support for **four new Camera Devices** on iOS:

- [External](https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/4172590-external) Cameras (On iPad, external devices are those that conform to the UVC (USB Video Class) specification)
- [Continuity](https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/4157134-continuitycamera) Cameras (e.g. your Mac's Camera streamed through AirPlay)
- [True Depth](https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/2933376-builtintruedepthcamera) Camera (a Camera device streaming both depth data (through Infrared) and colors (YUV))
- [LiDAR](https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/3915812-builtinlidardepthcamera) Camera (a Camera device streaming both depth data (through a LiDAR sensor) and colors (YUV))

### Blockers

Currently, a device looks like this:

```json
{
  devices: ('wide-angle-camera' | 'ultra-wide-angle-camera' | 'telephoto-camera')[]
  position: 'front' | 'back' | 'external'
}
```

But the external and continuity cameras don't have the device types. They don't tell me whether they're wide-angle or ultra-wide etc., they just say they're external. Therefore I either need to add a `unknown` or `external` type to the devices, which is kinda lame as the lens information should be known (through FOV/focal length). Only the position should be `external` in that case.
I'll need to investigate this, but unfortunately I don't have a device to test this on. **Someone wanna borrow me an iPad?**

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
