### PR TITLE
feat: New `useCameraPermission()` and `useMicrophonePermission()` hooks

### DIFF
--- a/package/src/Orientation.ts
+++ b/package/src/Orientation.ts
@@ -1,1 +1,10 @@
+/**
+ * Represents Orientation. Depending on the context, this might be a sensor
+ * orientation (relative to the phone's orentation), or view orientation.
+ *
+ * - `portrait`: **0°** (home-button at the bottom)
+ * - `landscape-left`: **90°** (home-button on the left)
+ * - `portrait-upside-down`: **180°** (home-button at the top)
+ * - `landscape-right`: **270°** (home-button on the right)
+ */
 export type Orientation = 'portrait' | 'portrait-upside-down' | 'landscape-left' | 'landscape-right';

--- a/package/src/hooks/useCameraPermission.ts
+++ b/package/src/hooks/useCameraPermission.ts
@@ -2,8 +2,16 @@ import { useCallback, useEffect, useState } from 'react';
 import { Camera } from '../Camera';
 
 interface PermissionState {
+  /**
+   * Whether the specified permission has explicitly been granted.
+   * By default, this will be `false`. To request permission, call `requestPermission()`.
+   */
   hasPermission: boolean;
-  requestPermission: () => void;
+  /**
+   * Requests the specified permission from the user.
+   * @returns Whether the specified permission has now been granted, or not.
+   */
+  requestPermission: () => Promise<boolean>;
 }
 
 /**
@@ -26,8 +34,10 @@ export function useCameraPermission(): PermissionState {
   const [hasPermission, setHasPermission] = useState(false);
 
   const requestPermission = useCallback(async () => {
-    const newState = await Camera.requestCameraPermission();
-    setHasPermission(newState === 'granted');
+    const result = await Camera.requestCameraPermission();
+    const hasPermissionNow = result === 'granted';
+    setHasPermission(hasPermissionNow);
+    return hasPermissionNow;
   }, []);
 
   useEffect(() => {
@@ -58,8 +68,10 @@ export function useMicrophonePermission(): PermissionState {
   const [hasPermission, setHasPermission] = useState(false);
 
   const requestPermission = useCallback(async () => {
-    const newState = await Camera.requestMicrophonePermission();
-    setHasPermission(newState === 'granted');
+    const result = await Camera.requestMicrophonePermission();
+    const hasPermissionNow = result === 'granted';
+    setHasPermission(hasPermissionNow);
+    return hasPermissionNow;
   }, []);
 
   useEffect(() => {

--- a/package/src/hooks/useCameraPermission.ts
+++ b/package/src/hooks/useCameraPermission.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Camera } from '../Camera';
+
+interface PermissionState {
+  hasPermission: boolean;
+  requestPermission: () => void;
+}
+
+/**
+ * Returns whether the user has granted permission to use the Camera, or not.
+ *
+ * If the user doesn't grant Camera Permission, you cannot use the `<Camera>`.
+ *
+ * @example
+ * ```tsx
+ * const { hasPermission, requestPermission } = useCameraPermission()
+ *
+ * if (!hasPermission) {
+ *   return <PermissionScreen onPress={requestPermission} />
+ * } else {
+ *   return <Camera ... />
+ * }
+ * ```
+ */
+export function useCameraPermission(): PermissionState {
+  const [hasPermission, setHasPermission] = useState(false);
+
+  const requestPermission = useCallback(async () => {
+    const newState = await Camera.requestCameraPermission();
+    setHasPermission(newState === 'granted');
+  }, []);
+
+  useEffect(() => {
+    Camera.getCameraPermissionStatus().then((s) => setHasPermission(s === 'granted'));
+  }, []);
+
+  return {
+    hasPermission,
+    requestPermission,
+  };
+}
+
+/**
+ * Returns whether the user has granted permission to use the Microphone, or not.
+ *
+ * If the user doesn't grant Audio Permission, you can use the `<Camera>` but you cannot
+ * record videos with audio (the `audio={..}` prop).
+ *
+ * @example
+ * ```tsx
+ * const { hasPermission, requestPermission } = useMicrophonePermission()
+ * const canRecordAudio = hasPermission
+ *
+ * return <Camera video={true} audio={canRecordAudio} />
+ * ```
+ */
+export function useMicrophonePermission(): PermissionState {
+  const [hasPermission, setHasPermission] = useState(false);
+
+  const requestPermission = useCallback(async () => {
+    const newState = await Camera.requestMicrophonePermission();
+    setHasPermission(newState === 'granted');
+  }, []);
+
+  useEffect(() => {
+    Camera.getMicrophonePermissionStatus().then((s) => setHasPermission(s === 'granted'));
+  }, []);
+
+  return {
+    hasPermission,
+    requestPermission,
+  };
+}

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,16 +1,21 @@
 export * from './Camera';
 export * from './CameraDevice';
 export * from './CameraError';
+export * from './CameraProps';
 export { Frame } from './Frame';
 export * from './FrameProcessorPlugins';
-export * from './CameraProps';
+export * from './Orientation';
 export * from './PhotoFile';
 export * from './PixelFormat';
 export * from './Point';
 export * from './VideoFile';
 
-export * from './hooks/useCameraDevices';
-export * from './hooks/useCameraDevice';
-export * from './hooks/useCameraFormat';
+export * from './devices/Filter';
 export * from './devices/getCameraFormat';
+export * from './devices/getCameraDevice';
+
+export * from './hooks/useCameraDevice';
+export * from './hooks/useCameraDevices';
+export * from './hooks/useCameraFormat';
+export * from './hooks/useCameraPermission';
 export * from './hooks/useFrameProcessor';


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

### `useCameraPermission()`

```tsx
const { hasPermission, requestPermission } = useCameraPermission()

if (!hasPermission) {
  return <PermissionScreen onPress={requestPermission} />
} else {
  return <Camera ... />
}
```

### `useMicrophonePermission()`

```tsx
const { hasPermission, requestPermission } = useCameraPermission()
const canRecordAudio = hasPermission

return <Camera video={true} audio={canRecordAudio} />
```

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
