### PR TITLE
feat: Add support for LiDAR, TrueDepth, External (USB) and Continuity Camera Devices (iOS 17)

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -85,7 +85,6 @@ body:
           "maxZoom": 123.75,
           "name": "Back Dual Wide Camera",
           "position": "back",
-          "supportsDepthCapture": false,
           "supportsFocus": true,
           "supportsLowLightBoost": false,
           "supportsParallelVideoProcessing": true,

--- a/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
@@ -78,8 +78,8 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
     val preferredDevice = if (devices.size() > 0) devices.getMap(0) else null
 
     return mutableMapOf(
-        "availableCameraDevices" to devices,
-        "userPreferredCameraDevice" to preferredDevice
+      "availableCameraDevices" to devices,
+      "userPreferredCameraDevice" to preferredDevice
     )
   }
 

--- a/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
@@ -73,7 +73,15 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
 
   override fun hasConstants(): Boolean = true
 
-  override fun getConstants(): MutableMap<String, Any> = mutableMapOf("availableCameraDevices" to getDevicesJson())
+  override fun getConstants(): MutableMap<String, Any?> {
+    val devices = getDevicesJson()
+    val preferredDevice = if (devices.size() > 0) devices.getMap(0) else null
+
+    return mutableMapOf(
+        "availableCameraDevices" to devices,
+        "userPreferredCameraDevice" to preferredDevice
+    )
+  }
 
   // Required for NativeEventEmitter, this is just a dummy implementation:
   @ReactMethod

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -192,7 +192,7 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
   fun toMap(): ReadableMap {
     val map = Arguments.createMap()
     map.putString("id", cameraId)
-    map.putArray("devices", getDeviceTypes())
+    map.putArray("physicalDevices", getDeviceTypes())
     map.putString("position", lensFacing.unionValue)
     map.putString("name", name)
     map.putBoolean("hasFlash", hasFlash)

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -183,6 +183,7 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
     map.putDouble("fieldOfView", getFieldOfView())
     map.putBoolean("supportsVideoHDR", supportsVideoHdr)
     map.putBoolean("supportsPhotoHDR", supportsPhotoHdr)
+    map.putBoolean("supportsDepthCapture", supportsDepthCapture)
     map.putString("autoFocusSystem", "contrast-detection") // TODO: Is this wrong?
     map.putArray("videoStabilizationModes", createStabilizationModes())
     map.putArray("pixelFormats", createPixelFormats(videoSize))
@@ -199,7 +200,6 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
     map.putBoolean("hasTorch", hasFlash)
     map.putBoolean("isMultiCam", isMultiCam)
     map.putBoolean("supportsRawCapture", supportsRawCapture)
-    map.putBoolean("supportsDepthCapture", supportsDepthCapture)
     map.putBoolean("supportsLowLightBoost", supportsLowLightBoost)
     map.putBoolean("supportsFocus", true) // I believe every device here supports focussing
     map.putDouble("minZoom", minZoom)

--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -216,7 +216,7 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
         )}
         {supports60Fps && (
           <PressableOpacity style={styles.button} onPress={() => setTargetFps((t) => (t === 30 ? 60 : 30))}>
-            <Text style={styles.text}>{`${targetFps} FPS`}</Text>
+            <Text style={styles.text}>{`${targetFps}\nFPS`}</Text>
           </PressableOpacity>
         )}
         {supportsHdr && (

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -45,10 +45,10 @@ class CameraDevicesManager: RCTEventEmitter {
     } else {
       preferredDevice = devices[0]
     }
-    
+
     return [
       "availableCameraDevices": devices,
-      "userPreferredCameraDevice": preferredDevice
+      "userPreferredCameraDevice": preferredDevice,
     ]
   }
 

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -70,14 +70,22 @@ class CameraDevicesManager: RCTEventEmitter {
 
   private static func getAllDeviceTypes() -> [AVCaptureDevice.DeviceType] {
     var deviceTypes: [AVCaptureDevice.DeviceType] = []
+    deviceTypes.append(.builtInDualCamera)
+    deviceTypes.append(.builtInWideAngleCamera)
+    deviceTypes.append(.builtInTelephotoCamera)
+    deviceTypes.append(.builtInTrueDepthCamera)
     if #available(iOS 13.0, *) {
       deviceTypes.append(.builtInTripleCamera)
       deviceTypes.append(.builtInDualWideCamera)
       deviceTypes.append(.builtInUltraWideCamera)
     }
-    deviceTypes.append(.builtInDualCamera)
-    deviceTypes.append(.builtInWideAngleCamera)
-    deviceTypes.append(.builtInTelephotoCamera)
+    if #available(iOS 15.4, *) {
+      deviceTypes.append(.builtInLiDARDepthCamera)
+    }
+    if #available(iOS 17.0, *) {
+      deviceTypes.append(.external)
+      deviceTypes.append(.continuityCamera)
+    }
     return deviceTypes
   }
 }

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -37,33 +37,24 @@ class CameraDevicesManager: RCTEventEmitter {
   }
 
   override func constantsToExport() -> [AnyHashable: Any]! {
+    let devices = getDevicesJson()
+    let preferredDevice: [String: Any]
+    if #available(iOS 17.0, *),
+       let userPreferred = AVCaptureDevice.userPreferredCamera {
+      preferredDevice = userPreferred.toDictionary()
+    } else {
+      preferredDevice = devices[0]
+    }
+    
     return [
-      "availableCameraDevices": getDevicesJson(),
+      "availableCameraDevices": devices,
+      "userPreferredCameraDevice": preferredDevice
     ]
   }
 
   private func getDevicesJson() -> [[String: Any]] {
     return discoverySession.devices.map {
-      return [
-        "id": $0.uniqueID,
-        "physicalDevices": $0.physicalDevices.map(\.deviceType.physicalDeviceDescriptor),
-        "position": $0.position.descriptor,
-        "name": $0.localizedName,
-        "hasFlash": $0.hasFlash,
-        "hasTorch": $0.hasTorch,
-        "minZoom": $0.minAvailableVideoZoomFactor,
-        "neutralZoom": $0.neutralZoomFactor,
-        "maxZoom": $0.maxAvailableVideoZoomFactor,
-        "isMultiCam": $0.isMultiCam,
-        "supportsRawCapture": false, // TODO: supportsRawCapture
-        "supportsLowLightBoost": $0.isLowLightBoostSupported,
-        "supportsFocus": $0.isFocusPointOfInterestSupported,
-        "hardwareLevel": "full",
-        "sensorOrientation": "portrait", // TODO: Sensor Orientation?
-        "formats": $0.formats.map { format -> [String: Any] in
-          format.toDictionary()
-        },
-      ]
+      return $0.toDictionary()
     }
   }
 

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -55,7 +55,6 @@ class CameraDevicesManager: RCTEventEmitter {
         "neutralZoom": $0.neutralZoomFactor,
         "maxZoom": $0.maxAvailableVideoZoomFactor,
         "isMultiCam": $0.isMultiCam,
-        "supportsDepthCapture": false, // TODO: supportsDepthCapture
         "supportsRawCapture": false, // TODO: supportsRawCapture
         "supportsLowLightBoost": $0.isLowLightBoostSupported,
         "supportsFocus": $0.isFocusPointOfInterestSupported,

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -81,14 +81,15 @@ class CameraDevicesManager: RCTEventEmitter {
     if #available(iOS 15.4, *) {
       deviceTypes.append(.builtInLiDARDepthCamera)
     }
-    if #available(iOS 17.0, *) {
-      // This is only reported if `NSCameraUseExternalDeviceType` is set to true in Info.plist,
-      // otherwise external devices are just reported as wide-angle-cameras
-      // deviceTypes.append(.external)
-      // This is only reported if `NSCameraUseContinuityCameraDeviceType` is set to true in Info.plist,
-      // otherwise continuity camera devices are just reported as wide-angle-cameras
-      // deviceTypes.append(.continuityCamera)
-    }
+
+    // iOS 17 specifics:
+    //  This is only reported if `NSCameraUseExternalDeviceType` is set to true in Info.plist,
+    //  otherwise external devices are just reported as wide-angle-cameras
+    // deviceTypes.append(.external)
+    //  This is only reported if `NSCameraUseContinuityCameraDeviceType` is set to true in Info.plist,
+    //  otherwise continuity camera devices are just reported as wide-angle-cameras
+    // deviceTypes.append(.continuityCamera)
+
     return deviceTypes
   }
 }

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -39,12 +39,17 @@ class CameraDevicesManager: RCTEventEmitter {
   override func constantsToExport() -> [AnyHashable: Any]! {
     let devices = getDevicesJson()
     let preferredDevice: [String: Any]
-    if #available(iOS 17.0, *),
-       let userPreferred = AVCaptureDevice.userPreferredCamera {
-      preferredDevice = userPreferred.toDictionary()
-    } else {
+    // TODO: Remove this #if once Xcode 15 is rolled out
+    #if swift(>=5.9)
+      if #available(iOS 17.0, *),
+         let userPreferred = AVCaptureDevice.userPreferredCamera {
+        preferredDevice = userPreferred.toDictionary()
+      } else {
+        preferredDevice = devices[0]
+      }
+    #else
       preferredDevice = devices[0]
-    }
+    #endif
 
     return [
       "availableCameraDevices": devices,

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -83,8 +83,12 @@ class CameraDevicesManager: RCTEventEmitter {
       deviceTypes.append(.builtInLiDARDepthCamera)
     }
     if #available(iOS 17.0, *) {
-      deviceTypes.append(.external)
-      deviceTypes.append(.continuityCamera)
+      // This is only reported if `NSCameraUseExternalDeviceType` is set to true in Info.plist,
+      // otherwise external devices are just reported as wide-angle-cameras
+      // deviceTypes.append(.external)
+      // This is only reported if `NSCameraUseContinuityCameraDeviceType` is set to true in Info.plist,
+      // otherwise continuity camera devices are just reported as wide-angle-cameras
+      // deviceTypes.append(.continuityCamera)
     }
     return deviceTypes
   }

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -46,7 +46,7 @@ class CameraDevicesManager: RCTEventEmitter {
     return discoverySession.devices.map {
       return [
         "id": $0.uniqueID,
-        "devices": $0.physicalDevices.map(\.deviceType.descriptor),
+        "physicalDevices": $0.physicalDevices.map(\.deviceType.descriptor),
         "position": $0.position.descriptor,
         "name": $0.localizedName,
         "hasFlash": $0.hasFlash,

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -46,7 +46,7 @@ class CameraDevicesManager: RCTEventEmitter {
     return discoverySession.devices.map {
       return [
         "id": $0.uniqueID,
-        "physicalDevices": $0.physicalDevices.map(\.deviceType.descriptor),
+        "physicalDevices": $0.physicalDevices.map(\.deviceType.physicalDeviceDescriptor),
         "position": $0.position.descriptor,
         "name": $0.localizedName,
         "hasFlash": $0.hasFlash,

--- a/package/ios/CameraView+AVCaptureSession.swift
+++ b/package/ios/CameraView+AVCaptureSession.swift
@@ -84,6 +84,8 @@ extension CameraView {
           photoOutput!.isDualCameraDualPhotoDeliveryEnabled = photoOutput!.isDualCameraDualPhotoDeliverySupported
         }
       }
+      // TODO: Enable isResponsiveCaptureEnabled? (iOS 17+)
+      // TODO: Enable isFastCapturePrioritizationEnabled? (iOS 17+)
       if enableDepthData {
         photoOutput!.isDepthDataDeliveryEnabled = photoOutput!.isDepthDataDeliverySupported
       }

--- a/package/ios/Extensions/AVCaptureDevice+toDictionary.swift
+++ b/package/ios/Extensions/AVCaptureDevice+toDictionary.swift
@@ -1,0 +1,34 @@
+//
+//  AVCaptureDevice+toDictionary.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 21.09.23.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+import AVFoundation
+
+extension AVCaptureDevice {
+  func toDictionary() -> [String: Any] {
+    return [
+      "id": uniqueID,
+      "physicalDevices": physicalDevices.map(\.deviceType.physicalDeviceDescriptor),
+      "position": position.descriptor,
+      "name": localizedName,
+      "hasFlash": hasFlash,
+      "hasTorch": hasTorch,
+      "minZoom": minAvailableVideoZoomFactor,
+      "neutralZoom": neutralZoomFactor,
+      "maxZoom": maxAvailableVideoZoomFactor,
+      "isMultiCam": isMultiCam,
+      "supportsRawCapture": false, // TODO: supportsRawCapture
+      "supportsLowLightBoost": isLowLightBoostSupported,
+      "supportsFocus": isFocusPointOfInterestSupported,
+      "hardwareLevel": "full",
+      "sensorOrientation": "portrait", // TODO: Sensor Orientation?
+      "formats": formats.map { format -> [String: Any] in
+        format.toDictionary()
+      },
+    ]
+  }
+}

--- a/package/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
+++ b/package/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
@@ -55,6 +55,7 @@ extension AVCaptureDevice.Format {
       "minFps": minFrameRate,
       "maxFps": maxFrameRate,
       "pixelFormats": pixelFormats.map(\.unionValue),
+      "supportsDepthCapture": supportedDepthDataFormats.count > 0
     ]
   }
 }

--- a/package/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
+++ b/package/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
@@ -55,7 +55,7 @@ extension AVCaptureDevice.Format {
       "minFps": minFrameRate,
       "maxFps": maxFrameRate,
       "pixelFormats": pixelFormats.map(\.unionValue),
-      "supportsDepthCapture": supportedDepthDataFormats.count > 0
+      "supportsDepthCapture": !supportedDepthDataFormats.isEmpty,
     ]
   }
 }

--- a/package/ios/Parsers/AVCaptureDevice.DeviceType+descriptor.swift
+++ b/package/ios/Parsers/AVCaptureDevice.DeviceType+descriptor.swift
@@ -12,27 +12,19 @@ import Foundation
 extension AVCaptureDevice.DeviceType {
   var descriptor: String {
     if #available(iOS 13.0, *) {
-      switch self {
-      case .builtInDualWideCamera:
-        return "dual-wide-camera"
-      case .builtInTripleCamera:
-        return "triple-camera"
-      case .builtInUltraWideCamera:
+      if self == .builtInUltraWideCamera {
         return "ultra-wide-angle-camera"
-      default:
-        break
       }
     }
     switch self {
-    case .builtInDualCamera:
-      return "dual-camera"
     case .builtInTelephotoCamera:
       return "telephoto-camera"
     case .builtInWideAngleCamera:
       return "wide-angle-camera"
     default:
       // e.g. `.builtInTrueDepthCamera`
-      fatalError("AVCaptureDevice.Position has unknown state.")
+      ReactLogger.log(level: .error, message: "Unknown AVCaptureDevice.DeviceType (\(self.rawValue))! Falling back to wide-angle-camera..")
+      return "wide-angle-camera"
     }
   }
 }

--- a/package/ios/Parsers/AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift
+++ b/package/ios/Parsers/AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift
@@ -1,5 +1,5 @@
 //
-//  AVCaptureDevice.DeviceType+descriptor.swift
+//  AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift
 //  mrousavy
 //
 //  Created by Marc Rousavy on 15.12.20.
@@ -10,7 +10,10 @@ import AVFoundation
 import Foundation
 
 extension AVCaptureDevice.DeviceType {
-  var descriptor: String {
+  /**
+   Gets a descriptor if this is a physical device (wide, ultra-wide and telephoto), or "unknown-camera" otherwise (TrueDepth, LiDAR, InfraRed, USB, ..)
+   */
+  var physicalDeviceDescriptor: String {
     if #available(iOS 13.0, *) {
       if self == .builtInUltraWideCamera {
         return "ultra-wide-angle-camera"
@@ -22,7 +25,7 @@ extension AVCaptureDevice.DeviceType {
     case .builtInWideAngleCamera:
       return "wide-angle-camera"
     default:
-      // e.g. `.builtInTrueDepthCamera`
+      // e.g. Infra-Red, LiDAR, Depth Data, USB or Continuity Camera Devices
       ReactLogger.log(level: .error, message: "Unknown AVCaptureDevice.DeviceType (\(self.rawValue))! Falling back to wide-angle-camera..")
       return "wide-angle-camera"
     }

--- a/package/ios/Parsers/AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift
+++ b/package/ios/Parsers/AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift
@@ -26,7 +26,7 @@ extension AVCaptureDevice.DeviceType {
       return "wide-angle-camera"
     default:
       // e.g. Infra-Red, LiDAR, Depth Data, USB or Continuity Camera Devices
-      ReactLogger.log(level: .error, message: "Unknown AVCaptureDevice.DeviceType (\(self.rawValue))! Falling back to wide-angle-camera..")
+      ReactLogger.log(level: .error, message: "Unknown AVCaptureDevice.DeviceType (\(rawValue))! Falling back to wide-angle-camera..")
       return "wide-angle-camera"
     }
   }

--- a/package/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/package/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B86DC974260E310600FB17B2 /* CameraView+AVAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86DC973260E310600FB17B2 /* CameraView+AVAudioSession.swift */; };
 		B86DC977260E315100FB17B2 /* CameraView+AVCaptureSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86DC976260E315100FB17B2 /* CameraView+AVCaptureSession.swift */; };
 		B87B11BF2A8E63B700732EBF /* PixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87B11BE2A8E63B700732EBF /* PixelFormat.swift */; };
+		B881D35E2ABC775E009B21C8 /* AVCaptureDevice+toDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B881D35D2ABC775E009B21C8 /* AVCaptureDevice+toDictionary.swift */; };
 		B882721026AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B882720F26AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift */; };
 		B887518525E0102000DB86D6 /* PhotoCaptureDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887515C25E0102000DB86D6 /* PhotoCaptureDelegate.swift */; };
 		B887518625E0102000DB86D6 /* CameraView+RecordVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887515D25E0102000DB86D6 /* CameraView+RecordVideo.swift */; };
@@ -99,6 +100,7 @@
 		B86DC973260E310600FB17B2 /* CameraView+AVAudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CameraView+AVAudioSession.swift"; sourceTree = "<group>"; };
 		B86DC976260E315100FB17B2 /* CameraView+AVCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CameraView+AVCaptureSession.swift"; sourceTree = "<group>"; };
 		B87B11BE2A8E63B700732EBF /* PixelFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelFormat.swift; sourceTree = "<group>"; };
+		B881D35D2ABC775E009B21C8 /* AVCaptureDevice+toDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice+toDictionary.swift"; sourceTree = "<group>"; };
 		B882720F26AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureConnection+setInterfaceOrientation.swift"; sourceTree = "<group>"; };
 		B887515C25E0102000DB86D6 /* PhotoCaptureDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoCaptureDelegate.swift; sourceTree = "<group>"; };
 		B887515D25E0102000DB86D6 /* CameraView+RecordVideo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CameraView+RecordVideo.swift"; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 				B887516625E0102000DB86D6 /* AVCaptureDevice+physicalDevices.swift */,
 				B887516725E0102000DB86D6 /* AVFrameRateRange+includes.swift */,
 				B887516825E0102000DB86D6 /* AVCapturePhotoOutput+mirror.swift */,
+				B881D35D2ABC775E009B21C8 /* AVCaptureDevice+toDictionary.swift */,
 				B887516925E0102000DB86D6 /* AVCaptureDevice.Format+matchesFilter.swift */,
 				B887516A25E0102000DB86D6 /* AVCaptureDevice.Format+toDictionary.swift */,
 				B88B47462667C8E00091F538 /* AVCaptureSession+setVideoStabilizationMode.swift */,
@@ -408,6 +411,7 @@
 				B887519A25E0102000DB86D6 /* AVVideoCodecType+descriptor.swift in Sources */,
 				B88751A825E0102000DB86D6 /* CameraError.swift in Sources */,
 				B85F7AE92A77BB680089C539 /* FrameProcessorPlugin.m in Sources */,
+				B881D35E2ABC775E009B21C8 /* AVCaptureDevice+toDictionary.swift in Sources */,
 				B87B11BF2A8E63B700732EBF /* PixelFormat.swift in Sources */,
 				B88751A625E0102000DB86D6 /* CameraViewManager.swift in Sources */,
 				B887519F25E0102000DB86D6 /* AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift in Sources */,

--- a/package/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/package/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		B887519A25E0102000DB86D6 /* AVVideoCodecType+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887517525E0102000DB86D6 /* AVVideoCodecType+descriptor.swift */; };
 		B887519C25E0102000DB86D6 /* AVCaptureDevice.TorchMode+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887517725E0102000DB86D6 /* AVCaptureDevice.TorchMode+descriptor.swift */; };
 		B887519E25E0102000DB86D6 /* AVCapturePhotoOutput.QualityPrioritization+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887517925E0102000DB86D6 /* AVCapturePhotoOutput.QualityPrioritization+descriptor.swift */; };
-		B887519F25E0102000DB86D6 /* AVCaptureDevice.DeviceType+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887517A25E0102000DB86D6 /* AVCaptureDevice.DeviceType+descriptor.swift */; };
+		B887519F25E0102000DB86D6 /* AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887517A25E0102000DB86D6 /* AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift */; };
 		B88751A025E0102000DB86D6 /* AVAuthorizationStatus+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887517B25E0102000DB86D6 /* AVAuthorizationStatus+descriptor.swift */; };
 		B88751A125E0102000DB86D6 /* AVCaptureDevice.Position+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887517C25E0102000DB86D6 /* AVCaptureDevice.Position+descriptor.swift */; };
 		B88751A325E0102000DB86D6 /* AVCaptureDevice.FlashMode+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887517E25E0102000DB86D6 /* AVCaptureDevice.FlashMode+descriptor.swift */; };
@@ -122,7 +122,7 @@
 		B887517525E0102000DB86D6 /* AVVideoCodecType+descriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVVideoCodecType+descriptor.swift"; sourceTree = "<group>"; };
 		B887517725E0102000DB86D6 /* AVCaptureDevice.TorchMode+descriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice.TorchMode+descriptor.swift"; sourceTree = "<group>"; };
 		B887517925E0102000DB86D6 /* AVCapturePhotoOutput.QualityPrioritization+descriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVCapturePhotoOutput.QualityPrioritization+descriptor.swift"; sourceTree = "<group>"; };
-		B887517A25E0102000DB86D6 /* AVCaptureDevice.DeviceType+descriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice.DeviceType+descriptor.swift"; sourceTree = "<group>"; };
+		B887517A25E0102000DB86D6 /* AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift"; sourceTree = "<group>"; };
 		B887517B25E0102000DB86D6 /* AVAuthorizationStatus+descriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVAuthorizationStatus+descriptor.swift"; sourceTree = "<group>"; };
 		B887517C25E0102000DB86D6 /* AVCaptureDevice.Position+descriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice.Position+descriptor.swift"; sourceTree = "<group>"; };
 		B887517E25E0102000DB86D6 /* AVCaptureDevice.FlashMode+descriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice.FlashMode+descriptor.swift"; sourceTree = "<group>"; };
@@ -239,7 +239,7 @@
 				B887517525E0102000DB86D6 /* AVVideoCodecType+descriptor.swift */,
 				B887517725E0102000DB86D6 /* AVCaptureDevice.TorchMode+descriptor.swift */,
 				B887517925E0102000DB86D6 /* AVCapturePhotoOutput.QualityPrioritization+descriptor.swift */,
-				B887517A25E0102000DB86D6 /* AVCaptureDevice.DeviceType+descriptor.swift */,
+				B887517A25E0102000DB86D6 /* AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift */,
 				B887517B25E0102000DB86D6 /* AVAuthorizationStatus+descriptor.swift */,
 				B887517C25E0102000DB86D6 /* AVCaptureDevice.Position+descriptor.swift */,
 				B887517E25E0102000DB86D6 /* AVCaptureDevice.FlashMode+descriptor.swift */,
@@ -410,7 +410,7 @@
 				B85F7AE92A77BB680089C539 /* FrameProcessorPlugin.m in Sources */,
 				B87B11BF2A8E63B700732EBF /* PixelFormat.swift in Sources */,
 				B88751A625E0102000DB86D6 /* CameraViewManager.swift in Sources */,
-				B887519F25E0102000DB86D6 /* AVCaptureDevice.DeviceType+descriptor.swift in Sources */,
+				B887519F25E0102000DB86D6 /* AVCaptureDevice.DeviceType+physicalDeviceDescriptor.swift in Sources */,
 				B8D22CDC2642DB4D00234472 /* AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift in Sources */,
 				B84760DF2608F57D004C3180 /* CameraQueues.swift in Sources */,
 				B8446E502ABA14C900E56077 /* CameraDevicesManager.m in Sources */,

--- a/package/src/CameraDevice.ts
+++ b/package/src/CameraDevice.ts
@@ -90,6 +90,10 @@ export interface CameraDeviceFormat {
    */
   supportsPhotoHDR: boolean;
   /**
+   * Specifies whether this format supports delivering depth data for photo or video capture.
+   */
+  supportsDepthCapture: boolean;
+  /**
    * The minum frame rate this Format needs to run at. High resolution formats often run at lower frame rates.
    */
   minFps: number;
@@ -187,12 +191,6 @@ export interface CameraDevice {
    * Whether this camera device supports low light boost.
    */
   supportsLowLightBoost: boolean;
-  /**
-   * Whether this camera supports taking photos with depth data.
-   *
-   * **! Work in Progress !**
-   */
-  supportsDepthCapture: boolean;
   /**
    * Whether this camera supports taking photos in RAW format
    *

--- a/package/src/CameraDevice.ts
+++ b/package/src/CameraDevice.ts
@@ -121,14 +121,14 @@ export interface CameraDevice {
    */
   id: string;
   /**
-   * The physical devices this `CameraDevice` contains.
+   * The physical devices this `CameraDevice` consists of.
    *
-   * * If this camera device is a **logical camera** (combination of multiple physical cameras), there are multiple cameras in this array.
-   * * If this camera device is a **physical camera**, there is only a single element in this array.
+   * * If this camera device is a **logical camera** (combination of multiple physical cameras, e.g. "Triple Camera"), there are multiple cameras in this array.
+   * * If this camera device is a **physical camera** (e.g. "wide-angle-camera"), there is only a single element in this array.
    *
    * You can check if the camera is a logical multi-camera by using the `isMultiCam` property.
    */
-  devices: PhysicalCameraDeviceType[];
+  physicalDevices: PhysicalCameraDeviceType[];
   /**
    * Specifies the physical position of this camera. (back or front)
    */

--- a/package/src/CameraDevice.ts
+++ b/package/src/CameraDevice.ts
@@ -14,7 +14,7 @@ export type CameraPosition = 'front' | 'back' | 'external';
  * Indentifiers for a physical camera (one that actually exists on the back/front of the device)
  *
  * * `"ultra-wide-angle-camera"`: A built-in camera with a shorter focal length than that of a wide-angle camera. (focal length between below 24mm)
- * * `"wide-angle-camera"`: A built-in wide-angle camera. (focal length between 24mm and 35mm)
+ * * `"wide-angle-camera"`: A built-in wide-angle camera. (focal length between 24mm and 43mm)
  * * `"telephoto-camera"`: A built-in camera device with a longer focal length than a wide-angle camera. (focal length between above 85mm)
  *
  * Some Camera devices consist of multiple physical devices. They can be interpreted as _logical devices_, for example:

--- a/package/src/CameraDevices.ts
+++ b/package/src/CameraDevices.ts
@@ -4,6 +4,7 @@ import { CameraDevice } from './CameraDevice';
 const CameraDevicesManager = NativeModules.CameraDevices as {
   getConstants: () => {
     availableCameraDevices: CameraDevice[];
+    userPreferredCameraDevice: CameraDevice | undefined;
   };
 };
 
@@ -18,6 +19,7 @@ eventEmitter.addListener(DEVICES_CHANGED_NAME, (newDevices: CameraDevice[]) => {
 });
 
 export const CameraDevices = {
+  userPreferredCameraDevice: () => constants.userPreferredCameraDevice,
   getAvailableCameraDevices: () => devices,
   addCameraDevicesChangedListener: (callback: (newDevices: CameraDevice[]) => void) => {
     return eventEmitter.addListener(DEVICES_CHANGED_NAME, callback);

--- a/package/src/CameraDevices.ts
+++ b/package/src/CameraDevices.ts
@@ -19,7 +19,7 @@ eventEmitter.addListener(DEVICES_CHANGED_NAME, (newDevices: CameraDevice[]) => {
 });
 
 export const CameraDevices = {
-  userPreferredCameraDevice: () => constants.userPreferredCameraDevice,
+  userPreferredCameraDevice: constants.userPreferredCameraDevice,
   getAvailableCameraDevices: () => devices,
   addCameraDevicesChangedListener: (callback: (newDevices: CameraDevice[]) => void) => {
     return eventEmitter.addListener(DEVICES_CHANGED_NAME, callback);

--- a/package/src/devices/getCameraDevice.ts
+++ b/package/src/devices/getCameraDevice.ts
@@ -43,11 +43,11 @@ export function getCameraDevice(devices: CameraDevice[], position: CameraPositio
     // 1. user wants all cameras ([ultra-wide, wide, tele]) to zoom. prefer those devices that have all 3 cameras.
     // 2. user wants only one ([wide]) for faster performance. prefer those devices that only have one camera, if they have more, we rank them lower.
     if (filter.physicalDevices != null) {
-      for (const device of left.devices) {
+      for (const device of left.physicalDevices) {
         if (filter.physicalDevices.includes(device)) leftPoints += 1;
         else leftPoints -= 1;
       }
-      for (const device of right.devices) {
+      for (const device of right.physicalDevices) {
         if (filter.physicalDevices.includes(device)) rightPoints += 1;
         else rightPoints -= 1;
       }


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR consists of 3 changes:

1. ⚠️ BREAKING CHANGE: Renames `CameraDevice.devices` to `CameraDevice.physicalDevices`
2. Adds support for **four new Camera Devices** on iOS:
    - [External](https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/4172590-external) Cameras (On iPad, external devices are those that conform to the UVC (USB Video Class) specification)
    - [Continuity](https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/4157134-continuitycamera) Cameras (e.g. your Mac's Camera streamed through AirPlay)
    - [True Depth](https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/2933376-builtintruedepthcamera) Camera (a Camera device streaming both depth data (through Infrared) and colors (YUV))
    - [LiDAR](https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/3915812-builtinlidardepthcamera) Camera (a Camera device streaming both depth data (through a LiDAR sensor) and colors (YUV))
    This is based on https://github.com/mrousavy/react-native-vision-camera/pull/1784 which adds a new Camera Devices API that allows us to listen for Camera Device changes (USB camera plugged in/out)
    EDIT: Actually external and continuity camera devices were supported before (after the change in #1784), they were just reported as wide-angle cameras. I think I'm gonna leave it at that for now, no need to change that.
3. Expose `userPreferredCameraDevice`, which is a device the user prefers to use across apps (iOS 17). If not set, use the first available Camera Device (usually id 0)

### Blockers

Currently, a device looks like this:

```json
{
  devices: ('wide-angle-camera' | 'ultra-wide-angle-camera' | 'telephoto-camera')[]
  position: 'front' | 'back' | 'external'
}
```

But the external and continuity cameras don't have the device types. They don't tell me whether they're wide-angle or ultra-wide etc., they just say they're external. Therefore I either need to add a `unknown` or `external` type to the devices, which is kinda lame as the lens information should be known (through FOV/focal length). Only the position should be `external` in that case.
I'll need to investigate this, but unfortunately I don't have a device to test this on. **Someone wanna borrow me an iPad?**

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
