### PR TITLE
feat: Add support for Buffer Compression for a more efficient Video Pipeline (`enableBufferCompression`)

### DIFF
--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -40,6 +40,7 @@ public final class CameraView: UIView {
   @objc var enableDepthData = false
   @objc var enableHighQualityPhotos: NSNumber? // nullable bool
   @objc var enablePortraitEffectsMatteDelivery = false
+  @objc var enableBufferCompression = false
   // use cases
   @objc var photo: NSNumber? // nullable bool
   @objc var video: NSNumber? // nullable bool

--- a/package/ios/CameraViewManager.m
+++ b/package/ios/CameraViewManager.m
@@ -28,6 +28,7 @@ RCT_EXPORT_VIEW_PROPERTY(cameraId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enableDepthData, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(enableHighQualityPhotos, NSNumber); // nullable bool
 RCT_EXPORT_VIEW_PROPERTY(enablePortraitEffectsMatteDelivery, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(enableBufferCompression, BOOL);
 // use cases
 RCT_EXPORT_VIEW_PROPERTY(photo, NSNumber); // nullable bool
 RCT_EXPORT_VIEW_PROPERTY(video, NSNumber); // nullable bool

--- a/package/ios/Extensions/AVCaptureVideoDataOutput+findPixelFormat.swift
+++ b/package/ios/Extensions/AVCaptureVideoDataOutput+findPixelFormat.swift
@@ -1,0 +1,21 @@
+//
+//  AVCaptureVideoDataOutput+findPixelFormat.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 21.09.23.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+import AVFoundation
+
+extension AVCaptureVideoDataOutput {
+  /**
+   Of the given list, find the first that is available on this video data output.
+   If none are supported, this returns nil.
+   */
+  func findPixelFormat(firstOf pixelFormats: [OSType]) -> OSType? {
+    return pixelFormats.first { format in
+      availableVideoPixelFormatTypes.contains(format)
+    }
+  }
+}

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -154,9 +154,15 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     auto mediaType = CMFormatDescriptionGetMediaSubType(format);
     switch (mediaType) {
       case kCVPixelFormatType_32BGRA:
+      case kCVPixelFormatType_Lossless_32BGRA:
         return jsi::String::createFromUtf8(runtime, "rgb");
       case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
       case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+      case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+      case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+      case kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange:
+      case kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange:
+      case kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange:
         return jsi::String::createFromUtf8(runtime, "yuv");
       default:
         return jsi::String::createFromUtf8(runtime, "unknown");

--- a/package/ios/Parsers/PixelFormat.swift
+++ b/package/ios/Parsers/PixelFormat.swift
@@ -50,11 +50,15 @@ enum PixelFormat {
 
   init(mediaSubType: OSType) {
     switch mediaSubType {
-    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+         kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+         kCVPixelFormatType_420YpCbCr10BiPlanarFullRange,
+         kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
+         kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange,
+         kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange,
+         kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange:
       self = .yuv
-    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
-      self = .yuv
-    case kCVPixelFormatType_32BGRA:
+    case kCVPixelFormatType_32BGRA, kCVPixelFormatType_Lossless_32BGRA:
       self = .rgb
     default:
       self = .unknown

--- a/package/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/package/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		B86DC977260E315100FB17B2 /* CameraView+AVCaptureSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86DC976260E315100FB17B2 /* CameraView+AVCaptureSession.swift */; };
 		B87B11BF2A8E63B700732EBF /* PixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87B11BE2A8E63B700732EBF /* PixelFormat.swift */; };
 		B881D35E2ABC775E009B21C8 /* AVCaptureDevice+toDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B881D35D2ABC775E009B21C8 /* AVCaptureDevice+toDictionary.swift */; };
+		B881D3602ABC8E4E009B21C8 /* AVCaptureVideoDataOutput+findPixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B881D35F2ABC8E4E009B21C8 /* AVCaptureVideoDataOutput+findPixelFormat.swift */; };
 		B882721026AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B882720F26AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift */; };
 		B887518525E0102000DB86D6 /* PhotoCaptureDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887515C25E0102000DB86D6 /* PhotoCaptureDelegate.swift */; };
 		B887518625E0102000DB86D6 /* CameraView+RecordVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B887515D25E0102000DB86D6 /* CameraView+RecordVideo.swift */; };
@@ -101,6 +102,7 @@
 		B86DC976260E315100FB17B2 /* CameraView+AVCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CameraView+AVCaptureSession.swift"; sourceTree = "<group>"; };
 		B87B11BE2A8E63B700732EBF /* PixelFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelFormat.swift; sourceTree = "<group>"; };
 		B881D35D2ABC775E009B21C8 /* AVCaptureDevice+toDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice+toDictionary.swift"; sourceTree = "<group>"; };
+		B881D35F2ABC8E4E009B21C8 /* AVCaptureVideoDataOutput+findPixelFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureVideoDataOutput+findPixelFormat.swift"; sourceTree = "<group>"; };
 		B882720F26AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureConnection+setInterfaceOrientation.swift"; sourceTree = "<group>"; };
 		B887515C25E0102000DB86D6 /* PhotoCaptureDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoCaptureDelegate.swift; sourceTree = "<group>"; };
 		B887515D25E0102000DB86D6 /* CameraView+RecordVideo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CameraView+RecordVideo.swift"; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 				B887516A25E0102000DB86D6 /* AVCaptureDevice.Format+toDictionary.swift */,
 				B88B47462667C8E00091F538 /* AVCaptureSession+setVideoStabilizationMode.swift */,
 				B887516225E0102000DB86D6 /* Collection+safe.swift */,
+				B881D35F2ABC8E4E009B21C8 /* AVCaptureVideoDataOutput+findPixelFormat.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 				B88751A125E0102000DB86D6 /* AVCaptureDevice.Position+descriptor.swift in Sources */,
 				B882721026AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift in Sources */,
 				B8E957D02A693AD2008F5480 /* CameraView+Torch.swift in Sources */,
+				B881D3602ABC8E4E009B21C8 /* AVCaptureVideoDataOutput+findPixelFormat.swift in Sources */,
 				B86DC977260E315100FB17B2 /* CameraView+AVCaptureSession.swift in Sources */,
 				B887518A25E0102000DB86D6 /* AVCaptureDevice+neutralZoom.swift in Sources */,
 				B88751A325E0102000DB86D6 /* AVCaptureDevice.FlashMode+descriptor.swift in Sources */,

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -403,6 +403,8 @@ export class Camera extends React.PureComponent<CameraProps> {
       );
     }
 
+    const shouldEnableBufferCompression = props.video === true && frameProcessor == null;
+
     return (
       <NativeCameraView
         {...props}
@@ -412,6 +414,7 @@ export class Camera extends React.PureComponent<CameraProps> {
         onInitialized={this.onInitialized}
         onError={this.onError}
         enableFrameProcessor={frameProcessor != null}
+        enableBufferCompression={props.enableBufferCompression ?? shouldEnableBufferCompression}
       />
     );
   }

--- a/package/src/CameraProps.ts
+++ b/package/src/CameraProps.ts
@@ -124,6 +124,27 @@ export interface CameraProps extends ViewProps {
    */
   hdr?: boolean;
   /**
+   * Enables or disables lossless buffer compression for the video stream.
+   * If you only use {@linkcode video} or a {@linkcode frameProcessor}, this
+   * can increase the efficiency and lower memory usage of the Camera.
+   *
+   * If buffer compression is enabled, the video pipeline will try to use a
+   * lossless-compressed pixel format instead of the normal one.
+   *
+   * If you use a {@linkcode frameProcessor}, you might need to change how pixels
+   * are read inside your native frame processor function as this is different
+   * from the usual `yuv` or `rgb` layout.
+   *
+   * If buffer compression is not available but this property is enabled, the normal
+   * pixel formats will be used and no error will be thrown.
+   *
+   * @platform iOS
+   * @default
+   * - true // if video={true} and frameProcessor={undefined}
+   * - false // otherwise
+   */
+  enableBufferCompression?: boolean;
+  /**
    * Enables or disables low-light boost on this camera device. Make sure the given `format` supports low-light boost.
    *
    * Requires `format` to be set.


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds a new prop called `enableBufferCompression` that uses the lossless compressed pixel formats if it is supported.

This makes the Video Pipeline much more efficient and reduces memory-usage. 

By default it is enabled if `video` is `true` and `frameProcessor` is `undefined`. If you have a `frameProcessor` set, you need to manually opt in to buffer compression because the pixels might be in a different layout than what your native frame processor might expect.

If `enableBufferCompression` is `true`, the following pixel formats will be replaced with lossless compressed formats:

| Uncompressed Format | Compressed Format Equivalent |
| --------------------|------------------------------|
| `kCVPixelFormatType_32BGRA` | `kCVPixelFormatType_Lossless_32BGRA` |
| `kCVPixelFormatType_420YpCbCr8BiPlanarFullRange` | `kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange` |
| `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange` | `kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange` |
| `kCVPixelFormatType_420YpCbCr10BiPlanarFullRange` | `kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange` |
| `kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange` | `kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange` |

If you want to learn more about this:
- See [this 36min long video from WWDC](https://developer.apple.com/videos/play/wwdc2021/10047/)
- there is literally no other documentation on this, lol. It's all just private APIs. I spent way too much time on this now.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
