### PR TITLE
fix: (V2) Android build problem for static minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,7 +135,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
 
     if (ENABLE_FRAME_PROCESSORS) {


### PR DESCRIPTION
## What

This PR fixes Android build for a static `minSdkVersion`.

## Changes

This PR changes `minSdkVersion` value from `21` to `getExtOrIntegerDefault('minSdkVersion')`

## Tested on

Android with this config (RN 0.71.13):
```
buildToolsVersion = "33.0.0"
minSdkVersion = 23
compileSdkVersion = 33
targetSdkVersion = 33
```
## Related issues

[stemyke comment #1814](https://github.com/mrousavy/react-native-vision-camera/issues/1814#issuecomment-1729395134)
