### PR TITLE
fix: Allow `getCameraDevice` to return `undefined` when no Devices are available (e.g. iOS Simulator)

### DIFF
--- a/package/src/devices/getCameraDevice.ts
+++ b/package/src/devices/getCameraDevice.ts
@@ -1,5 +1,4 @@
 import { CameraDevice, CameraPosition, PhysicalCameraDeviceType } from '../CameraDevice';
-import { CameraRuntimeError } from '../CameraError';
 
 export interface DeviceFilter {
   /**
@@ -24,7 +23,7 @@ export interface DeviceFilter {
 }
 
 /**
- * Get the best matching Camera device that best satisfies your requirements using a sorting filter.
+ * Get the best matching Camera device that best satisfies your requirements using a sorting filter, or `undefined` if {@linkcode devices} does not contain any devices.
  * @param position The position of the Camera device relative to the phone.
  * @param filter The filter you want to use. The Camera device that matches your filter the closest will be returned
  * @returns The Camera device that matches your filter the closest, or `undefined` if no such Camera Device exists on the given {@linkcode position}.
@@ -36,13 +35,13 @@ export interface DeviceFilter {
  * })
  * ```
  */
-export function getCameraDevice(devices: CameraDevice[], position: CameraPosition, filter: DeviceFilter = {}): CameraDevice {
+export function getCameraDevice(devices: CameraDevice[], position: CameraPosition, filter: DeviceFilter = {}): CameraDevice | undefined {
   const explicitlyWantsNonWideAngle = filter.physicalDevices != null && !filter.physicalDevices.includes('wide-angle-camera');
 
   const filtered = devices.filter((d) => d.position === position);
 
   let bestDevice = filtered[0];
-  if (bestDevice == null) throw new CameraRuntimeError('device/invalid-device', 'No Camera Device could be found!');
+  if (bestDevice == null) return undefined;
 
   // Compare each device using a point scoring system
   for (const device of devices) {


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

On an iOS simulator, `getAvailableCameraDevices()` returns `[]` (there are no cameras unfortunately).

This PR returns `undefined` instead of throwing an error if no device can be found.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #1847 

cc @hamdij0maa

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
