### PR TITLE
Fix: wrong image format check in videopipeline

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
@@ -1,5 +1,5 @@
 package com.mrousavy.camera.frameprocessor;
-
+import android.hardware.HardwareBuffer;
 import android.graphics.ImageFormat;
 import android.media.Image;
 import com.facebook.proguard.annotations.DoNotStrip;
@@ -113,6 +113,7 @@ public class Frame {
 
                 return byteArrayCache;
             case ImageFormat.JPEG:
+            case HardwareBuffer.RGBA_8888:
                 return image.getPlanes()[0].getBuffer();
             default:
                 throw new RuntimeException("Cannot convert Frame with Format " + image.getFormat() + " to byte array!");


### PR DESCRIPTION
## What

when using `rgb` with `frameProcessors` app hangs in a black screen and throws
```sh
E  Failed to configure session: [device/pixel-format-not-supported] The pixelFormat rgb is currently not supported in the VideoPipeline! See this issue for more details ($4.000 bounty!): https://github.com/mrousavy/react-native-vision-camera/issues/1837
com.mrousavy.camera.PixelFormatNotSupportedInVideoPipelineError: [device/pixel-format-not-supported] The pixelFormat rgb is currently not supported in the VideoPipeline! See this issue for more details ($4.000 bounty!): https://github.com/mrousavy/react-native-vision-camera/issues/1837
at com.mrousavy.camera.core.VideoPipeline.<init>(VideoPipeline.kt:80)
at com.mrousavy.camera.core.outputs.CameraOutputs.<init>(CameraOutputs.kt:138)
at com.mrousavy.camera.core.CameraSession.configureSession(CameraSession.kt:145)
at com.mrousavy.camera.CameraView.configureSession(CameraView.kt:218)
at com.mrousavy.camera.CameraView.access$configureSession(CameraView.kt:43)
at com.mrousavy.camera.CameraView$setupPreviewView$previewView$1.invoke(CameraView.kt:141)
at com.mrousavy.camera.CameraView$setupPreviewView$previewView$1.invoke(CameraView.kt:139)
at com.mrousavy.camera.core.PreviewView$1.surfaceCreated(PreviewView.kt:27)
at android.view.SurfaceView.updateSurface(SurfaceView.java:1266)
at android.view.SurfaceView.lambda$new$0$SurfaceView(SurfaceView.java:179)
at android.view.-$$Lambda$SurfaceView$w68OV7dB_zKVNsA-r0IrAUtyWas.onPreDraw(Unknown Source:2)
at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:1093)
at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3229)
at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2066)
at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8496)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1076)
at android.view.Choreographer.doCallbacks(Choreographer.java:897)
at android.view.Choreographer.doFrame(Choreographer.java:826)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1061)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:236)
at android.app.ActivityThread.main(ActivityThread.java:8061)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:656)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)
```

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

- android 11 / mi 9t pro

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
