### PR TITLE
fix: Incorrect zoom on Android < 11

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -479,12 +479,20 @@ class CameraSession(
     )
 
     // Zoom
+    val cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId!!)
+    val zoomRange = (
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        cameraCharacteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE)
+      } else {
+        null
+      }
+    ) ?: Range(1f, cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM) ?: 1f)
+    val zoomClamped = zoomRange.clamp(zoom)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      captureRequest.set(CaptureRequest.CONTROL_ZOOM_RATIO, zoom)
+      captureRequest.set(CaptureRequest.CONTROL_ZOOM_RATIO, zoomClamped)
     } else {
-      val cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId!!)
       val size = cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)!!
-      captureRequest.set(CaptureRequest.SCALER_CROP_REGION, size.zoomed(zoom))
+      captureRequest.set(CaptureRequest.SCALER_CROP_REGION, size.zoomed(zoomClamped))
     }
 
     // Torch Mode

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -30,7 +30,7 @@ import com.mrousavy.camera.extensions.capture
 import com.mrousavy.camera.extensions.createCaptureSession
 import com.mrousavy.camera.extensions.createPhotoCaptureRequest
 import com.mrousavy.camera.extensions.openCamera
-import com.mrousavy.camera.extensions.zoomed
+import com.mrousavy.camera.extensions.setZoom
 import com.mrousavy.camera.frameprocessor.FrameProcessor
 import com.mrousavy.camera.parsers.Flash
 import com.mrousavy.camera.parsers.Orientation
@@ -480,20 +480,7 @@ class CameraSession(
 
     // Zoom
     val cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId!!)
-    val zoomRange = (
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        cameraCharacteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE)
-      } else {
-        null
-      }
-    ) ?: Range(1f, cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM) ?: 1f)
-    val zoomClamped = zoomRange.clamp(zoom)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      captureRequest.set(CaptureRequest.CONTROL_ZOOM_RATIO, zoomClamped)
-    } else {
-      val size = cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)!!
-      captureRequest.set(CaptureRequest.SCALER_CROP_REGION, size.zoomed(zoomClamped))
-    }
+    captureRequest.setZoom(zoom, cameraCharacteristics)
 
     // Torch Mode
     val torchMode = if (torch == true) CaptureRequest.FLASH_MODE_TORCH else CaptureRequest.FLASH_MODE_OFF

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraDevice+createPhotoCaptureRequest.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraDevice+createPhotoCaptureRequest.kt
@@ -4,8 +4,6 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CaptureRequest
-import android.os.Build
-import android.util.Range
 import android.view.Surface
 import com.mrousavy.camera.parsers.Flash
 import com.mrousavy.camera.parsers.Orientation
@@ -87,20 +85,7 @@ fun CameraDevice.createPhotoCaptureRequest(
     }
   }
 
-  val zoomRange = (
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      cameraCharacteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE)
-    } else {
-      null
-    }
-  ) ?: Range(1f, cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM) ?: 1f)
-  val zoomClamped = zoomRange.clamp(zoom)
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-    captureRequest.set(CaptureRequest.CONTROL_ZOOM_RATIO, zoomClamped)
-  } else {
-    val size = cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)!!
-    captureRequest.set(CaptureRequest.SCALER_CROP_REGION, size.zoomed(zoomClamped))
-  }
+  captureRequest.setZoom(zoom, cameraCharacteristics)
 
   captureRequest.addTarget(surface)
 

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CaptureRequest+setZoom.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CaptureRequest+setZoom.kt
@@ -1,0 +1,23 @@
+package com.mrousavy.camera.extensions
+
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CaptureRequest
+import android.os.Build
+import android.util.Range
+
+fun CaptureRequest.Builder.setZoom(zoom: Float, cameraCharacteristics: CameraCharacteristics) {
+    val zoomRange = (
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        cameraCharacteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE)
+      } else {
+        null
+      }
+      ) ?: Range(1f, cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM) ?: 1f)
+    val zoomClamped = zoomRange.clamp(zoom)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      this.set(CaptureRequest.CONTROL_ZOOM_RATIO, zoomClamped)
+    } else {
+      val size = cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)!!
+      this.set(CaptureRequest.SCALER_CROP_REGION, size.zoomed(zoomClamped))
+    }
+}

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CaptureRequest+setZoom.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CaptureRequest+setZoom.kt
@@ -6,18 +6,15 @@ import android.os.Build
 import android.util.Range
 
 fun CaptureRequest.Builder.setZoom(zoom: Float, cameraCharacteristics: CameraCharacteristics) {
-    val zoomRange = (
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        cameraCharacteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE)
-      } else {
-        null
-      }
-      ) ?: Range(1f, cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM) ?: 1f)
-    val zoomClamped = zoomRange.clamp(zoom)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      val zoomRange = cameraCharacteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE) ?: Range(1f, 1f)
+      val zoomClamped = zoomRange.clamp(zoom)
       this.set(CaptureRequest.CONTROL_ZOOM_RATIO, zoomClamped)
     } else {
+      val maxZoom = cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM)
+      val zoomRange = Range(1f, maxZoom ?: 1f)
       val size = cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)!!
+      val zoomClamped = zoomRange.clamp(zoom)
       this.set(CaptureRequest.SCALER_CROP_REGION, size.zoomed(zoomClamped))
     }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/Rect+zoomed.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/Rect+zoomed.kt
@@ -3,12 +3,11 @@ package com.mrousavy.camera.extensions
 import android.graphics.Rect
 
 fun Rect.zoomed(zoomFactor: Float): Rect {
-  val height = bottom - top
-  val width = right - left
-
-  val left = this.left + (width / zoomFactor / 2)
-  val top = this.top + (height / zoomFactor / 2)
-  val right = this.right - (width / zoomFactor / 2)
-  val bottom = this.bottom - (height / zoomFactor / 2)
-  return Rect(left.toInt(), top.toInt(), right.toInt(), bottom.toInt())
+  val dx = (width() / zoomFactor / 2).toInt()
+  val dy = (height() / zoomFactor / 2).toInt()
+  val left = centerX() - dx
+  val top = centerY() - dy
+  val right = centerX() + dx
+  val bottom = centerY() + dy
+  return Rect(left, top, right, bottom)
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes incorrect zoom on Android < 11 and clamps zoom as out-of-bounds values can cause crashes (`zoom={0.5}` on Galaxy S8+). Additionally, iOS also clamps zoom so this makes it consistent.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

* Zoom cropping of camera preview and takePhoto() (Android < 11).
* Clamp zoom of camera preview and takePhoto() to camera device's min and max zoom (Android).
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

Samsung Galaxy S8+, Android 9
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes #1865
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
