### PR TITLE
fix: Use compressed buffer format as default format as well

### DIFF
--- a/package/ios/CameraView+AVCaptureSession.swift
+++ b/package/ios/CameraView+AVCaptureSession.swift
@@ -144,12 +144,12 @@ extension CameraView {
     if enableBufferCompression {
       // use compressed format instead if we enabled buffer compression
       if defaultFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange &&
-          videoOutput.availableVideoPixelFormatTypes.contains(kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange) {
+        videoOutput.availableVideoPixelFormatTypes.contains(kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange) {
         // YUV 4:2:0 8-bit (limited video colors; compressed)
         defaultFormat = kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange
       }
       if defaultFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange &&
-          videoOutput.availableVideoPixelFormatTypes.contains(kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange) {
+        videoOutput.availableVideoPixelFormatTypes.contains(kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange) {
         // YUV 4:2:0 8-bit (full video colors; compressed)
         defaultFormat = kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange
       }

--- a/package/ios/CameraView+AVCaptureSession.swift
+++ b/package/ios/CameraView+AVCaptureSession.swift
@@ -140,7 +140,20 @@ extension CameraView {
    */
   private func getPixelFormat(videoOutput: AVCaptureVideoDataOutput) -> OSType {
     // as per documentation, the first value is always the most efficient format
-    let defaultFormat = videoOutput.availableVideoPixelFormatTypes.first!
+    var defaultFormat = videoOutput.availableVideoPixelFormatTypes.first!
+    if enableBufferCompression {
+      // use compressed format instead if we enabled buffer compression
+      if defaultFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange &&
+          videoOutput.availableVideoPixelFormatTypes.contains(kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange) {
+        // YUV 4:2:0 8-bit (limited video colors; compressed)
+        defaultFormat = kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange
+      }
+      if defaultFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange &&
+          videoOutput.availableVideoPixelFormatTypes.contains(kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange) {
+        // YUV 4:2:0 8-bit (full video colors; compressed)
+        defaultFormat = kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange
+      }
+    }
 
     // If the user enabled HDR, we can only use the YUV 4:2:0 10-bit pixel format.
     if hdr == true {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
