### PR TITLE
feat: Use `AHardwareBuffer*` for `frame.toArrayBuffer()`

### DIFF
--- a/package/android/src/main/cpp/VideoPipeline.cpp
+++ b/package/android/src/main/cpp/VideoPipeline.cpp
@@ -31,7 +31,6 @@ VideoPipeline::VideoPipeline(jni::alias_ref<jhybridobject> jThis, int width, int
 
 VideoPipeline::~VideoPipeline() {
   // 1. Remove output surfaces
-  removeFrameProcessorOutputSurface();
   removeRecordingSessionOutputSurface();
   // 2. Delete the input textures
   if (_inputTexture != std::nullopt) {
@@ -40,21 +39,6 @@ VideoPipeline::~VideoPipeline() {
   }
   // 3. Destroy the OpenGL context
   _context = nullptr;
-}
-
-void VideoPipeline::removeFrameProcessorOutputSurface() {
-  if (_frameProcessorOutput)
-    _frameProcessorOutput->destroy();
-  _frameProcessorOutput = nullptr;
-}
-
-void VideoPipeline::setFrameProcessorOutputSurface(jobject surface) {
-  // 1. Delete existing output surface
-  removeFrameProcessorOutputSurface();
-
-  // 2. Set new output surface if it is not null
-  ANativeWindow* window = ANativeWindow_fromSurface(jni::Environment::current(), surface);
-  _frameProcessorOutput = OpenGLRenderer::CreateWithWindowSurface(_context, window);
 }
 
 void VideoPipeline::removeRecordingSessionOutputSurface() {
@@ -93,10 +77,6 @@ void VideoPipeline::onFrame(jni::alias_ref<jni::JArrayFloat> transformMatrixPara
 
   OpenGLTexture& texture = _inputTexture.value();
 
-  if (_frameProcessorOutput) {
-    __android_log_print(ANDROID_LOG_INFO, TAG, "Rendering to FrameProcessor..");
-    _frameProcessorOutput->renderTextureToSurface(texture, transformMatrix);
-  }
   if (_recordingSessionOutput) {
     __android_log_print(ANDROID_LOG_INFO, TAG, "Rendering to RecordingSession..");
     _recordingSessionOutput->renderTextureToSurface(texture, transformMatrix);
@@ -106,8 +86,6 @@ void VideoPipeline::onFrame(jni::alias_ref<jni::JArrayFloat> transformMatrixPara
 void VideoPipeline::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", VideoPipeline::initHybrid),
-      makeNativeMethod("setFrameProcessorOutputSurface", VideoPipeline::setFrameProcessorOutputSurface),
-      makeNativeMethod("removeFrameProcessorOutputSurface", VideoPipeline::removeFrameProcessorOutputSurface),
       makeNativeMethod("setRecordingSessionOutputSurface", VideoPipeline::setRecordingSessionOutputSurface),
       makeNativeMethod("removeRecordingSessionOutputSurface", VideoPipeline::removeRecordingSessionOutputSurface),
       makeNativeMethod("getInputTextureId", VideoPipeline::getInputTextureId),

--- a/package/android/src/main/cpp/VideoPipeline.cpp
+++ b/package/android/src/main/cpp/VideoPipeline.cpp
@@ -53,6 +53,12 @@ void VideoPipeline::setRecordingSessionOutputSurface(jobject surface) {
 
   // 2. Set new output surface if it is not null
   ANativeWindow* window = ANativeWindow_fromSurface(jni::Environment::current(), surface);
+  auto format = ANativeWindow_getFormat(window);
+  bool yuv = false;
+  if (format == AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420) {
+      yuv = true;
+  }
+  __android_log_print(ANDROID_LOG_INFO, TAG, "Format is %i (YUV: %i)..", format, yuv);
   _recordingSessionOutput = OpenGLRenderer::CreateWithWindowSurface(_context, window);
 }
 

--- a/package/android/src/main/cpp/VideoPipeline.cpp
+++ b/package/android/src/main/cpp/VideoPipeline.cpp
@@ -53,12 +53,6 @@ void VideoPipeline::setRecordingSessionOutputSurface(jobject surface) {
 
   // 2. Set new output surface if it is not null
   ANativeWindow* window = ANativeWindow_fromSurface(jni::Environment::current(), surface);
-  auto format = ANativeWindow_getFormat(window);
-  bool yuv = false;
-  if (format == AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420) {
-    yuv = true;
-  }
-  __android_log_print(ANDROID_LOG_INFO, TAG, "Format is %i (YUV: %i)..", format, yuv);
   _recordingSessionOutput = OpenGLRenderer::CreateWithWindowSurface(_context, window);
 }
 

--- a/package/android/src/main/cpp/VideoPipeline.cpp
+++ b/package/android/src/main/cpp/VideoPipeline.cpp
@@ -56,7 +56,7 @@ void VideoPipeline::setRecordingSessionOutputSurface(jobject surface) {
   auto format = ANativeWindow_getFormat(window);
   bool yuv = false;
   if (format == AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420) {
-      yuv = true;
+    yuv = true;
   }
   __android_log_print(ANDROID_LOG_INFO, TAG, "Format is %i (YUV: %i)..", format, yuv);
   _recordingSessionOutput = OpenGLRenderer::CreateWithWindowSurface(_context, window);

--- a/package/android/src/main/cpp/VideoPipeline.h
+++ b/package/android/src/main/cpp/VideoPipeline.h
@@ -30,10 +30,6 @@ public:
   // -> SurfaceTexture input
   int getInputTextureId();
 
-  // <- Frame Processor output
-  void setFrameProcessorOutputSurface(jobject surface);
-  void removeFrameProcessorOutputSurface();
-
   // <- MediaRecorder output
   void setRecordingSessionOutputSurface(jobject surface);
   void removeRecordingSessionOutputSurface();
@@ -54,7 +50,6 @@ private:
 
   // Output Contexts
   std::shared_ptr<OpenGLContext> _context = nullptr;
-  std::unique_ptr<OpenGLRenderer> _frameProcessorOutput = nullptr;
   std::unique_ptr<OpenGLRenderer> _recordingSessionOutput = nullptr;
 
 private:

--- a/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
@@ -12,6 +12,9 @@
 #include <string>
 #include <vector>
 
+#include <android/hardware_buffer.h>
+#include <android/hardware_buffer_jni.h>
+
 namespace vision {
 
 using namespace facebook;
@@ -82,11 +85,12 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "toArrayBuffer") {
     jsi::HostFunctionType toArrayBuffer = [=](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args,
                                               size_t count) -> jsi::Value {
-      auto buffer = this->frame->toByteBuffer();
-      if (!buffer->isDirect()) {
-        throw std::runtime_error("Failed to get byte content of Frame - array is not direct ByteBuffer!");
-      }
-      auto size = buffer->getDirectSize();
+      AHardwareBuffer* hardwareBuffer = this->frame->getHardwareBuffer();
+
+      AHardwareBuffer_Desc bufferDescription;
+      AHardwareBuffer_describe(hardwareBuffer, &bufferDescription);
+      __android_log_print(ANDROID_LOG_INFO, "Frame", "Buffer %i x %i @ %i", bufferDescription.width, bufferDescription.height, bufferDescription.stride);
+      size_t size = bufferDescription.height * bufferDescription.stride;
 
       static constexpr auto ARRAYBUFFER_CACHE_PROP_NAME = "__frameArrayBufferCache";
       if (!runtime.global().hasProperty(runtime, ARRAYBUFFER_CACHE_PROP_NAME)) {
@@ -102,9 +106,17 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
         runtime.global().setProperty(runtime, ARRAYBUFFER_CACHE_PROP_NAME, arrayBuffer);
       }
 
+      // Get CPU access to the HardwareBuffer (&buffer is a virtual temporary address)
+      void* buffer;
+      AHardwareBuffer_lock(hardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_MASK, -1, nullptr, &buffer);
+
       // directly write to C++ JSI ArrayBuffer
       auto destinationBuffer = arrayBuffer.data(runtime);
-      memcpy(destinationBuffer, buffer->getDirectAddress(), sizeof(uint8_t) * size);
+      memcpy(destinationBuffer, buffer, sizeof(uint8_t) * size);
+
+      // Release HardwareBuffer again
+      AHardwareBuffer_unlock(hardwareBuffer, nullptr);
+      AHardwareBuffer_release(hardwareBuffer);
 
       return arrayBuffer;
     };

--- a/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
@@ -89,7 +89,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
 
       AHardwareBuffer_Desc bufferDescription;
       AHardwareBuffer_describe(hardwareBuffer, &bufferDescription);
-      __android_log_print(ANDROID_LOG_INFO, "Frame", "Buffer %i x %i @ %i", bufferDescription.width, bufferDescription.height, bufferDescription.stride);
+      __android_log_print(ANDROID_LOG_INFO, "Frame", "Buffer %i x %i @ %i", bufferDescription.width, bufferDescription.height,
+                          bufferDescription.stride);
       size_t size = bufferDescription.height * bufferDescription.stride;
 
       static constexpr auto ARRAYBUFFER_CACHE_PROP_NAME = "__frameArrayBufferCache";

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
@@ -4,10 +4,10 @@
 
 #include "JFrame.h"
 
+#include <android/hardware_buffer_jni.h>
 #include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#include <android/hardware_buffer_jni.h>
 
 namespace vision {
 

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
@@ -7,6 +7,7 @@
 #include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
 #include <jni.h>
+#include <android/hardware_buffer_jni.h>
 
 namespace vision {
 
@@ -58,9 +59,10 @@ int JFrame::getBytesPerRow() const {
   return getBytesPerRowMethod(self());
 }
 
-local_ref<JByteBuffer> JFrame::toByteBuffer() const {
-  static const auto toByteBufferMethod = getClass()->getMethod<JByteBuffer()>("toByteBuffer");
-  return toByteBufferMethod(self());
+AHardwareBuffer* JFrame::getHardwareBuffer() const {
+  static const auto getHardwareBufferMethod = getClass()->getMethod<jobject()>("getHardwareBufferBoxed");
+  auto hardwareBuffer = getHardwareBufferMethod(self());
+  return AHardwareBuffer_fromHardwareBuffer(jni::Environment::current(), hardwareBuffer.get());
 }
 
 void JFrame::incrementRefCount() {

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
@@ -7,6 +7,7 @@
 #include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
 #include <jni.h>
+#include <android/hardware_buffer.h>
 
 namespace vision {
 
@@ -26,7 +27,7 @@ public:
   jlong getTimestamp() const;
   local_ref<JString> getOrientation() const;
   local_ref<JString> getPixelFormat() const;
-  local_ref<JByteBuffer> toByteBuffer() const;
+  AHardwareBuffer* getHardwareBuffer() const;
   void incrementRefCount();
   void decrementRefCount();
   void close();

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include <android/hardware_buffer.h>
 #include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#include <android/hardware_buffer.h>
 
 namespace vision {
 

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -210,7 +210,7 @@ class CameraView(context: Context) : FrameLayout(context) {
         null
       }
       val videoOutput = if (video == true || enableFrameProcessor) {
-        CameraOutputs.VideoOutput(targetVideoSize, video == true, enableFrameProcessor, pixelFormat.toImageFormat())
+        CameraOutputs.VideoOutput(targetVideoSize, video == true, enableFrameProcessor, pixelFormat)
       } else {
         null
       }

--- a/package/android/src/main/java/com/mrousavy/camera/Errors.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/Errors.kt
@@ -66,6 +66,8 @@ class CameraSessionCannotBeConfiguredError(cameraId: String, outputs: CameraOutp
   CameraError("session", "cannot-create-session", "Failed to create a Camera Session for Camera $cameraId! Outputs: $outputs")
 class CameraDisconnectedError(cameraId: String, error: CameraDeviceError) :
   CameraError("session", "camera-has-been-disconnected", "The given Camera device (id: $cameraId) has been disconnected! Error: $error")
+class FrameProcessorsUnavailableError(reason: String) :
+    CameraError("system", "frame-processors-unavailable", "Frame Processors are unavailable! Reason: $reason")
 
 class VideoNotEnabledError :
   CameraError("capture", "video-not-enabled", "Video capture is disabled! Pass `video={true}` to enable video recordings.")

--- a/package/android/src/main/java/com/mrousavy/camera/Errors.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/Errors.kt
@@ -50,13 +50,6 @@ class NoCameraDeviceError :
   )
 class PixelFormatNotSupportedError(format: String) :
   CameraError("device", "pixel-format-not-supported", "The pixelFormat $format is not supported on the given Camera Device!")
-class PixelFormatNotSupportedInVideoPipelineError(format: String) :
-  CameraError(
-    "device",
-    "pixel-format-not-supported",
-    "The pixelFormat $format is currently not supported in the VideoPipeline! " +
-      "See this issue for more details ($4.000 bounty!): https://github.com/mrousavy/react-native-vision-camera/issues/1837"
-  )
 
 class CameraNotReadyError :
   CameraError("session", "camera-not-ready", "The Camera is not ready yet! Wait for the onInitialized() callback!")
@@ -66,8 +59,6 @@ class CameraSessionCannotBeConfiguredError(cameraId: String, outputs: CameraOutp
   CameraError("session", "cannot-create-session", "Failed to create a Camera Session for Camera $cameraId! Outputs: $outputs")
 class CameraDisconnectedError(cameraId: String, error: CameraDeviceError) :
   CameraError("session", "camera-has-been-disconnected", "The given Camera device (id: $cameraId) has been disconnected! Error: $error")
-class FrameProcessorsUnavailableError(reason: String) :
-  CameraError("system", "frame-processors-unavailable", "Frame Processors are unavailable! Reason: $reason")
 
 class VideoNotEnabledError :
   CameraError("capture", "video-not-enabled", "Video capture is disabled! Pass `video={true}` to enable video recordings.")
@@ -77,10 +68,8 @@ class CaptureAbortedError(wasImageCaptured: Boolean) :
   CameraError("capture", "aborted", "The image capture was aborted! Was Image captured: $wasImageCaptured")
 class UnknownCaptureError(wasImageCaptured: Boolean) :
   CameraError("capture", "unknown", "An unknown error occurred while trying to capture an Image! Was Image captured: $wasImageCaptured")
-
 class RecorderError(name: String, extra: Int) :
   CameraError("capture", "recorder-error", "An error occured while recording a video! $name $extra")
-
 class NoRecordingInProgressError :
   CameraError("capture", "no-recording-in-progress", "There was no active video recording in progress! Did you call stopRecording() twice?")
 class RecordingInProgressError :
@@ -92,5 +81,9 @@ class RecordingInProgressError :
 
 class ViewNotFoundError(viewId: Int) :
   CameraError("system", "view-not-found", "The given view (ID $viewId) was not found in the view manager.")
+class FrameProcessorsUnavailableError(reason: String) :
+  CameraError("system", "frame-processors-unavailable", "Frame Processors are unavailable! Reason: $reason")
+class HardwareBuffersNotAvailableError:
+    CameraError("system", "hardware-buffers-unavailable", "HardwareBuffers are only available on API 28 or higher!")
 
 class UnknownCameraError(cause: Throwable?) : CameraError("unknown", "unknown", cause?.message ?: "An unknown camera error occured.", cause)

--- a/package/android/src/main/java/com/mrousavy/camera/Errors.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/Errors.kt
@@ -67,7 +67,7 @@ class CameraSessionCannotBeConfiguredError(cameraId: String, outputs: CameraOutp
 class CameraDisconnectedError(cameraId: String, error: CameraDeviceError) :
   CameraError("session", "camera-has-been-disconnected", "The given Camera device (id: $cameraId) has been disconnected! Error: $error")
 class FrameProcessorsUnavailableError(reason: String) :
-    CameraError("system", "frame-processors-unavailable", "Frame Processors are unavailable! Reason: $reason")
+  CameraError("system", "frame-processors-unavailable", "Frame Processors are unavailable! Reason: $reason")
 
 class VideoNotEnabledError :
   CameraError("capture", "video-not-enabled", "Video capture is disabled! Pass `video={true}` to enable video recordings.")

--- a/package/android/src/main/java/com/mrousavy/camera/Errors.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/Errors.kt
@@ -83,7 +83,7 @@ class ViewNotFoundError(viewId: Int) :
   CameraError("system", "view-not-found", "The given view (ID $viewId) was not found in the view manager.")
 class FrameProcessorsUnavailableError(reason: String) :
   CameraError("system", "frame-processors-unavailable", "Frame Processors are unavailable! Reason: $reason")
-class HardwareBuffersNotAvailableError:
-    CameraError("system", "hardware-buffers-unavailable", "HardwareBuffers are only available on API 28 or higher!")
+class HardwareBuffersNotAvailableError :
+  CameraError("system", "hardware-buffers-unavailable", "HardwareBuffers are only available on API 28 or higher!")
 
 class UnknownCameraError(cause: Throwable?) : CameraError("unknown", "unknown", cause?.message ?: "An unknown camera error occured.", cause)

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -158,15 +158,11 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
   }
 
   private fun createPixelFormats(size: Size): ReadableArray {
-    val formats = cameraConfig.outputFormats
+    // Every output in Camera2 supports YUV, RGB and NATIVE
     val array = Arguments.createArray()
-    formats.forEach { format ->
-      val sizes = cameraConfig.getOutputSizes(format)
-      val hasSize = sizes.any { it.width == size.width && it.height == size.height }
-      if (hasSize) {
-        array.pushString(PixelFormat.fromImageFormat(format).unionValue)
-      }
-    }
+    array.pushString(PixelFormat.YUV.unionValue)
+    array.pushString(PixelFormat.RGB.unionValue)
+    array.pushString(PixelFormat.NATIVE.unionValue)
     return array
   }
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -157,11 +157,10 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
     return array
   }
 
-  private fun createPixelFormats(size: Size): ReadableArray {
-    // Every output in Camera2 supports YUV, RGB and NATIVE
+  private fun createPixelFormats(): ReadableArray {
+    // Every output in Camera2 supports YUV and NATIVE
     val array = Arguments.createArray()
     array.pushString(PixelFormat.YUV.unionValue)
-    array.pushString(PixelFormat.RGB.unionValue)
     array.pushString(PixelFormat.NATIVE.unionValue)
     return array
   }
@@ -182,7 +181,7 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
     map.putBoolean("supportsDepthCapture", supportsDepthCapture)
     map.putString("autoFocusSystem", "contrast-detection") // TODO: Is this wrong?
     map.putArray("videoStabilizationModes", createStabilizationModes())
-    map.putArray("pixelFormats", createPixelFormats(videoSize))
+    map.putArray("pixelFormats", createPixelFormats())
     return map
   }
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -26,12 +26,13 @@ import java.io.Closeable
  * @param [format] The format of the Frames to stream. ([ImageFormat.PRIVATE], [ImageFormat.YUV_420_888] or [ImageFormat.JPEG])
  */
 @Suppress("KotlinJniMissingFunction")
-class VideoPipeline(val width: Int,
-                    val height: Int,
-                    val format: PixelFormat = PixelFormat.NATIVE,
-                    private val isMirrored: Boolean = false,
-                    enableFrameProcessor: Boolean = false) :
-  SurfaceTexture.OnFrameAvailableListener,
+class VideoPipeline(
+  val width: Int,
+  val height: Int,
+  val format: PixelFormat = PixelFormat.NATIVE,
+  private val isMirrored: Boolean = false,
+  enableFrameProcessor: Boolean = false
+) : SurfaceTexture.OnFrameAvailableListener,
   Closeable {
   companion object {
     private const val MAX_IMAGES = 3
@@ -66,6 +67,7 @@ class VideoPipeline(val width: Int,
   // Input
   private val surfaceTexture: SurfaceTexture
   val surface: Surface
+
   // If Frame Processors are enabled, we go through ImageReader first before we go thru OpenGL
   private var imageReader: ImageReader? = null
   private var imageWriter: ImageWriter? = null
@@ -153,14 +155,13 @@ class VideoPipeline(val width: Int,
     }
   }
 
-  private fun getImageReaderFormat(): Int {
-    return when (format) {
+  private fun getImageReaderFormat(): Int =
+    when (format) {
       PixelFormat.NATIVE -> ImageFormat.PRIVATE
       PixelFormat.RGB -> HardwareBuffer.RGBA_8888
       PixelFormat.YUV -> ImageFormat.YUV_420_888
       else -> ImageFormat.PRIVATE
     }
-  }
 
   /**
    * Configures the Pipeline to also call the given [FrameProcessor] (or null).

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -3,6 +3,7 @@ package com.mrousavy.camera.core
 import android.graphics.ImageFormat
 import android.graphics.SurfaceTexture
 import android.media.ImageReader
+import android.media.ImageWriter
 import android.util.Log
 import android.view.Surface
 import com.facebook.jni.HybridData
@@ -69,18 +70,6 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
       "Initializing $width x $height Video Pipeline " +
         "(format: ${PixelFormat.fromImageFormat(format)} #$format)"
     )
-    // TODO: We currently use OpenGL for the Video Pipeline.
-    //  OpenGL only works in the RGB (RGBA_8888; 0x23) pixel-format, so we cannot
-    //  override the pixel-format to something like YUV or PRIVATE.
-    //  This absolutely sucks and I would prefer to replace the OpenGL pipeline with
-    //  something similar to how iOS works where we just pass GPU buffers around,
-    //  but android.media APIs are just not as advanced yet.
-    //  For example, ImageReader/ImageWriter is way too buggy and does not work with MediaRecorder.
-    //  See this issue ($4.000 bounty!) for more details:
-    //  https://github.com/mrousavy/react-native-vision-camera/issues/1837
-    if (format != ImageFormat.PRIVATE && format != 0x23) {
-      throw PixelFormatNotSupportedInVideoPipelineError(PixelFormat.fromImageFormat(format).unionValue)
-    }
     mHybridData = initHybrid(width, height)
     surfaceTexture = SurfaceTexture(false)
     surfaceTexture.setDefaultBufferSize(width, height)
@@ -154,7 +143,7 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
   }
 
   /**
-   * Configures the Pipeline to also write Frames to a Surface from a [MediaRecorder] (or null)
+   * Configures the Pipeline to also write Frames to a Surface from a `MediaRecorder` (or null)
    */
   fun setRecordingSessionOutput(recordingSession: RecordingSession?) {
     synchronized(this) {

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -11,13 +11,15 @@ import android.view.Surface
 import com.facebook.jni.HybridData
 import com.mrousavy.camera.CameraQueues
 import com.mrousavy.camera.FrameProcessorsUnavailableError
+import com.mrousavy.camera.frameprocessor.Frame
 import com.mrousavy.camera.frameprocessor.FrameProcessor
+import com.mrousavy.camera.parsers.Orientation
 import com.mrousavy.camera.parsers.PixelFormat
 import java.io.Closeable
 
 /**
  * An OpenGL pipeline for streaming Camera Frames to one or more outputs.
- * Currently, [VideoPipeline] can stream to a [FrameProcessor] and a [MediaRecorder].
+ * Currently, [VideoPipeline] can stream to a [FrameProcessor] and a [RecordingSession].
  *
  * @param [width] The width of the Frames to stream (> 0)
  * @param [height] The height of the Frames to stream (> 0)
@@ -98,13 +100,13 @@ class VideoPipeline(val width: Int,
         Log.i(TAG, "Image Format: ${image.format}")
 
         // // TODO: Get correct orientation and isMirrored
-        // val frame = Frame(image, image.timestamp, Orientation.PORTRAIT, isMirrored)
-        // frame.incrementRefCount()
-        // frameProcessor?.call(frame)
+        val frame = Frame(image, image.timestamp, Orientation.PORTRAIT, isMirrored)
+        frame.incrementRefCount()
+        frameProcessor?.call(frame)
 
         imageWriter!!.queueInputImage(image)
 
-        // frame.decrementRefCount()
+        frame.decrementRefCount()
       }, CameraQueues.videoQueue.handler)
 
       surface = imageReader!!.surface

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -8,10 +8,7 @@ import android.util.Log
 import android.view.Surface
 import com.facebook.jni.HybridData
 import com.mrousavy.camera.CameraQueues
-import com.mrousavy.camera.PixelFormatNotSupportedInVideoPipelineError
-import com.mrousavy.camera.frameprocessor.Frame
 import com.mrousavy.camera.frameprocessor.FrameProcessor
-import com.mrousavy.camera.parsers.Orientation
 import com.mrousavy.camera.parsers.PixelFormat
 import java.io.Closeable
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/outputs/CameraOutputs.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/outputs/CameraOutputs.kt
@@ -16,6 +16,7 @@ import com.mrousavy.camera.extensions.getPhotoSizes
 import com.mrousavy.camera.extensions.getPreviewTargetSize
 import com.mrousavy.camera.extensions.getVideoSizes
 import com.mrousavy.camera.extensions.smaller
+import com.mrousavy.camera.parsers.PixelFormat
 import java.io.Closeable
 
 class CameraOutputs(
@@ -38,7 +39,7 @@ class CameraOutputs(
     val targetSize: Size? = null,
     val enableRecording: Boolean = false,
     val enableFrameProcessor: Boolean? = false,
-    val format: Int = ImageFormat.PRIVATE
+    val format: PixelFormat = PixelFormat.NATIVE
   )
 
   interface Callback {
@@ -134,8 +135,11 @@ class CameraOutputs(
 
     // Video output: High resolution repeating images (startRecording() or useFrameProcessor())
     if (video != null) {
-      val size = characteristics.getVideoSizes(cameraId, video.format).closestToOrMax(video.targetSize)
-      val videoPipeline = VideoPipeline(size.width, size.height, video.format, isMirrored)
+      // TODO: Should this be dynamic?
+      val format = ImageFormat.YUV_420_888
+      val size = characteristics.getVideoSizes(cameraId, format).closestToOrMax(video.targetSize)
+      val enableFrameProcessor = video.enableFrameProcessor ?: false
+      val videoPipeline = VideoPipeline(size.width, size.height, video.format, isMirrored, enableFrameProcessor)
 
       Log.i(TAG, "Adding ${size.width}x${size.height} video output. (Format: ${video.format})")
       videoOutput = VideoPipelineOutput(videoPipeline, SurfaceOutput.OutputType.VIDEO)

--- a/package/android/src/main/java/com/mrousavy/camera/parsers/PixelFormat.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/parsers/PixelFormat.kt
@@ -7,15 +7,13 @@ import com.mrousavy.camera.PixelFormatNotSupportedError
 enum class PixelFormat(override val unionValue: String) : JSUnionValue {
   YUV("yuv"),
   RGB("rgb"),
-  DNG("dng"),
   NATIVE("native"),
   UNKNOWN("unknown");
 
   fun toImageFormat(): Int {
     val result = when (this) {
       YUV -> ImageFormat.YUV_420_888
-      RGB -> ImageFormat.JPEG
-      DNG -> ImageFormat.RAW_SENSOR
+      RGB -> android.graphics.PixelFormat.RGBA_8888
       NATIVE -> ImageFormat.PRIVATE
       UNKNOWN -> null
     }
@@ -29,8 +27,7 @@ enum class PixelFormat(override val unionValue: String) : JSUnionValue {
     fun fromImageFormat(imageFormat: Int): PixelFormat =
       when (imageFormat) {
         ImageFormat.YUV_420_888 -> YUV
-        ImageFormat.JPEG, ImageFormat.DEPTH_JPEG -> RGB
-        ImageFormat.RAW_SENSOR -> DNG
+        android.graphics.PixelFormat.RGBA_8888 -> RGB
         ImageFormat.PRIVATE -> NATIVE
         else -> UNKNOWN
       }
@@ -39,7 +36,6 @@ enum class PixelFormat(override val unionValue: String) : JSUnionValue {
       when (unionValue) {
         "yuv" -> YUV
         "rgb" -> RGB
-        "dng" -> DNG
         "native" -> NATIVE
         "unknown" -> UNKNOWN
         else -> null


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This is a follow-up of #1874 to use the `AHardwareBuffer*` API again for getting the Frame's raw contents. 

This gives the actual GPU pixel data (`image.getHardwareBuffer()`), instead of planar-divided CPU data (`image.getPlanes()`)

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
