### PR TITLE
perf: Use `jsi::Scope` to trigger GC after Frame Processor call

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrameProcessor.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrameProcessor.cpp
@@ -38,7 +38,7 @@ void JFrameProcessor::callWithFrameHostObject(const std::shared_ptr<FrameHostObj
 
   try {
     // Wrap entire call in a jsi::Scope so it requests GC after it returns
-    jsi::Scope scope;
+    jsi::Scope scope(runtime);
 
     // Wrap HostObject as JSI Value
     auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrameProcessor.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrameProcessor.cpp
@@ -37,6 +37,9 @@ void JFrameProcessor::callWithFrameHostObject(const std::shared_ptr<FrameHostObj
   jsi::Runtime& runtime = _workletContext->getWorkletRuntime();
 
   try {
+    // Wrap entire call in a jsi::Scope so it requests GC after it returns
+    jsi::Scope scope;
+
     // Wrap HostObject as JSI Value
     auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);
     jsi::Value jsValue(std::move(argument));

--- a/package/ios/Frame Processor/FrameProcessor.mm
+++ b/package/ios/Frame Processor/FrameProcessor.mm
@@ -36,7 +36,7 @@ using namespace facebook;
 
   try {
     // Wrap entire call in a jsi::Scope so it requests GC after it returns
-    jsi::Scope scope;
+    jsi::Scope scope(runtime);
 
     // Wrap HostObject as JSI Value
     auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);

--- a/package/ios/Frame Processor/FrameProcessor.mm
+++ b/package/ios/Frame Processor/FrameProcessor.mm
@@ -35,6 +35,9 @@ using namespace facebook;
   jsi::Runtime& runtime = _workletContext->getWorkletRuntime();
 
   try {
+    // Wrap entire call in a jsi::Scope so it requests GC after it returns
+    jsi::Scope scope;
+
     // Wrap HostObject as JSI Value
     auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);
     jsi::Value jsValue(std::move(argument));


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
