### PR TITLE
doc: Fixes Saving the Photo to the Camera Roll in TAKING_PHOTOS.mdx

### DIFF
--- a/docs/docs/guides/TAKING_PHOTOS.mdx
+++ b/docs/docs/guides/TAKING_PHOTOS.mdx
@@ -71,8 +71,8 @@ const photo = await camera.current.takePhoto({
 Since the Photo is stored as a temporary file, you need to save it to the Camera Roll to permanentely store it. You can use [react-native-cameraroll](https://github.com/react-native-cameraroll/react-native-cameraroll) for this:
 
 ```ts
-const path = await camera.current.takePhoto()
-await CameraRoll.save(`file://${path}`, {
+const file = await camera.current.takePhoto()
+await CameraRoll.save(`file://${file.path}`, {
   type: 'photo',
 })
 ```


### PR DESCRIPTION
##This PR fixes a code error in the section Saving the Photo to the Camera Roll.
The variable path has been renamed to file, as camera.current.takePhoto() always returns a file. Additionally, the CameraRoll.save() method has been updated to use file.path for saving the captured photo.