### PR TITLE
docs: fix redirect for videostabilizationmode

### DIFF
--- a/docs/docs/guides/PERFORMANCE.mdx
+++ b/docs/docs/guides/PERFORMANCE.mdx
@@ -72,7 +72,7 @@ Note: When not using a `frameProcessor`, buffer compression is automatically ena
 
 ### Video Stabilization
 
-Video Stabilization requires additional overhead to start the algorithm, so disabling [`videoStabilizationMode`](/docs/api/interfaces/CameraProps#videoStabilizationMode) can significantly speed up the Camera initialization time.
+Video Stabilization requires additional overhead to start the algorithm, so disabling [`videoStabilizationMode`](/docs/api/interfaces/CameraProps#videostabilizationmode) can significantly speed up the Camera initialization time.
 
 ### Pixel Format
 


### PR DESCRIPTION
## What

Fix redirection of videoStabilizationMode for below.
https://www.react-native-vision-camera.com/docs/api/interfaces/CameraProps#videoStabilizationMode

## Changes

In the file docs/docs/guides/PERFORMANCE.mdx (Line No 75)
Changed **videoStabilizationMode** to  **videostabilizationmode**
