### PR TITLE
fix: Fix `CamcorderProfile` get crash on Samsung devices

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getOutputSizes.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getOutputSizes.kt
@@ -6,23 +6,28 @@ import android.os.Build
 import android.util.Size
 
 private fun getMaximumVideoSize(cameraId: String): Size? {
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-    val profiles = CamcorderProfile.getAll(cameraId, CamcorderProfile.QUALITY_HIGH)
-    if (profiles != null) {
-      val largestProfile = profiles.videoProfiles.filterNotNull().maxByOrNull { it.width * it.height }
-      if (largestProfile != null) {
-        return Size(largestProfile.width, largestProfile.height)
+  try {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      val profiles = CamcorderProfile.getAll(cameraId, CamcorderProfile.QUALITY_HIGH)
+      if (profiles != null) {
+        val largestProfile = profiles.videoProfiles.filterNotNull().maxByOrNull { it.width * it.height }
+        if (largestProfile != null) {
+          return Size(largestProfile.width, largestProfile.height)
+        }
       }
     }
-  }
 
-  val cameraIdInt = cameraId.toIntOrNull()
-  if (cameraIdInt != null) {
-    val profile = CamcorderProfile.get(cameraIdInt, CamcorderProfile.QUALITY_HIGH)
-    return Size(profile.videoFrameWidth, profile.videoFrameHeight)
-  }
+    val cameraIdInt = cameraId.toIntOrNull()
+    if (cameraIdInt != null) {
+      val profile = CamcorderProfile.get(cameraIdInt, CamcorderProfile.QUALITY_HIGH)
+      return Size(profile.videoFrameWidth, profile.videoFrameHeight)
+    }
 
-  return null
+    return null
+  } catch (e: Throwable) {
+    // some Samsung phones just crash when trying to get the CamcorderProfile. Only god knows why.
+    return null
+  }
 }
 
 fun CameraCharacteristics.getVideoSizes(cameraId: String, format: Int): List<Size> {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Some Samsung devices crash when trying to do `CamcorderProfile.get`. Only god knows why.

Let's just swallow that error and move on, there's nothing we can do.

Btw: In the documentation this method cannot throw a `RuntimeError`. But yea, classic Android/Samsung.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes #1793 

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
