### PR TITLE
fix: Use simpler wide-angle device if no options are passed

### DIFF
--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -45,9 +45,7 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
   const [enableNightMode, setEnableNightMode] = useState(false)
 
   // camera format settings
-  const device = useCameraDevice(cameraPosition, {
-    physicalDevices: ['ultra-wide-angle-camera', 'wide-angle-camera', 'telephoto-camera'],
-  })
+  const device = useCameraDevice(cameraPosition)
 
   const [targetFps, setTargetFps] = useState(60)
 
@@ -148,14 +146,13 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
   })
   //#endregion
 
-  if (device != null && format != null) {
-    console.log(
-      `Re-rendering camera page with ${isActive ? 'active' : 'inactive'} camera. ` +
-        `Device: "${device.name}" (${format.photoWidth}x${format.photoHeight} photo / ${format.videoWidth}x${format.videoHeight} video @ ${fps}fps)`,
-    )
-  } else {
-    console.log('re-rendering camera page without active camera')
-  }
+  useEffect(() => {
+    const f =
+      format != null
+        ? `(${format.photoWidth}x${format.photoHeight} photo / ${format.videoWidth}x${format.videoHeight}@${format.maxFps} video @ ${fps}fps)`
+        : undefined
+    console.log(`Camera: ${device?.name} | Format: ${f}`)
+  }, [device?.name, format, fps])
 
   const frameProcessor = useFrameProcessor((frame) => {
     'worklet'

--- a/package/src/devices/getCameraDevice.ts
+++ b/package/src/devices/getCameraDevice.ts
@@ -54,8 +54,11 @@ export function getCameraDevice(devices: CameraDevice[], position: CameraPositio
 
     if (!explicitlyWantsNonWideAngle) {
       // prefer wide-angle-camera as a default
-      if (bestDevice.physicalDevices.includes('wide-angle-camera')) leftPoints += 1
-      if (device.physicalDevices.includes('wide-angle-camera')) rightPoints += 1
+      if (bestDevice.physicalDevices.includes('wide-angle-camera')) leftPoints += 2
+      if (device.physicalDevices.includes('wide-angle-camera')) rightPoints += 2
+      // if we have more than one device, we rank it lower. we only want a simple camera
+      if (bestDevice.physicalDevices.length > device.physicalDevices.length) leftPoints -= 1
+      if (device.physicalDevices.length > bestDevice.physicalDevices.length) rightPoints -= 1
     }
 
     // compare devices. two possible scenarios:


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Changes the behaviour of `useCameraDevice(..)` and `getCameraDevice(..)` so that they prefer a simple wide-angle Camera device if no options are explicitly passed, effectively finding the "default" device as the user expects.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
