### PR TITLE
fix: Make HardwareBuffers compile optionally

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
@@ -85,6 +85,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "toArrayBuffer") {
     jsi::HostFunctionType toArrayBuffer = [=](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args,
                                               size_t count) -> jsi::Value {
+#if __ANDROID_API__ >= 26
       AHardwareBuffer* hardwareBuffer = this->frame->getHardwareBuffer();
 
       AHardwareBuffer_Desc bufferDescription;
@@ -120,6 +121,9 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
       AHardwareBuffer_release(hardwareBuffer);
 
       return arrayBuffer;
+#else
+      throw jsi::JSError(runtime, "Frame.toArrayBuffer() is only available if minSdkVersion is set to 26 or higher!");
+#endif
     };
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "toArrayBuffer"), 0, toArrayBuffer);
   }

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
@@ -59,7 +59,7 @@ int JFrame::getBytesPerRow() const {
   return getBytesPerRowMethod(self());
 }
 
-#if __ANDROID_API >= 26
+#if __ANDROID_API__ >= 26
 AHardwareBuffer* JFrame::getHardwareBuffer() const {
   static const auto getHardwareBufferMethod = getClass()->getMethod<jobject()>("getHardwareBufferBoxed");
   auto hardwareBuffer = getHardwareBufferMethod(self());

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
@@ -4,8 +4,8 @@
 
 #include "JFrame.h"
 
-#include <jni.h>
 #include <fbjni/fbjni.h>
+#include <jni.h>
 
 #include <android/hardware_buffer_jni.h>
 

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
@@ -4,10 +4,10 @@
 
 #include "JFrame.h"
 
-#include <android/hardware_buffer_jni.h>
-#include <fbjni/ByteBuffer.h>
-#include <fbjni/fbjni.h>
 #include <jni.h>
+#include <fbjni/fbjni.h>
+
+#include <android/hardware_buffer_jni.h>
 
 namespace vision {
 
@@ -59,11 +59,13 @@ int JFrame::getBytesPerRow() const {
   return getBytesPerRowMethod(self());
 }
 
+#if __ANDROID_API >= 26
 AHardwareBuffer* JFrame::getHardwareBuffer() const {
   static const auto getHardwareBufferMethod = getClass()->getMethod<jobject()>("getHardwareBufferBoxed");
   auto hardwareBuffer = getHardwareBufferMethod(self());
   return AHardwareBuffer_fromHardwareBuffer(jni::Environment::current(), hardwareBuffer.get());
 }
+#endif
 
 void JFrame::incrementRefCount() {
   static const auto incrementRefCountMethod = getClass()->getMethod<void()>("incrementRefCount");

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include <android/hardware_buffer.h>
-#include <fbjni/ByteBuffer.h>
-#include <fbjni/fbjni.h>
 #include <jni.h>
+#include <fbjni/fbjni.h>
+
+#include <android/hardware_buffer.h>
 
 namespace vision {
 
@@ -27,7 +27,10 @@ public:
   jlong getTimestamp() const;
   local_ref<JString> getOrientation() const;
   local_ref<JString> getPixelFormat() const;
+#if __ANDROID_API >= 26
   AHardwareBuffer* getHardwareBuffer() const;
+#endif
+
   void incrementRefCount();
   void decrementRefCount();
   void close();

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
@@ -27,7 +27,7 @@ public:
   jlong getTimestamp() const;
   local_ref<JString> getOrientation() const;
   local_ref<JString> getPixelFormat() const;
-#if __ANDROID_API >= 26
+#if __ANDROID_API__ >= 26
   AHardwareBuffer* getHardwareBuffer() const;
 #endif
 

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <jni.h>
 #include <fbjni/fbjni.h>
+#include <jni.h>
 
 #include <android/hardware_buffer.h>
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Makes `AHardwareBuffer` C++ compilation optional.

- If the user's app specified `minSdkVersion` of 26 or higher, the feature is available and everything works as normal.
- If the user's app specified `minSdkVersion` of 25 or lower, HardwareBuffers are simply not compiled/linked in C++ and `Frame.toArrayBuffer()` will not work.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes 1905
- Fixes #1899 
- Fixes #1898

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
