### PR TITLE
fix: Set `minSdkVersion` to 23

### DIFF
--- a/docs/docs/guides/TROUBLESHOOTING.mdx
+++ b/docs/docs/guides/TROUBLESHOOTING.mdx
@@ -82,12 +82,12 @@ If you're experiencing build issues or runtime issues in VisionCamera, make sure
    yarn   # or `npm i`
    ```
 4. Make sure you have installed the [Android NDK](https://developer.android.com/ndk).
-5. Make sure your minimum SDK version is **26 or higher**, and target SDK version is **33 or higher**. See [the example's `build.gradle`](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/android/build.gradle#L5-L10) for reference.
+5. Make sure your minimum SDK version is **21 or higher**, and target SDK version is **33 or higher**. See [the example's `build.gradle`](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/android/build.gradle#L5-L10) for reference.
    1. Open your `build.gradle`
    2. Set `buildToolsVersion` to `33.0.0` or higher
    3. Set `compileSdkVersion` to `33` or higher
    4. Set `targetSdkVersion` to `33` or higher
-   5. Set `minSdkVersion` to `26` or higher
+   5. Set `minSdkVersion` to `21` or higher
    6. Set `ndkVersion` to `"23.1.7779620"` or higher
    7. Update the Gradle Build-Tools version to `7.3.1` or higher:
       ```

--- a/docs/docs/guides/TROUBLESHOOTING.mdx
+++ b/docs/docs/guides/TROUBLESHOOTING.mdx
@@ -82,12 +82,12 @@ If you're experiencing build issues or runtime issues in VisionCamera, make sure
    yarn   # or `npm i`
    ```
 4. Make sure you have installed the [Android NDK](https://developer.android.com/ndk).
-5. Make sure your minimum SDK version is **21 or higher**, and target SDK version is **33 or higher**. See [the example's `build.gradle`](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/android/build.gradle#L5-L10) for reference.
+5. Make sure your minimum SDK version is **23 or higher**, and target SDK version is **33 or higher**. See [the example's `build.gradle`](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/example/android/build.gradle#L5-L10) for reference.
    1. Open your `build.gradle`
    2. Set `buildToolsVersion` to `33.0.0` or higher
    3. Set `compileSdkVersion` to `33` or higher
    4. Set `targetSdkVersion` to `33` or higher
-   5. Set `minSdkVersion` to `21` or higher
+   5. Set `minSdkVersion` to `23` or higher
    6. Set `ndkVersion` to `"23.1.7779620"` or higher
    7. Update the Gradle Build-Tools version to `7.3.1` or higher:
       ```

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -90,7 +90,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion safeExtGet('minSdkVersion', 21)
+    minSdkVersion safeExtGet('minSdkVersion', 23)
     compileSdkVersion safeExtGet('compileSdkVersion', 33)
     targetSdkVersion safeExtGet('targetSdkVersion', 33)
     versionCode 1

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -90,7 +90,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion safeExtGet('minSdkVersion', 26)
+    minSdkVersion safeExtGet('minSdkVersion', 21)
     compileSdkVersion safeExtGet('compileSdkVersion', 33)
     targetSdkVersion safeExtGet('targetSdkVersion', 33)
     versionCode 1

--- a/package/example/android/build.gradle
+++ b/package/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 26
+        minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33
         ndkVersion = "23.1.7779620"

--- a/package/example/android/build.gradle
+++ b/package/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 33
         targetSdkVersion = 33
         ndkVersion = "23.1.7779620"


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Apparently some users still aren't on `minSdkVersion` 26. So I just added the possibility to use a lower target, whatever

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
