### PR TITLE
build: add Android MLKit Vision model downloading to expo config plugin

### DIFF
--- a/package/src/expo-plugin/withAndroidMLKitVisionModel.ts
+++ b/package/src/expo-plugin/withAndroidMLKitVisionModel.ts
@@ -1,0 +1,17 @@
+import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins'
+
+const { addMetaDataItemToMainApplication, getMainApplicationOrThrow } = AndroidConfig.Manifest
+
+export const withAndroidMLKitVisionModel: ConfigPlugin = (config) => {
+  return withAndroidManifest(config, (conf) => {
+    const androidManifest = conf.modResults
+
+    const mainApplication = getMainApplicationOrThrow(androidManifest)
+
+    addMetaDataItemToMainApplication(mainApplication, 'com.google.mlkit.vision.DEPENDENCIES', 'barcode')
+
+    conf.modResults = androidManifest
+
+    return conf
+  })
+}

--- a/package/src/expo-plugin/withVisionCamera.ts
+++ b/package/src/expo-plugin/withVisionCamera.ts
@@ -1,6 +1,7 @@
 import { withPlugins, AndroidConfig, ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins'
 import { withDisableFrameProcessorsAndroid } from './withDisableFrameProcessorsAndroid'
 import { withDisableFrameProcessorsIOS } from './withDisableFrameProcessorsIOS'
+import { withAndroidMLKitVisionModel } from './withAndroidMLKitVisionModel'
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
 const pkg = require('../../../package.json')
 
@@ -31,7 +32,7 @@ const withCamera: ConfigPlugin<Props> = (config, props = {}) => {
     config = withDisableFrameProcessorsIOS(config)
   }
 
-  return withPlugins(config, [[AndroidConfig.Permissions.withPermissions, androidPermissions]])
+  return withPlugins(config, [[AndroidConfig.Permissions.withPermissions, androidPermissions], withAndroidMLKitVisionModel])
 }
 
 export default createRunOncePlugin(withCamera, pkg.name, pkg.version)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->



## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

https://www.react-native-vision-camera.com/docs/guides/code-scanning#setup

Adds this logic to the Expo config plugin. I know that the model is already being downloaded lazily, but why not make use of this as soon as the user installs the app :) If needed, we can make this a configurable property so that it is not downloaded via the config plugin if the user doesn't want that, but I doubt that it'll be the case

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

Added AndroidManifest modification logic to the config plugin, reference: https://docs.expo.dev/config-plugins/development-and-debugging/#modify-androidmanifestxml

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

N/A

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
