### PR TITLE
feat: activate/enable the torch mode

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -575,8 +575,9 @@ class CameraSession(
       val videoStabilizationMode = videoStabilizationMode
       val lowLightBoost = lowLightBoost
       val hdr = hdr
+      val enableTorch = enableTorch
 
-      val repeatingRequest = getPreviewCaptureRequest(fps, videoStabilizationMode, lowLightBoost, hdr)
+      val repeatingRequest = getPreviewCaptureRequest(fps, videoStabilizationMode, lowLightBoost, hdr, enableTorch)
       Log.d(TAG, "Setting Repeating Request..")
       session.setRepeatingRequest(repeatingRequest, null, null)
     }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
First of all, I would like to thank you for your huge work.

On my projects, we need to use the torch mode, which makes easier users to see/display some stuff before taking the picture. Even if we aim iOS, I wanted to make sure that Android users could do it.

Maybe it is duplicated with the upcoming "flash feature", but let me know if it can be merged here!

## Changes
In this simple PR, you'll find the call with the additional boolean to properly use the prop `torchMode`.

## Tested on
Android 13, Xiaomi

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
