### PR TITLE
fix: Fix `focus()` on iOS

### DIFF
--- a/package/ios/PreviewView.swift
+++ b/package/ios/PreviewView.swift
@@ -42,6 +42,10 @@ class PreviewView: UIView {
     return videoPreviewLayer.layerRectConverted(fromMetadataOutputRect: rect)
   }
 
+  func captureDevicePointConverted(fromLayerPoint point: CGPoint) -> CGPoint {
+    return videoPreviewLayer.captureDevicePointConverted(fromLayerPoint: point)
+  }
+
   init(frame: CGRect, session: AVCaptureSession) {
     super.init(frame: frame)
     videoPreviewLayer.session = session


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes `focus()` not working on iOS since it stayed in continuous auto-focus mode.

Changes are heavily inspired by https://github.com/mrousavy/react-native-vision-camera/pull/1541 from @levipro

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #1938

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
