### PR TITLE
flipImage was doing nothing on landscape orientated images

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/utils/ImageProxy+save.kt
+++ b/android/src/main/java/com/mrousavy/camera/utils/ImageProxy+save.kt
@@ -49,6 +49,9 @@ fun flipImage(imageBytes: ByteArray): ByteArray {
   val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
 
   when (orientation) {
+    ExifInterface.ORIENTATION_NORMAL -> {
+      matrix.postScale(-1f, 1f)
+    }
     ExifInterface.ORIENTATION_ROTATE_180 -> {
       matrix.setRotate(180f)
       matrix.postScale(-1f, 1f)


### PR DESCRIPTION
Added the case for ORIENTATION_NORMAL

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

On Android when the front camera is used the code *tries* to flip the image (to match the preview). On Portrait and Landscape Right orientations this works. On Landscape Left it does not. The reason for this is that the flipImage function checks the orientation of the image and applies a different transform based on that, but it's missing the case for ORIENTATION_NORMAL which is what is set when the image was tken in Landscape Left.

This PR adds that ORIENTATION_NORMAL case.

## Changes

Add a case for ORIENTATION_NORMAL to the when block in flipImage

## Tested on

Android Samsung tablet and phone.
