### PR TITLE
fix: Unbind Camera in onDetachedFromWindow and fix minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\
 def FOR_HERMES = System.getenv("FOR_HERMES") == "True"
 rootProject.getSubprojects().forEach({project ->
   if (project.plugins.hasPlugin("com.android.application")) {
-    FOR_HERMES = REACT_NATIVE_VERSION >= 71 && project.hermesEnabled || project.ext.react.enableHermes
+    FOR_HERMES = (REACT_NATIVE_VERSION >= 71 && project?.hermesEnabled?.toBoolean()) || project?.ext?.react?.enableHermes?.toBoolean()
   }
 })
 def jsRuntimeDir = {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -140,7 +140,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
 
     if (ENABLE_FRAME_PROCESSORS) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,11 @@ def isNewArchitectureEnabled() {
     return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 def nodeModules = findNodeModules(projectDir)
 logger.warn("VisionCamera: node_modules/ found at: ${nodeModules}")
 def reactNative = new File("$nodeModules/react-native")
@@ -142,7 +147,7 @@ android {
       externalNativeBuild {
         cmake {
           cppFlags "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"
-          abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+          abiFilters (*reactNativeArchitectures())
           arguments '-DANDROID_STL=c++_shared',
                   "-DREACT_NATIVE_VERSION=${REACT_NATIVE_VERSION}",
                   "-DNODE_MODULES_DIR=${nodeModules}",

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -302,6 +302,10 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   }
 
   override fun onDetachedFromWindow() {
+    coroutineScope.launch {
+      val cameraProvider = ProcessCameraProvider.getInstance(reactContext).await()
+      cameraProvider.unbindAll()
+    }
     super.onDetachedFromWindow()
     updateLifecycleState()
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->
This PR fixes camera device and session resource cleanup when unmounted for Android devices. Additionally this build resolves a number of build issues relating to reading project configuration.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->
- Adds camera provider unbinding in `onDetachedFromWindow`.
- Fixes `minSdkVersion` in `android/build.gradle` to read from root project.
- Fixes `FOR_HERMES` in `android/build.gradle` to read from root project.
- Fixes `abiFilters` in `android/build.gradle` to read from `gradle.properties`.

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->
Samsung S10-S22, Samsung XCover Pro V3-6, Pixel 3a-6

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
- Resolves #1685
- Fixes https://github.com/mrousavy/react-native-vision-camera/pull/1955
