### PR TITLE
Fix Frame Processor is not removed when Camera view unmount

### DIFF
--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -434,7 +434,7 @@ export class Camera extends React.PureComponent<CameraProps> {
 
   /** @internal */
   componentWillUnmount(): void {
-    if (this.props.frameProcessor !== null) {
+    if (this.lastFrameProcessor !== null) {
       this.unsetFrameProcessor()
     }
   }

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -431,6 +431,13 @@ export class Camera extends React.PureComponent<CameraProps> {
       this.lastFrameProcessor = frameProcessor
     }
   }
+
+  /** @internal */
+  componentWillUnmount(): void {
+    if (this.props.frameProcessor !== null) {
+      this.unsetFrameProcessor()
+    }
+  }
   //#endregion
 
   /** @internal */


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR fix issue frame proccessor is not removed when Camera view unmount

## Changes
- Add `componentWillUnmount` method
- Check if frame processor is not null
- Unset frame processor

## Tested on
- iPhone 7, ios 15
- I don't have physical android devices
