### PR TITLE
fix: Always call `CaptureSession` fully synchronously under Mutex

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -29,7 +29,6 @@ import com.mrousavy.camera.parsers.ResizeMode
 import com.mrousavy.camera.parsers.Torch
 import com.mrousavy.camera.parsers.VideoStabilizationMode
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -31,6 +31,7 @@ import com.mrousavy.camera.parsers.VideoStabilizationMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
 
 //
 // TODOs for the CameraView which are currently too hard to implement either because of CameraX' limitations, or my brain capacity.
@@ -42,7 +43,7 @@ import kotlinx.coroutines.launch
 // TODO: takePhoto() return with jsi::Value Image reference for faster capture
 
 @SuppressLint("ClickableViewAccessibility", "ViewConstructor", "MissingPermission")
-class CameraView(context: Context) : FrameLayout(context) {
+class CameraView(context: Context) : FrameLayout(context), CoroutineScope {
   companion object {
     const val TAG = "CameraView"
 
@@ -104,6 +105,8 @@ class CameraView(context: Context) : FrameLayout(context) {
   internal val outputOrientation: Orientation
     get() = orientation ?: inputOrientation
 
+  override val coroutineContext: CoroutineContext = CameraQueues.cameraQueue.coroutineDispatcher
+
   init {
     this.installHierarchyFitter()
     setupPreviewView()
@@ -116,12 +119,12 @@ class CameraView(context: Context) : FrameLayout(context) {
       isMounted = true
       invokeOnViewReady()
     }
-    updateLifecycle()
+    launch { updateLifecycle() }
   }
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
-    updateLifecycle()
+    launch { updateLifecycle() }
   }
 
   private fun getPreviewTargetSize(): Size {
@@ -142,7 +145,7 @@ class CameraView(context: Context) : FrameLayout(context) {
 
     val previewView = PreviewView(context, this.getPreviewTargetSize(), resizeMode) { surface ->
       previewSurface = surface
-      configureSession()
+      launch { configureSession() }
     }
     previewView.layoutParams = LayoutParams(
       LayoutParams.MATCH_PARENT,
@@ -164,27 +167,30 @@ class CameraView(context: Context) : FrameLayout(context) {
       val shouldCheckActive = shouldReconfigureFormat || changedProps.contains("isActive")
       val shouldReconfigureZoomGesture = changedProps.contains("enableZoomGesture")
 
-      if (shouldReconfigurePreview) {
-        setupPreviewView()
-      }
-      if (shouldReconfigureSession) {
-        configureSession()
-      }
-      if (shouldReconfigureFormat) {
-        configureFormat()
-      }
-      if (shouldCheckActive) {
-        updateLifecycle()
-      }
-
-      if (shouldReconfigureZoom) {
-        updateZoom()
-      }
-      if (shouldReconfigureTorch) {
-        updateTorch()
-      }
-      if (shouldReconfigureZoomGesture) {
-        updateZoomGesture()
+      launch {
+        // Expensive Calls
+        if (shouldReconfigurePreview) {
+          setupPreviewView()
+        }
+        if (shouldReconfigureSession) {
+          configureSession()
+        }
+        if (shouldReconfigureFormat) {
+          configureFormat()
+        }
+        if (shouldCheckActive) {
+          updateLifecycle()
+        }
+        // Fast Calls
+        if (shouldReconfigureZoom) {
+          updateZoom()
+        }
+        if (shouldReconfigureTorch) {
+          updateTorch()
+        }
+        if (shouldReconfigureZoomGesture) {
+          updateZoomGesture()
+        }
       }
     } catch (e: Throwable) {
       Log.e(TAG, "update() threw: ${e.message}")
@@ -192,7 +198,7 @@ class CameraView(context: Context) : FrameLayout(context) {
     }
   }
 
-  private fun configureSession() {
+  private suspend fun configureSession() {
     try {
       Log.i(TAG, "Configuring Camera Device...")
 
@@ -236,22 +242,20 @@ class CameraView(context: Context) : FrameLayout(context) {
     }
   }
 
-  private fun configureFormat() {
+  private suspend fun configureFormat() {
     cameraSession.configureFormat(fps, videoStabilizationMode, hdr, lowLightBoost)
   }
 
-  private fun updateLifecycle() {
+  private suspend fun updateLifecycle() {
     cameraSession.setIsActive(isActive && isAttachedToWindow)
   }
 
-  private fun updateZoom() {
+  private suspend fun updateZoom() {
     cameraSession.setZoom(zoom)
   }
 
-  private fun updateTorch() {
-    CoroutineScope(Dispatchers.Default).launch {
-      cameraSession.setTorchMode(torch == Torch.ON)
-    }
+  private suspend fun updateTorch() {
+    cameraSession.setTorchMode(torch == Torch.ON)
   }
 
   @SuppressLint("ClickableViewAccessibility")
@@ -262,7 +266,7 @@ class CameraView(context: Context) : FrameLayout(context) {
         object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
           override fun onScale(detector: ScaleGestureDetector): Boolean {
             zoom *= detector.scaleFactor
-            cameraSession.setZoom(zoom)
+            launch { updateZoom() }
             return true
           }
         }

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -28,9 +28,9 @@ import com.mrousavy.camera.parsers.PixelFormat
 import com.mrousavy.camera.parsers.ResizeMode
 import com.mrousavy.camera.parsers.Torch
 import com.mrousavy.camera.parsers.VideoStabilizationMode
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlin.coroutines.CoroutineContext
 
 //
 // TODOs for the CameraView which are currently too hard to implement either because of CameraX' limitations, or my brain capacity.
@@ -42,7 +42,9 @@ import kotlin.coroutines.CoroutineContext
 // TODO: takePhoto() return with jsi::Value Image reference for faster capture
 
 @SuppressLint("ClickableViewAccessibility", "ViewConstructor", "MissingPermission")
-class CameraView(context: Context) : FrameLayout(context), CoroutineScope {
+class CameraView(context: Context) :
+  FrameLayout(context),
+  CoroutineScope {
   companion object {
     const val TAG = "CameraView"
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes an issue in the Expensify app

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
