### PR TITLE
fix: "Main Thread Checker: UI API called on a background thread: -[UI…

### DIFF
--- a/package/ios/CameraView+CodeScanner.swift
+++ b/package/ios/CameraView+CodeScanner.swift
@@ -18,12 +18,15 @@ extension CameraView: AVCaptureMetadataOutputObjectsDelegate {
       return
     }
 
+    // Run this on the main queue, since we access the view's layout from here to convert the coordinates
     DispatchQueue.main.async {
+      // Map codes to JS values
       let codes = metadataObjects.map { object in
           var value: String?
           if let code = object as? AVMetadataMachineReadableCodeObject {
               value = code.stringValue
           }
+
           let frame = self.previewView.layerRectConverted(fromMetadataOutputRect: object.bounds)
           
           return [

--- a/package/ios/CameraView+CodeScanner.swift
+++ b/package/ios/CameraView+CodeScanner.swift
@@ -18,28 +18,28 @@ extension CameraView: AVCaptureMetadataOutputObjectsDelegate {
       return
     }
 
-    // Map codes to JS values
-    let codes = metadataObjects.map { object in
-      var value: String?
-      if let code = object as? AVMetadataMachineReadableCodeObject {
-        value = code.stringValue
+    DispatchQueue.main.async {
+      let codes = metadataObjects.map { object in
+          var value: String?
+          if let code = object as? AVMetadataMachineReadableCodeObject {
+              value = code.stringValue
+          }
+          let frame = self.previewView.layerRectConverted(fromMetadataOutputRect: object.bounds)
+          
+          return [
+              "type": object.type.descriptor,
+              "value": value as Any,
+              "frame": [
+                  "x": frame.origin.x,
+                  "y": frame.origin.y,
+                  "width": frame.size.width,
+                  "height": frame.size.height,
+              ],
+          ]
       }
-      let frame = previewView.layerRectConverted(fromMetadataOutputRect: object.bounds)
 
-      return [
-        "type": object.type.descriptor,
-        "value": value as Any,
-        "frame": [
-          "x": frame.origin.x,
-          "y": frame.origin.y,
-          "width": frame.size.width,
-          "height": frame.size.height,
-        ],
-      ]
+      // Call JS event
+      onCodeScanned(["codes": codes])
     }
-    // Call JS event
-    onCodeScanned([
-      "codes": codes,
-    ])
   }
 }


### PR DESCRIPTION
## What

When scanning codes for the first time the initial code scan takes several seconds 3-5 sec before calling onCodeScanned. 

This PR fixes the warning in Xcode and also improves the scan performance.

## Changes

This PR wraps the frame processing block in `DispatchQueue.main.async {}`

## Tested on

iPhone 12 Pro (iOS 17.0.2)
