### PR TITLE
fix: Fix basic Orientation on iOS

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build:
     name: Build iOS Example App
-    runs-on: macOS-latest
+    runs-on: macOS-13
     defaults:
       run:
         working-directory: package/example/ios
@@ -80,7 +80,7 @@ jobs:
 
   build-no-frame-processors:
     name: Build iOS Example App without Frame Processors
-    runs-on: macOS-latest
+    runs-on: macOS-13
     defaults:
       run:
         working-directory: package/example/ios

--- a/.github/workflows/validate-ios.yml
+++ b/.github/workflows/validate-ios.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           WORKING_DIRECTORY: ios
   SwiftFormat:
-    runs-on: macOS-latest
+    runs-on: macOS-13
     defaults:
       run:
         working-directory: ./package/ios

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -39,17 +39,12 @@ class CameraDevicesManager: RCTEventEmitter {
   override func constantsToExport() -> [AnyHashable: Any]! {
     let devices = getDevicesJson()
     let preferredDevice: [String: Any]?
-    // TODO: Remove this #if once Xcode 15 is rolled out
-    #if swift(>=5.9)
-      if #available(iOS 17.0, *),
-         let userPreferred = AVCaptureDevice.userPreferredCamera {
-        preferredDevice = userPreferred.toDictionary()
-      } else {
-        preferredDevice = devices.first
-      }
-    #else
+    if #available(iOS 17.0, *),
+        let userPreferred = AVCaptureDevice.userPreferredCamera {
+      preferredDevice = userPreferred.toDictionary()
+    } else {
       preferredDevice = devices.first
-    #endif
+    }
 
     return [
       "availableCameraDevices": devices,

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -40,7 +40,7 @@ class CameraDevicesManager: RCTEventEmitter {
     let devices = getDevicesJson()
     let preferredDevice: [String: Any]?
     if #available(iOS 17.0, *),
-        let userPreferred = AVCaptureDevice.userPreferredCamera {
+       let userPreferred = AVCaptureDevice.userPreferredCamera {
       preferredDevice = userPreferred.toDictionary()
     } else {
       preferredDevice = devices.first

--- a/package/ios/Extensions/AVCaptureOutput+mirror.swift
+++ b/package/ios/Extensions/AVCaptureOutput+mirror.swift
@@ -30,23 +30,24 @@ extension AVCaptureOutput {
    - For Videos, the buffers are physically rotated if available, since we use an AVCaptureVideoDataOutput instead of an AVCaptureMovieFileOutput.
    */
   func setOrientation(_ orientation: Orientation) {
-    // Camera Sensors are always in 90deg rotation.
-    // We are setting the target rotation here, so we need to rotate by 90deg once.
-    let cameraOrientation = orientation.rotateRight()
-
+    
     // Set orientation for each connection
     connections.forEach { connection in
       // TODO: Use this once Xcode 15 is rolled out
-      // if #available(iOS 17.0, *) {
-      //   let degrees = cameraOrientation.toDegrees()
-      //   if connection.isVideoRotationAngleSupported(degrees) {
-      //     connection.videoRotationAngle = degrees
-      //   }
-      // } else {
-      if connection.isVideoOrientationSupported {
-        connection.videoOrientation = cameraOrientation.toAVCaptureVideoOrientation()
+      if #available(iOS 17.0, *) {
+        // Camera Sensors are always in landscape rotation (90deg).
+        // We are setting the target rotation here, so we need to rotate by landscape once.
+        let cameraOrientation = orientation.rotateBy(orientation: .landscapeLeft)
+        let degrees = cameraOrientation.toDegrees()
+        
+        if connection.isVideoRotationAngleSupported(degrees) {
+          connection.videoRotationAngle = degrees
+        }
+      } else {
+        if connection.isVideoOrientationSupported {
+          connection.videoOrientation = orientation.toAVCaptureVideoOrientation()
+        }
       }
-      // }
     }
   }
 }

--- a/package/ios/Extensions/AVCaptureOutput+mirror.swift
+++ b/package/ios/Extensions/AVCaptureOutput+mirror.swift
@@ -30,16 +30,15 @@ extension AVCaptureOutput {
    - For Videos, the buffers are physically rotated if available, since we use an AVCaptureVideoDataOutput instead of an AVCaptureMovieFileOutput.
    */
   func setOrientation(_ orientation: Orientation) {
-    
+
     // Set orientation for each connection
     connections.forEach { connection in
-      // TODO: Use this once Xcode 15 is rolled out
       if #available(iOS 17.0, *) {
         // Camera Sensors are always in landscape rotation (90deg).
         // We are setting the target rotation here, so we need to rotate by landscape once.
         let cameraOrientation = orientation.rotateBy(orientation: .landscapeLeft)
         let degrees = cameraOrientation.toDegrees()
-        
+
         if connection.isVideoRotationAngleSupported(degrees) {
           connection.videoRotationAngle = degrees
         }

--- a/package/ios/Extensions/AVCaptureOutput+mirror.swift
+++ b/package/ios/Extensions/AVCaptureOutput+mirror.swift
@@ -30,7 +30,6 @@ extension AVCaptureOutput {
    - For Videos, the buffers are physically rotated if available, since we use an AVCaptureVideoDataOutput instead of an AVCaptureMovieFileOutput.
    */
   func setOrientation(_ orientation: Orientation) {
-
     // Set orientation for each connection
     connections.forEach { connection in
       if #available(iOS 17.0, *) {

--- a/package/ios/Types/Orientation.swift
+++ b/package/ios/Types/Orientation.swift
@@ -37,17 +37,17 @@ enum Orientation: String, JSUnionValue {
       throw CameraError.parameter(.invalid(unionName: "orientation", receivedValue: jsValue))
     }
   }
-  
+
   init(degrees: Double) {
     switch degrees {
-    case 45..<135:
-        self = .landscapeLeft
-    case 135..<225:
-        self = .portraitUpsideDown
-    case 225..<315:
-        self = .landscapeRight
+    case 45 ..< 135:
+      self = .landscapeLeft
+    case 135 ..< 225:
+      self = .portraitUpsideDown
+    case 225 ..< 315:
+      self = .landscapeRight
     default:
-        self = .portrait
+      self = .portrait
     }
   }
 
@@ -80,9 +80,9 @@ enum Orientation: String, JSUnionValue {
       return 270
     }
   }
-  
+
   func rotateBy(orientation: Orientation) -> Orientation {
-    let added = self.toDegrees() + orientation.toDegrees()
+    let added = toDegrees() + orientation.toDegrees()
     let degress = added.truncatingRemainder(dividingBy: 360)
     return Orientation(degrees: degress)
   }

--- a/package/ios/Types/Orientation.swift
+++ b/package/ios/Types/Orientation.swift
@@ -37,6 +37,19 @@ enum Orientation: String, JSUnionValue {
       throw CameraError.parameter(.invalid(unionName: "orientation", receivedValue: jsValue))
     }
   }
+  
+  init(degrees: Double) {
+    switch degrees {
+    case 45..<135:
+        self = .landscapeLeft
+    case 135..<225:
+        self = .portraitUpsideDown
+    case 225..<315:
+        self = .landscapeRight
+    default:
+        self = .portrait
+    }
+  }
 
   var jsValue: String {
     return rawValue
@@ -67,17 +80,10 @@ enum Orientation: String, JSUnionValue {
       return 270
     }
   }
-
-  func rotateRight() -> Orientation {
-    switch self {
-    case .portrait:
-      return .landscapeLeft
-    case .landscapeLeft:
-      return .portraitUpsideDown
-    case .portraitUpsideDown:
-      return .landscapeRight
-    case .landscapeRight:
-      return .portrait
-    }
+  
+  func rotateBy(orientation: Orientation) -> Orientation {
+    let added = self.toDegrees() + orientation.toDegrees()
+    let degress = added.truncatingRemainder(dividingBy: 360)
+    return Orientation(degrees: degress)
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the basic video stream orientation being wrong on iOS

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
