### PR TITLE
fix: Fix PreviewView overflowing on Android

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -114,6 +114,7 @@ class CameraView(context: Context) :
 
   init {
     this.installHierarchyFitter()
+    clipToOutline = true
     setupPreviewView()
     cameraSession = CameraSession(context, cameraManager, { invokeOnInitialized() }, { error -> invokeOnError(error) })
   }

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -13,6 +13,7 @@ import android.view.Surface
 import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.UiThreadUtil
 import com.mrousavy.camera.core.CameraPermissionError
 import com.mrousavy.camera.core.CameraQueues
 import com.mrousavy.camera.core.CameraSession
@@ -156,8 +157,10 @@ class CameraView(context: Context) :
       LayoutParams.MATCH_PARENT,
       Gravity.CENTER
     )
-    addView(previewView)
     this.previewView = previewView
+    UiThreadUtil.runOnUiThread {
+      addView(previewView)
+    }
   }
 
   fun update(changedProps: ArrayList<String>) {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the PreviewView overflowing it's parent layout on Android.

Before:

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td> <img height="600" src="https://github.com/mrousavy/react-native-vision-camera/assets/15199031/49d24dd1-9de0-4191-8e57-56673277ff8e" /> </td>
<td> <img height="600" src="https://github.com/mrousavy/react-native-vision-camera/assets/15199031/015aaf9c-4039-4eaf-91e2-3a393ea5858c" /> </td>
</tr>
</table>



<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1957

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
