### PR TITLE
fix: Run CodeScanner on default queue, fix stalling

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraQueues.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraQueues.kt
@@ -11,7 +11,6 @@ class CameraQueues {
   companion object {
     val cameraQueue = CameraQueue("mrousavy/VisionCamera.main")
     val videoQueue = CameraQueue("mrousavy/VisionCamera.video")
-    val codeScannerQueue = CameraQueue("mrousavy/VisionCamera.codeScanner")
   }
 
   class CameraQueue(name: String) {

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
@@ -29,7 +29,6 @@ class CodeScannerPipeline(val size: Size, val format: Int, val output: CameraOut
     val types = output.codeScanner.codeTypes.map { it.toBarcodeType() }
     val barcodeScannerOptions = BarcodeScannerOptions.Builder()
       .setBarcodeFormats(types[0], *types.toIntArray())
-      .setExecutor(CameraQueues.codeScannerQueue.executor)
       .build()
     scanner = BarcodeScanning.getClient(barcodeScannerOptions)
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
@@ -13,10 +13,10 @@ import java.io.Closeable
 
 class CodeScannerPipeline(val size: Size, val format: Int, val output: CameraOutputs.CodeScannerOutput) : Closeable {
   companion object {
-    // We want to have a buffer of 2 images, but we always only acquire one.
-    // That way the pipeline is free to stream frames into the unused buffer,
+    // We want to have a buffer of 3 images, but we always only acquire one.
+    // That way the pipeline is free to stream up to two frames into the unused buffer,
     // while the other buffer is being used for code scanning.
-    private const val MAX_IMAGES = 2
+    private const val MAX_IMAGES = 3
   }
 
   private val imageReader: ImageReader


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
