### PR TITLE
chore: Rename `CodeScanner` to `CodeScannerOptions` in native

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -26,7 +26,7 @@ import com.mrousavy.camera.extensions.getPreviewTargetSize
 import com.mrousavy.camera.extensions.installHierarchyFitter
 import com.mrousavy.camera.extensions.smaller
 import com.mrousavy.camera.frameprocessor.FrameProcessor
-import com.mrousavy.camera.parsers.CodeScanner
+import com.mrousavy.camera.parsers.CodeScannerOptions
 import com.mrousavy.camera.parsers.Orientation
 import com.mrousavy.camera.parsers.PixelFormat
 import com.mrousavy.camera.parsers.ResizeMode
@@ -88,7 +88,7 @@ class CameraView(context: Context) :
   var enableZoomGesture: Boolean = false
 
   // code scanner
-  var codeScannerOptions: CodeScanner? = null
+  var codeScannerOptions: CodeScannerOptions? = null
 
   // private properties
   private var isMounted = false

--- a/package/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -5,7 +5,7 @@ import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.mrousavy.camera.parsers.CodeScanner
+import com.mrousavy.camera.parsers.CodeScannerOptions
 import com.mrousavy.camera.parsers.Orientation
 import com.mrousavy.camera.parsers.PixelFormat
 import com.mrousavy.camera.parsers.ResizeMode
@@ -204,7 +204,7 @@ class CameraViewManager : ViewGroupManager<CameraView>() {
 
   @ReactProp(name = "codeScannerOptions")
   fun setCodeScanner(view: CameraView, codeScannerOptions: ReadableMap) {
-    val newCodeScannerOptions = CodeScanner(codeScannerOptions)
+    val newCodeScannerOptions = CodeScannerOptions(codeScannerOptions)
     if (view.codeScannerOptions != newCodeScannerOptions) {
       addChangedPropToTransaction(view, "codeScannerOptions")
     }

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
@@ -26,7 +26,7 @@ class CodeScannerPipeline(val size: Size, val format: Int, val output: CameraOut
     get() = imageReader.surface
 
   init {
-    val types = output.codeScanner.codeTypes.map { it.toBarcodeType() }
+    val types = output.options.codeTypes.map { it.toBarcodeType() }
     val barcodeScannerOptions = BarcodeScannerOptions.Builder()
       .setBarcodeFormats(types[0], *types.toIntArray())
       .build()
@@ -67,7 +67,7 @@ class CodeScannerPipeline(val size: Size, val format: Int, val output: CameraOut
   }
 
   override fun toString(): String {
-    val codeTypes = output.codeScanner.codeTypes.joinToString(", ")
+    val codeTypes = output.options.codeTypes.joinToString(", ")
     return "${size.width} x ${size.height} CodeScanner for [$codeTypes] ($format)"
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/outputs/CameraOutputs.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/outputs/CameraOutputs.kt
@@ -18,7 +18,7 @@ import com.mrousavy.camera.extensions.getPhotoSizes
 import com.mrousavy.camera.extensions.getPreviewTargetSize
 import com.mrousavy.camera.extensions.getVideoSizes
 import com.mrousavy.camera.extensions.smaller
-import com.mrousavy.camera.parsers.CodeScanner
+import com.mrousavy.camera.parsers.CodeScannerOptions
 import com.mrousavy.camera.parsers.PixelFormat
 import java.io.Closeable
 
@@ -46,7 +46,7 @@ class CameraOutputs(
     val format: PixelFormat = PixelFormat.NATIVE
   )
   data class CodeScannerOutput(
-    val codeScanner: CodeScanner,
+    val options: CodeScannerOptions,
     val onCodeScanned: (codes: List<Barcode>) -> Unit,
     val onError: (error: Throwable) -> Unit
   )
@@ -84,7 +84,7 @@ class CameraOutputs(
       this.video?.enableRecording == other.video?.enableRecording &&
       this.video?.targetSize == other.video?.targetSize &&
       this.video?.format == other.video?.format &&
-      this.codeScanner?.codeScanner == other.codeScanner?.codeScanner &&
+      this.codeScanner?.options == other.codeScanner?.options &&
       this.enableHdr == other.enableHdr
   }
 
@@ -168,7 +168,7 @@ class CameraOutputs(
       val size = characteristics.getVideoSizes(cameraId, format).closestToOrMax(targetSize)
       val pipeline = CodeScannerPipeline(size, format, codeScanner)
 
-      Log.i(TAG, "Adding ${size.width}x${size.height} code scanner output. (Code Types: ${codeScanner.codeScanner.codeTypes})")
+      Log.i(TAG, "Adding ${size.width}x${size.height} code scanner output. (Code Types: ${codeScanner.options.codeTypes})")
       codeScannerOutput = BarcodeScannerOutput(pipeline)
     }
 

--- a/package/android/src/main/java/com/mrousavy/camera/parsers/CodeScannerOptions.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/parsers/CodeScannerOptions.kt
@@ -3,7 +3,7 @@ package com.mrousavy.camera.parsers
 import com.facebook.react.bridge.ReadableMap
 import com.mrousavy.camera.core.InvalidTypeScriptUnionError
 
-class CodeScanner(map: ReadableMap) {
+class CodeScannerOptions(map: ReadableMap) {
   val codeTypes: List<CodeType>
 
   init {
@@ -14,7 +14,7 @@ class CodeScanner(map: ReadableMap) {
   }
 
   override fun equals(other: Any?): Boolean {
-    if (other !is CodeScanner) return false
+    if (other !is CodeScannerOptions) return false
     return codeTypes.size == other.codeTypes.size && codeTypes.containsAll(other.codeTypes)
   }
 

--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -179,8 +179,8 @@ public final class CameraView: UIView, CameraSessionDelegate {
 
       // Code Scanner
       if let codeScannerOptions {
-        let codeScanner = try CodeScanner(fromJsValue: codeScannerOptions)
-        config.codeScanner = .enabled(config: codeScanner)
+        let options = try CodeScannerOptions(fromJsValue: codeScannerOptions)
+        config.codeScanner = .enabled(config: CameraConfiguration.CodeScanner(options: options))
       } else {
         config.codeScanner = .disabled
       }

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -150,7 +150,7 @@ class CameraConfiguration {
   struct Audio: Equatable {
     // no props for audio at the moment
   }
-  
+
   /**
    A CodeScanner Output configuration
    */

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -150,6 +150,13 @@ class CameraConfiguration {
   struct Audio: Equatable {
     // no props for audio at the moment
   }
+  
+  /**
+   A CodeScanner Output configuration
+   */
+  struct CodeScanner: Equatable {
+    var options: CodeScannerOptions
+  }
 }
 
 extension CameraConfiguration.Video {

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -126,14 +126,15 @@ extension CameraSession {
       let codeScannerOutput = AVCaptureMetadataOutput()
 
       // 1. Configure
-      try codeScanner.codeTypes.forEach { type in
+      let options = codeScanner.options
+      try codeScanner.options.codeTypes.forEach { type in
         if !codeScannerOutput.availableMetadataObjectTypes.contains(type) {
           throw CameraError.codeScanner(.codeTypeNotSupported(codeType: type.descriptor))
         }
       }
       codeScannerOutput.setMetadataObjectsDelegate(self, queue: CameraQueues.codeScannerQueue)
-      codeScannerOutput.metadataObjectTypes = codeScanner.codeTypes
-      if let rectOfInterest = codeScanner.regionOfInterest {
+      codeScannerOutput.metadataObjectTypes = options.codeTypes
+      if let rectOfInterest = options.regionOfInterest {
         codeScannerOutput.rectOfInterest = rectOfInterest
       }
 

--- a/package/ios/Types/CodeScannerOptions.swift
+++ b/package/ios/Types/CodeScannerOptions.swift
@@ -9,7 +9,7 @@
 import AVFoundation
 import Foundation
 
-struct CodeScanner: Equatable {
+struct CodeScannerOptions: Equatable {
   let codeTypes: [AVMetadataObject.ObjectType]
   let interval: Int
   let regionOfInterest: CGRect?

--- a/package/ios/Types/CodeScannerOptions.swift
+++ b/package/ios/Types/CodeScannerOptions.swift
@@ -1,5 +1,5 @@
 //
-//  CodeScanner.swift
+//  CodeScannerOptions.swift
 //  VisionCamera
 //
 //  Created by Marc Rousavy on 03.10.23.

--- a/package/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/package/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		B8DB3BCA263DC4D8004C18D7 /* RecordingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BC9263DC4D8004C18D7 /* RecordingSession.swift */; };
 		B8DB3BCC263DC97E004C18D7 /* AVFileType+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BCB263DC97E004C18D7 /* AVFileType+descriptor.swift */; };
 		B8F127D02ACF054A00B39EA3 /* CMVideoDimensions+toCGSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F127CF2ACF054A00B39EA3 /* CMVideoDimensions+toCGSize.swift */; };
-		B8FF60AE2ACC9731009D612F /* CodeScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF60AD2ACC9731009D612F /* CodeScanner.swift */; };
+		B8FF60AE2ACC9731009D612F /* CodeScannerOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF60AD2ACC9731009D612F /* CodeScannerOptions.swift */; };
 		B8FF60B12ACC981B009D612F /* AVMetadataObject.ObjectType+descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF60B02ACC981B009D612F /* AVMetadataObject.ObjectType+descriptor.swift */; };
 /* End PBXBuildFile section */
 
@@ -176,7 +176,7 @@
 		B8F0825F2A60491900C17EB6 /* FrameProcessor.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrameProcessor.mm; sourceTree = "<group>"; };
 		B8F127CF2ACF054A00B39EA3 /* CMVideoDimensions+toCGSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMVideoDimensions+toCGSize.swift"; sourceTree = "<group>"; };
 		B8F7DDD1266F715D00120533 /* Frame.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Frame.m; sourceTree = "<group>"; };
-		B8FF60AD2ACC9731009D612F /* CodeScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeScanner.swift; sourceTree = "<group>"; };
+		B8FF60AD2ACC9731009D612F /* CodeScannerOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeScannerOptions.swift; sourceTree = "<group>"; };
 		B8FF60B02ACC981B009D612F /* AVMetadataObject.ObjectType+descriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVMetadataObject.ObjectType+descriptor.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -226,7 +226,7 @@
 			isa = PBXGroup;
 			children = (
 				B80175EB2ABDEBD000E7DE90 /* ResizeMode.swift */,
-				B8FF60AD2ACC9731009D612F /* CodeScanner.swift */,
+				B8FF60AD2ACC9731009D612F /* CodeScannerOptions.swift */,
 				B88103DE2AD6FB230087F063 /* Orientation.swift */,
 				B88103E02AD7046E0087F063 /* Torch.swift */,
 				B8A1AEC92AD8034E00169C0D /* RecordVideoOptions.swift */,
@@ -488,7 +488,7 @@
 				B88685ED2AD6A5E600E93869 /* CameraSession+CodeScanner.swift in Sources */,
 				B8D22CDC2642DB4D00234472 /* AVAssetWriterInputPixelBufferAdaptor+initWithVideoSettings.swift in Sources */,
 				B84760DF2608F57D004C3180 /* CameraQueues.swift in Sources */,
-				B8FF60AE2ACC9731009D612F /* CodeScanner.swift in Sources */,
+				B8FF60AE2ACC9731009D612F /* CodeScannerOptions.swift in Sources */,
 				B8446E502ABA14C900E56077 /* CameraDevicesManager.m in Sources */,
 				B887518F25E0102000DB86D6 /* AVCaptureOutput+mirror.swift in Sources */,
 				B88751A425E0102000DB86D6 /* AVCaptureDevice.Format.AutoFocusSystem+descriptor.swift in Sources */,


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
