### PR TITLE
fix: Fix `torch` not working on iOS

### DIFF
--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -70,6 +70,7 @@ class CameraConfiguration {
     let orientationChanged: Bool
     let formatChanged: Bool
     let sidePropsChanged: Bool
+    let torchChanged: Bool
     let zoomChanged: Bool
 
     let audioSessionChanged: Bool
@@ -100,7 +101,9 @@ class CameraConfiguration {
       // format (depends on cameraId)
       formatChanged = inputChanged || left?.format != right.format
       // side-props (depends on format)
-      sidePropsChanged = formatChanged || left?.fps != right.fps || left?.enableLowLightBoost != right.enableLowLightBoost || left?.torch != right.torch
+      sidePropsChanged = formatChanged || left?.fps != right.fps || left?.enableLowLightBoost != right.enableLowLightBoost
+      // torch (depends on isActive)
+      torchChanged = left?.isActive != right.isActive || left?.torch != right.torch
       // zoom (depends on format)
       zoomChanged = formatChanged || left?.zoom != right.zoom
 

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -175,16 +175,13 @@ extension CameraSession {
   /**
    Configures the active format (`format`)
    */
-  func configureFormat(configuration: CameraConfiguration) throws {
+  func configureFormat(configuration: CameraConfiguration, device: AVCaptureDevice) throws {
     guard let targetFormat = configuration.format else {
       // No format was set, just use the default.
       return
     }
 
     ReactLogger.log(level: .info, message: "Configuring Format (\(targetFormat))...")
-    guard let device = videoDeviceInput?.device else {
-      throw CameraError.session(.cameraNotReady)
-    }
 
     let currentFormat = CameraDeviceFormat(fromFormat: device.activeFormat)
     if currentFormat == targetFormat {
@@ -209,11 +206,7 @@ extension CameraSession {
   /**
    Configures format-dependant "side-props" (`fps`, `lowLightBoost`)
    */
-  func configureSideProps(configuration: CameraConfiguration) throws {
-    guard let device = videoDeviceInput?.device else {
-      throw CameraError.session(.cameraNotReady)
-    }
-
+  func configureSideProps(configuration: CameraConfiguration, device: AVCaptureDevice) throws {
     // Configure FPS
     if let fps = configuration.fps {
       let supportsGivenFps = device.activeFormat.videoSupportedFrameRateRanges.contains { range in
@@ -244,11 +237,7 @@ extension CameraSession {
    Configures the torch.
    The CaptureSession has to be running for the Torch to work.
    */
-  func configureTorch(configuration: CameraConfiguration) throws {
-    guard let device = videoDeviceInput?.device else {
-      throw CameraError.session(.cameraNotReady)
-    }
-
+  func configureTorch(configuration: CameraConfiguration, device: AVCaptureDevice) throws {
     // Configure Torch
     let torchMode = configuration.torch.toTorchMode()
     if device.torchMode != torchMode {
@@ -268,10 +257,7 @@ extension CameraSession {
   /**
    Configures zoom (`zoom`)
    */
-  func configureZoom(configuration: CameraConfiguration) throws {
-    guard let device = videoDeviceInput?.device else {
-      throw CameraError.session(.cameraNotReady)
-    }
+  func configureZoom(configuration: CameraConfiguration, device: AVCaptureDevice) {
     guard let zoom = configuration.zoom else {
       return
     }

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -207,7 +207,7 @@ extension CameraSession {
   // pragma MARK: Side-Props
 
   /**
-   Configures format-dependant "side-props" (`fps`, `lowLightBoost`, `torch`)
+   Configures format-dependant "side-props" (`fps`, `lowLightBoost`)
    */
   func configureSideProps(configuration: CameraConfiguration) throws {
     guard let device = videoDeviceInput?.device else {
@@ -238,13 +238,24 @@ extension CameraSession {
       }
       device.automaticallyEnablesLowLightBoostWhenAvailable = configuration.enableLowLightBoost
     }
-
+  }
+  
+  /**
+   Configures the torch.
+   The CaptureSession has to be running for the Torch to work.
+   */
+  func configureTorch(configuration: CameraConfiguration) throws {
+    guard let device = videoDeviceInput?.device else {
+      throw CameraError.session(.cameraNotReady)
+    }
+    
     // Configure Torch
     let torchMode = configuration.torch.toTorchMode()
     if device.torchMode != torchMode {
       guard device.hasTorch else {
         throw CameraError.device(.flashUnavailable)
       }
+      
       device.torchMode = torchMode
       if torchMode == .on {
         try device.setTorchModeOn(level: 1.0)

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -239,7 +239,7 @@ extension CameraSession {
       device.automaticallyEnablesLowLightBoostWhenAvailable = configuration.enableLowLightBoost
     }
   }
-  
+
   /**
    Configures the torch.
    The CaptureSession has to be running for the Torch to work.
@@ -248,14 +248,14 @@ extension CameraSession {
     guard let device = videoDeviceInput?.device else {
       throw CameraError.session(.cameraNotReady)
     }
-    
+
     // Configure Torch
     let torchMode = configuration.torch.toTorchMode()
     if device.torchMode != torchMode {
       guard device.hasTorch else {
         throw CameraError.device(.flashUnavailable)
       }
-      
+
       device.torchMode = torchMode
       if torchMode == .on {
         try device.setTorchModeOn(level: 1.0)

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -163,7 +163,7 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
 
         // 6. Start or stop the session if needed
         self.checkIsActive(configuration: config)
-        
+
         // 7. Enable or disable the Torch if needed (requires session to be running)
         if difference.torchChanged {
           try self.configureTorch(configuration: config)

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -163,6 +163,11 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
 
         // 6. Start or stop the session if needed
         self.checkIsActive(configuration: config)
+        
+        // 7. Enable or disable the Torch if needed (requires session to be running)
+        if difference.torchChanged {
+          try self.configureTorch(configuration: config)
+        }
 
         // Update successful, set the new configuration!
         self.configuration = config

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -114,51 +114,38 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
       do {
         // If needed, configure the AVCaptureSession (inputs, outputs)
         if difference.isSessionConfigurationDirty {
-          // Lock Capture Session for configuration
-          ReactLogger.log(level: .info, message: "Beginning CameraSession configuration...")
-          self.captureSession.beginConfiguration()
-
-          // 1. Update input device
-          if difference.inputChanged {
-            try self.configureDevice(configuration: config)
+          try self.withSessionLock {
+            // 1. Update input device
+            if difference.inputChanged {
+              try self.configureDevice(configuration: config)
+            }
+            // 2. Update outputs
+            if difference.outputsChanged {
+              try self.configureOutputs(configuration: config)
+            }
+            // 3. Update output orientation
+            if difference.orientationChanged {
+              self.configureOrientation(configuration: config)
+            }
           }
-          // 2. Update outputs
-          if difference.outputsChanged {
-            try self.configureOutputs(configuration: config)
-          }
-          // 3. Update output orientation
-          if difference.orientationChanged {
-            self.configureOrientation(configuration: config)
-          }
-
-          // Unlock Capture Session again and submit configuration to Hardware
-          self.captureSession.commitConfiguration()
-          ReactLogger.log(level: .info, message: "Committed CameraSession configuration!")
         }
 
         // If needed, configure the AVCaptureDevice (format, zoom, low-light-boost, ..)
         if difference.isDeviceConfigurationDirty {
-          guard let device = self.videoDeviceInput?.device else {
-            throw CameraError.session(.cameraNotReady)
+          try self.withDeviceLock { device in
+            // 4. Configure format
+            if difference.formatChanged {
+              try self.configureFormat(configuration: config, device: device)
+            }
+            // 5. Configure side-props (fps, lowLightBoost)
+            if difference.sidePropsChanged {
+              try self.configureSideProps(configuration: config, device: device)
+            }
+            // 6. Configure zoom
+            if difference.zoomChanged {
+              self.configureZoom(configuration: config, device: device)
+            }
           }
-          ReactLogger.log(level: .info, message: "Beginning CaptureDevice configuration...")
-          try device.lockForConfiguration()
-
-          // 4. Configure format
-          if difference.formatChanged {
-            try self.configureFormat(configuration: config)
-          }
-          // 5. Configure side-props (fps, lowLightBoost)
-          if difference.sidePropsChanged {
-            try self.configureSideProps(configuration: config)
-          }
-          // 6. Configure zoom
-          if difference.zoomChanged {
-            try self.configureZoom(configuration: config)
-          }
-
-          device.unlockForConfiguration()
-          ReactLogger.log(level: .info, message: "Committed CaptureDevice configuration!")
         }
 
         // 6. Start or stop the session if needed
@@ -166,7 +153,9 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
 
         // 7. Enable or disable the Torch if needed (requires session to be running)
         if difference.torchChanged {
-          try self.configureTorch(configuration: config)
+          try self.withDeviceLock { device in
+            try self.configureTorch(configuration: config, device: device)
+          }
         }
 
         // Update successful, set the new configuration!
@@ -194,6 +183,41 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
         }
       }
     }
+  }
+
+  /**
+   Runs the given [lambda] under an AVCaptureSession configuration lock (`beginConfiguration()`)
+   */
+  private func withSessionLock(_ lambda: () throws -> Void) throws {
+    // Lock Capture Session for configuration
+    ReactLogger.log(level: .info, message: "Beginning CameraSession configuration...")
+    captureSession.beginConfiguration()
+    defer {
+      // Unlock Capture Session again and submit configuration to Hardware
+      self.captureSession.commitConfiguration()
+      ReactLogger.log(level: .info, message: "Committed CameraSession configuration!")
+    }
+
+    // Call lambda
+    try lambda()
+  }
+
+  /**
+   Runs the given [lambda] under an AVCaptureDevice configuration lock (`lockForConfiguration()`)
+   */
+  private func withDeviceLock(_ lambda: (_ device: AVCaptureDevice) throws -> Void) throws {
+    guard let device = videoDeviceInput?.device else {
+      throw CameraError.session(.cameraNotReady)
+    }
+    ReactLogger.log(level: .info, message: "Beginning CaptureDevice configuration...")
+    try device.lockForConfiguration()
+    defer {
+      device.unlockForConfiguration()
+      ReactLogger.log(level: .info, message: "Committed CaptureDevice configuration!")
+    }
+
+    // Call lambda with Device
+    try lambda(device)
   }
 
   /**

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -148,10 +148,10 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
           }
         }
 
-        // 6. Start or stop the session if needed
+        // 7. Start or stop the session if needed
         self.checkIsActive(configuration: config)
 
-        // 7. Enable or disable the Torch if needed (requires session to be running)
+        // 8. Enable or disable the Torch if needed (requires session to be running)
         if difference.torchChanged {
           try self.withDeviceLock { device in
             try self.configureTorch(configuration: config, device: device)

--- a/package/ios/Core/RecordingSession.swift
+++ b/package/ios/Core/RecordingSession.swift
@@ -36,10 +36,16 @@ class RecordingSession {
   private var hasWrittenFirstVideoFrame = false
   private var isFinishing = false
 
+  /**
+   Gets the file URL of the recorded video.
+   */
   var url: URL {
     return assetWriter.outputURL
   }
 
+  /**
+   Get the duration (in seconds) of the recorded video.
+   */
   var duration: Double {
     guard let latestTimestamp = latestTimestamp,
           let initialTimestamp = initialTimestamp else {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

The Torch can only be controlled after we start the capture session, so this code moves the torch configuration down a bit.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2030

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
