### PR TITLE
fix: Initialize Plugins in a `static` block of ReactPackage

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
@@ -88,7 +88,7 @@ import com.mrousavy.camera.frameprocessor.FrameProcessorPluginRegistry;
 
 public class FaceDetectorFrameProcessorPluginPackage implements ReactPackage {
   // highlight-start
-  FaceDetectorFrameProcessorPluginPackage() {
+  static {
     FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces", options -> new FaceDetectorFrameProcessorPlugin(options));
   }
   // highlight-end
@@ -158,9 +158,11 @@ import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
 
 class FaceDetectorFrameProcessorPluginPackage : ReactPackage {
   // highlight-start
-  init {
-    FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces") { options ->
-      FaceDetectorFrameProcessorPlugin(options)
+  companion object {
+    init {
+      FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces") { options ->
+        FaceDetectorFrameProcessorPlugin(options)
+      }
     }
   }
   // highlight-end

--- a/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.java
+++ b/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.java
@@ -18,6 +18,11 @@ import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin;
 import com.mrousavy.camera.frameprocessor.FrameProcessorPluginRegistry;
 
 public class MainApplication extends Application implements ReactApplication {
+  // Register the Frame Processor Plugins for our app
+  static {
+    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin", options -> new ExampleFrameProcessorPlugin(options));
+    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_kotlin_swift_plugin", options -> new ExampleKotlinFrameProcessorPlugin(options));
+  }
 
   private final ReactNativeHost mReactNativeHost =
       new DefaultReactNativeHost(this) {
@@ -64,8 +69,5 @@ public class MainApplication extends Application implements ReactApplication {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
       DefaultNewArchitectureEntryPoint.load();
     }
-
-    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin", options -> new ExampleFrameProcessorPlugin(options));
-    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_kotlin_swift_plugin", options -> new ExampleKotlinFrameProcessorPlugin(options));
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This docs change tells people to register plugins in a `static` block of the `ReactPackage` - this fixes the error https://github.com/mrousavy/react-native-vision-camera/issues/2036 because it is guaranteed to only run once, when the app loads the Java file.

The plugins aren't bound to lifecycle anyways since those are just initializer calls, so this is perfectly safe to do.

#### Why do we need a `ReactPackage` in the first place?

Frame Processor Plugins should be distributed through npm, and just shipping java files to npm won't be enough. The react-native CLI will only include the java files of an npm package in your app's `android/` project if the npm package contains a `ReactPackage`, so we just create a dummy `ReactPackage` in our case and use the static initializer to register our Frame Processor Plugin.

cc @mateusz1913 

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2036

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
