### PR TITLE
fix: Add `getFrameProcessorPlugin` for backwards compatibility

### DIFF
--- a/package/src/FrameProcessorPlugins.ts
+++ b/package/src/FrameProcessorPlugins.ts
@@ -100,7 +100,19 @@ if (hasWorklets) {
   }
 }
 
-export const VisionCameraProxy = proxy
+export const VisionCameraProxy: TVisionCameraProxy = {
+  initFrameProcessorPlugin: proxy.initFrameProcessorPlugin,
+  removeFrameProcessor: proxy.removeFrameProcessor,
+  setFrameProcessor: proxy.setFrameProcessor,
+  // TODO: Remove this in the next version
+  // @ts-expect-error
+  getFrameProcessorPlugin: (name, options) => {
+    console.warn(
+      '"getFrameProcessorPlugin" has been renamed to "initFrameProcessorPlugin". This function will be removed in the next release.',
+    )
+    return proxy.initFrameProcessorPlugin(name, options)
+  },
+}
 
 declare global {
   // eslint-disable-next-line no-var


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
