### PR TITLE
feat: Make Frame Processors work on API <29

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -70,6 +70,9 @@ class VideoPipeline(
   private var imageReader: ImageReader? = null
   private var imageWriter: ImageWriter? = null
 
+  private val hasOutputs: Boolean
+    get() = recordingSession != null
+
   init {
     Log.i(
       TAG,
@@ -84,15 +87,20 @@ class VideoPipeline(
     if (enableFrameProcessor) {
       // User has passed a Frame Processor, we need to route images through ImageReader so we can get
       // CPU access to the Frames, then send them to the OpenGL pipeline later.
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-        throw FrameProcessorsUnavailableError("Frame Processors require API 29 or higher. (Q)")
-      }
-      // GPU_SAMPLED because we redirect to OpenGL, CPU_READ because we read pixels before that.
-      val usage = HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE or HardwareBuffer.USAGE_CPU_READ_OFTEN
       val format = getImageReaderFormat()
       Log.i(TAG, "Using ImageReader round-trip (format: #$format)")
-      imageWriter = ImageWriter.newInstance(glSurface, MAX_IMAGES, format)
-      imageReader = ImageReader.newInstance(width, height, format, MAX_IMAGES, usage)
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        Log.i(TAG, "Using API 29 for GPU ImageReader...")
+        // GPU_SAMPLED because we redirect to OpenGL, CPU_READ because we read pixels before that.
+        val usage = HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE or HardwareBuffer.USAGE_CPU_READ_OFTEN
+        imageReader = ImageReader.newInstance(width, height, format, MAX_IMAGES, usage)
+        imageWriter = ImageWriter.newInstance(glSurface, MAX_IMAGES, format)
+      } else {
+        Log.i(TAG, "Using legacy API for CPU ImageReader...")
+        imageReader = ImageReader.newInstance(width, height, format, MAX_IMAGES)
+        imageWriter = ImageWriter.newInstance(glSurface, MAX_IMAGES)
+      }
       imageReader!!.setOnImageAvailableListener({ reader ->
         Log.i(TAG, "ImageReader::onImageAvailable!")
         val image = reader.acquireNextImage() ?: return@setOnImageAvailableListener
@@ -104,7 +112,10 @@ class VideoPipeline(
         frame.incrementRefCount()
         frameProcessor?.call(frame)
 
-        imageWriter!!.queueInputImage(image)
+        if (hasOutputs) {
+          // If we have outputs (e.g. a RecordingSession), pass the frame along to the OpenGL pipeline
+          imageWriter!!.queueInputImage(image)
+        }
 
         frame.decrementRefCount()
       }, CameraQueues.videoQueue.handler)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

If the phone is not on API 29, instead of crashing we still try to create the ImageReader to enable Frame Processing, but without API 29 we can't create GPU-based `ImageReader`s. This means, that there is no guarantee that the video recording feature (OpenGL pipeline) works as expected, because it is implementation-specific - some devices may record fine and some won't.

But if you only run a FP, or only Record, everything is fine!

If you want to be on the absolute safe side of things, only enable your Frame Processor if the user's phone is on Android API 29 or higher. 

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
