### PR TITLE
fix: Fix Xcode 15 build error (`var` instead of `let`)

### DIFF
--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -38,7 +38,7 @@ class CameraDevicesManager: RCTEventEmitter {
 
   override func constantsToExport() -> [AnyHashable: Any]! {
     let devices = getDevicesJson()
-    let preferredDevice = devices.first
+    var preferredDevice = devices.first
 
     #if swift(>=5.9)
       if #available(iOS 17.0, *) {

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -38,19 +38,11 @@ class CameraDevicesManager: RCTEventEmitter {
 
   override func constantsToExport() -> [AnyHashable: Any]! {
     let devices = getDevicesJson()
-    var preferredDevice = devices.first
-
-    #if swift(>=5.9)
-      if #available(iOS 17.0, *) {
-        if let userPreferred = AVCaptureDevice.userPreferredCamera {
-          preferredDevice = userPreferred.toDictionary()
-        }
-      }
-    #endif
+    let preferredDevice = getPreferredDevice()
 
     return [
       "availableCameraDevices": devices,
-      "userPreferredCameraDevice": preferredDevice as Any,
+      "userPreferredCameraDevice": preferredDevice?.toDictionary() as Any,
     ]
   }
 
@@ -58,6 +50,19 @@ class CameraDevicesManager: RCTEventEmitter {
     return discoverySession.devices.map {
       return $0.toDictionary()
     }
+  }
+  
+  private func getPreferredDevice() -> AVCaptureDevice? {
+    #if swift(>=5.9)
+      if #available(iOS 17.0, *) {
+        if let userPreferred = AVCaptureDevice.userPreferredCamera {
+          // Return the device that was explicitly marked as a preferred camera by the user
+          return userPreferred
+        }
+      }
+    #endif
+    // Just return the first device
+    return discoverySession.devices.first
   }
 
   private static func getAllDeviceTypes() -> [AVCaptureDevice.DeviceType] {

--- a/package/ios/CameraDevicesManager.swift
+++ b/package/ios/CameraDevicesManager.swift
@@ -51,7 +51,7 @@ class CameraDevicesManager: RCTEventEmitter {
       return $0.toDictionary()
     }
   }
-  
+
   private func getPreferredDevice() -> AVCaptureDevice? {
     #if swift(>=5.9)
       if #available(iOS 17.0, *) {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes a regression introduced in the last release that caused a build error on Xcode 15.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2044

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
