### PR TITLE
[V2] Fix swift macro on Xcode 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It is recommended that everybody upgrades to VisionCamera V3. If you have any is
 > [!NOTE]
 > The documentation hosted on https://react-native-vision-camera.com represents the documentation for V3. For V2, read the [docs/](docs/) folder here.
 
-VisionCamera V2 requires React Native 0.70+, iOS 11+, Android API 21+.
+VisionCamera V2 requires React Native 0.70+, iOS 11+, Android API 21+, Xcode 15+.
 
 
 ### Documentation

--- a/docs/docs/guides/SETUP.mdx
+++ b/docs/docs/guides/SETUP.mdx
@@ -44,7 +44,7 @@ expo install react-native-vision-camera
 
 VisionCamera requires **iOS 11 or higher**, and **Android-SDK version 21 or higher**. See [Troubleshooting](/docs/guides/troubleshooting) if you're having installation issues.
 
-> **(Optional)** If you want to use [**Frame Processors**](/docs/guides/frame-processors), you need to install [**react-native-reanimated**](https://github.com/software-mansion/react-native-reanimated) 2.2.0 or higher.
+> **(Optional)** If you want to use [**Frame Processors**](/docs/guides/frame-processors), you need to install [**react-native-reanimated**](https://github.com/software-mansion/react-native-reanimated) 3.4.0 or higher.
 
 ## Updating manifests
 

--- a/ios/Frame Processor/FrameProcessorPlugin.h
+++ b/ios/Frame Processor/FrameProcessorPlugin.h
@@ -49,7 +49,7 @@
 objc_name : NSObject<FrameProcessorPluginBase>                                      \
 @end                                                                                \
                                                                                     \
-@interface objc_name (FrameProcessorPlugin)                                         \
+@interface objc_name (FrameProcessorPlugin) <FrameProcessorPluginBase>              \
 @end                                                                                \
 @implementation objc_name (FrameProcessorPlugin)                                    \
                                                                                     \


### PR DESCRIPTION
## What

Xcode 15 seems to enforce the protocol segment on an interface in my best research. As this unchanged line of code in Xcode 14 works without an issue.

Unfortunately on the flip between swapping back to +load() or removing the protocol seems to not work on 15 at the benefit of working on lower Xcodes. I believe the best path forward here is to support Xcode 15 and update the docs (as included) to enforce this.

V2 is basically EOL anyway for v3 - so I think this is acceptable. This is now confirmed working on the sample application, my sample application for https://github.com/sourcetoad/vision-camera-plugin-barcode-scanner/pulls and our internal application.

I'm personally unaware myself how this works without the protocol type on the sample application here, but fails on my own application. This exceeds my knowledge but must be related to how Xcode handles a 1st party package vs a dependency.

## Changes

* Adjust swift macro for frame processor on Xcode 15

## Tested on

* iPhone 13 Pro

https://github.com/mrousavy/react-native-vision-camera/assets/611784/bd6e5a59-b86d-42c2-9bb0-73063c32c6d9


## Related issues

* Discovered during https://github.com/mrousavy/react-native-vision-camera/pull/2037 while patching internal project/plugin to RN72, Xcode 15.
* Which I'll revisit after this.

