### PR TITLE
feat: Pass `ReactApplicationContext` along to Plugin Initializer

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
@@ -90,7 +90,7 @@ public class FaceDetectorFrameProcessorPluginPackage implements ReactPackage {
   // highlight-start
   static {
     FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces", (context, options) -> {
-      return new FaceDetectorFrameProcessorPlugin(options)
+      return new FaceDetectorFrameProcessorPlugin(options);
     });
   }
   // highlight-end

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
@@ -89,7 +89,9 @@ import com.mrousavy.camera.frameprocessor.FrameProcessorPluginRegistry;
 public class FaceDetectorFrameProcessorPluginPackage implements ReactPackage {
   // highlight-start
   static {
-    FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces", options -> new FaceDetectorFrameProcessorPlugin(options));
+    FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces", (context, options) -> {
+      return new FaceDetectorFrameProcessorPlugin(options)
+    });
   }
   // highlight-end
 
@@ -160,7 +162,7 @@ class FaceDetectorFrameProcessorPluginPackage : ReactPackage {
   // highlight-start
   companion object {
     init {
-      FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces") { options ->
+      FrameProcessorPluginRegistry.addFrameProcessorPlugin("detectFaces") { context, options ->
         FaceDetectorFrameProcessorPlugin(options)
       }
     }

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorPluginRegistry.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorPluginRegistry.java
@@ -4,6 +4,7 @@ import android.util.Log;
 import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.bridge.ReactApplicationContext;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -24,7 +25,7 @@ public class FrameProcessorPluginRegistry {
 
     @DoNotStrip
     @Keep
-    public static FrameProcessorPlugin getPlugin(String name, Map<String, Object> options) {
+    public static FrameProcessorPlugin getPlugin(ReactApplicationContext context, String name, Map<String, Object> options) {
         Log.i(TAG, "Looking up Frame Processor Plugin \"" + name + "\"...");
         PluginInitializer initializer = Plugins.get(name);
         if (initializer == null) {
@@ -32,10 +33,10 @@ public class FrameProcessorPluginRegistry {
             return null;
         }
         Log.i(TAG, "Frame Processor Plugin \"" + name + "\" found! Initializing...");
-        return initializer.initializePlugin(options);
+        return initializer.initializePlugin(context, options);
     }
 
     public interface PluginInitializer {
-        FrameProcessorPlugin initializePlugin(@Nullable Map<String, Object> options);
+        FrameProcessorPlugin initializePlugin(ReactApplicationContext context, @Nullable Map<String, Object> options);
     }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraProxy.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraProxy.kt
@@ -14,7 +14,7 @@ import com.mrousavy.camera.core.ViewNotFoundError
 import java.lang.ref.WeakReference
 
 @Suppress("KotlinJniMissingFunction") // we use fbjni.
-class VisionCameraProxy(context: ReactApplicationContext) {
+class VisionCameraProxy(private val context: ReactApplicationContext) {
   companion object {
     const val TAG = "VisionCameraProxy"
     init {
@@ -71,7 +71,7 @@ class VisionCameraProxy(context: ReactApplicationContext) {
   @DoNotStrip
   @Keep
   fun initFrameProcessorPlugin(name: String, options: Map<String, Any>): FrameProcessorPlugin =
-    FrameProcessorPluginRegistry.getPlugin(name, options)
+    FrameProcessorPluginRegistry.getPlugin(context, name, options)
 
   // private C++ funcs
   private external fun initHybrid(jsContext: Long, jsCallInvokerHolder: CallInvokerHolderImpl, scheduler: VisionCameraScheduler): HybridData

--- a/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.java
+++ b/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.java
@@ -20,8 +20,12 @@ import com.mrousavy.camera.frameprocessor.FrameProcessorPluginRegistry;
 public class MainApplication extends Application implements ReactApplication {
   // Register the Frame Processor Plugins for our app
   static {
-    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin", options -> new ExampleFrameProcessorPlugin(options));
-    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_kotlin_swift_plugin", options -> new ExampleKotlinFrameProcessorPlugin(options));
+    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin", (context, options) -> {
+      return new ExampleFrameProcessorPlugin(options)
+    });
+    FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_kotlin_swift_plugin", (context, options) -> {
+      return new ExampleKotlinFrameProcessorPlugin(options)
+    });
   }
 
   private final ReactNativeHost mReactNativeHost =

--- a/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.java
+++ b/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.java
@@ -21,10 +21,10 @@ public class MainApplication extends Application implements ReactApplication {
   // Register the Frame Processor Plugins for our app
   static {
     FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin", (context, options) -> {
-      return new ExampleFrameProcessorPlugin(options)
+      return new ExampleFrameProcessorPlugin(options);
     });
     FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_kotlin_swift_plugin", (context, options) -> {
-      return new ExampleKotlinFrameProcessorPlugin(options)
+      return new ExampleKotlinFrameProcessorPlugin(options);
     });
   }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Passes the `ReactApplicationContext` along to the Frame Processor Plugin Initializer function.

Before:

```java
FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin", options -> {
  return new ExampleFrameProcessorPlugin(options)
});
```

After:

```java
FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin", (context, options) -> {
  return new ExampleFrameProcessorPlugin(options)
});
```

This is considered a breaking change since the new parameter has to be added to all FP Plugins

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
