### PR TITLE
fix: Fix `physicalDevices` DeviceType computation on Android

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/extensions/List+toJSValue.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/List+toJSValue.kt
@@ -1,0 +1,11 @@
+package com.mrousavy.camera.extensions
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableArray
+import com.mrousavy.camera.types.JSUnionValue
+
+fun List<JSUnionValue>.toJSValue(): ReadableArray {
+  val arguments = Arguments.createArray()
+  this.forEach { arguments.pushString(it.unionValue) }
+  return arguments
+}

--- a/package/android/src/main/java/com/mrousavy/camera/types/DeviceType.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/types/DeviceType.kt
@@ -1,0 +1,7 @@
+package com.mrousavy.camera.types
+
+enum class DeviceType(override val unionValue: String) : JSUnionValue {
+  ULTRA_WIDE_ANGLE("ultra-wide-angle-camera"),
+  WIDE_ANGLE("wide-angle-camera"),
+  TELEPHOTO("telephoto-camera")
+}

--- a/package/src/CameraDevice.ts
+++ b/package/src/CameraDevice.ts
@@ -13,9 +13,9 @@ export type CameraPosition = 'front' | 'back' | 'external'
 /**
  * Indentifiers for a physical camera (one that actually exists on the back/front of the device)
  *
- * * `"ultra-wide-angle-camera"`: A built-in camera with a shorter focal length than that of a wide-angle camera. (focal length between below 24mm)
- * * `"wide-angle-camera"`: A built-in wide-angle camera. (focal length between 24mm and 43mm)
- * * `"telephoto-camera"`: A built-in camera device with a longer focal length than a wide-angle camera. (focal length between above 85mm)
+ * * `"ultra-wide-angle-camera"`: A built-in camera with a shorter focal length than that of a wide-angle camera. (FOV of 94° or higher)
+ * * `"wide-angle-camera"`: A built-in wide-angle camera. (FOV between 60° and 94°)
+ * * `"telephoto-camera"`: A built-in camera device with a longer focal length than a wide-angle camera. (FOV of 60° or lower)
  *
  * Some Camera devices consist of multiple physical devices. They can be interpreted as _logical devices_, for example:
  *


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the DeviceType computation on Android where some devices where ultra-wide-angle Cameras when in reality they are wide-angle Cameras.

This uses the FOV calculation now.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
