### PR TITLE
fix: Fix physical devices detection on Android

### DIFF
--- a/package/src/hooks/useCameraDevices.ts
+++ b/package/src/hooks/useCameraDevices.ts
@@ -12,6 +12,8 @@ import { CameraDevices } from '../CameraDevices'
 export function useCameraDevices(): CameraDevice[] {
   const [devices, setDevices] = useState(() => CameraDevices.getAvailableCameraDevices())
 
+  console.log(JSON.stringify(devices.map((d) => ({ ...d, formats: [] }))))
+
   useEffect(() => {
     const listener = CameraDevices.addCameraDevicesChangedListener((newDevices) => {
       setDevices(newDevices)

--- a/package/src/hooks/useCameraDevices.ts
+++ b/package/src/hooks/useCameraDevices.ts
@@ -12,8 +12,6 @@ import { CameraDevices } from '../CameraDevices'
 export function useCameraDevices(): CameraDevice[] {
   const [devices, setDevices] = useState(() => CameraDevices.getAvailableCameraDevices())
 
-  console.log(JSON.stringify(devices.map((d) => ({ ...d, formats: [] }))))
-
   useEffect(() => {
     const listener = CameraDevices.addCameraDevicesChangedListener((newDevices) => {
       setDevices(newDevices)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the `physicalDevice` detection on Android. Previously, Multi-Cams were not detected properly. Now they are.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
