### PR TITLE
Add depth data support validation and explicitly embeds it in the photo

### DIFF
--- a/package/ios/Core/CameraSession+Photo.swift
+++ b/package/ios/Core/CameraSession+Photo.swift
@@ -63,7 +63,8 @@ extension CameraSession {
       let enableShutterSound = options["enableShutterSound"] as? Bool ?? true
 
       // depth data
-      photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
+      photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled && photoOutput.isDepthDataDeliverySupported
+      photoSettings.embedsDepthDataInPhoto = photoSettings.isDepthDataDeliveryEnabled
       if #available(iOS 12.0, *) {
         photoSettings.isPortraitEffectsMatteDeliveryEnabled = photoOutput.isPortraitEffectsMatteDeliveryEnabled
       }


### PR DESCRIPTION
This PR checks if the depth data feature is actually supported from the current camera before trying to enable it, otherwise it will crash the app. It also explicitly embeds the depth data inside the output photo; even though it's the default behaviour I think it's better to add it so that everyone is aware of it.

## Changes

Changes are highlighted in bold:

      * photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled **&& photoOutput.isDepthDataDeliverySupported**
      * **photoSettings.embedsDepthDataInPhoto = photoSettings.isDepthDataDeliveryEnabled**


## Tested on

    * iPhone 15 Pro, iOS 17