### PR TITLE
chore: upgrade react-native-worklets-core to 0.2.4

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -73,7 +73,7 @@ repositories {
 }
 
 android {
-  namespace "com.mrousavy.camera.example"
+  namespace "com.mrousavy.camera"
 
   // Used to override the NDK path/version on internal CI or by allowing
   // users to customize the NDK path/version from their root project (e.g. for M1 support)

--- a/package/example/package.json
+++ b/package/example/package.json
@@ -29,7 +29,7 @@
     "react-native-static-safe-area-insets": "^2.2.0",
     "react-native-vector-icons": "^10.0.0",
     "react-native-video": "^5.2.1",
-    "react-native-worklets-core": "^0.2.1"
+    "react-native-worklets-core": "0.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.22.10",

--- a/package/example/yarn.lock
+++ b/package/example/yarn.lock
@@ -5802,10 +5802,10 @@ react-native-video@^5.2.1:
     prop-types "^15.7.2"
     shaka-player "^2.5.9"
 
-react-native-worklets-core@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-0.2.1.tgz#d30cd779eb31d21f889517524249b13759746bb3"
-  integrity sha512-ezKjljddT4V1Ble3b+mF8XL02OpJfaHApH4XtxxhMoP/G/0Eplp0bAI7qI+SnIIPYVTEL66/kzMAYiXbcC00Ug==
+react-native-worklets-core@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-0.2.4.tgz#a4a79c04f2c6769ff03e96b7529c8638c88fa560"
+  integrity sha512-NKqxLRDOYfO7RJRZHHDA/1yztdiSadSTTILgHw2VwSrcQcmnWAZGXWr9EYpzKblpbk/vXfJa6QpWIKHjNrbe4w==
   dependencies:
     string-hash-64 "^1.0.3"
 


### PR DESCRIPTION
Upgraded the example app with latest version of `react-native-worklets-core` (0.2.4)

Also changed the namespace in the build gradle to not be com.mrousavy.camera.example - this would crash when using dex in release mode on android. Changed to `com.mrousavy.camera`.

