### PR TITLE
fix: set correct namespace in build.gradle

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -73,7 +73,7 @@ repositories {
 }
 
 android {
-  namespace "com.mrousavy.camera.example"
+  namespace "com.mrousavy.camera"
 
   // Used to override the NDK path/version on internal CI or by allowing
   // users to customize the NDK path/version from their root project (e.g. for M1 support)

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -1,4 +1,8 @@
 import java.nio.file.Paths
+import com.android.Version
+
+def agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+def androidManifestPath = agpVersion >= 7 ? 'src/main/AndroidManifest.xml' : 'src/hasNamespace/AndroidManifest.xml'
 
 buildscript {
   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["VisionCamera_kotlinVersion"]
@@ -73,7 +77,9 @@ repositories {
 }
 
 android {
-  namespace "com.mrousavy.camera"
+  if (agpVersion >= 7) {
+    namespace "com.mrousavy.camera"
+  }
 
   // Used to override the NDK path/version on internal CI or by allowing
   // users to customize the NDK path/version from their root project (e.g. for M1 support)
@@ -104,6 +110,12 @@ android {
                 "-DENABLE_FRAME_PROCESSORS=${hasWorklets}"
         abiFilters (*reactNativeArchitectures())
       }
+    }
+  }
+
+  sourceSets {
+    main {
+      manifest.srcFile androidManifestPath
     }
   }
 

--- a/package/android/src/hasNamespace/AndroidManifest.xml
+++ b/package/android/src/hasNamespace/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.mrousavy.camera">
+
+</manifest>

--- a/package/android/src/main/AndroidManifest.xml
+++ b/package/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.mrousavy.camera">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes a build error in Android by setting the correct namespace in the `build.gradle` file.

## Changes

* Set correct namespace in `build.gradle`.

## Tested on

macOS

## Related issues

* Fixes #2100 
