### PR TITLE
fix crash on samsung devices if using frameProcessor with YUV

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -92,8 +92,8 @@ class VideoPipeline(
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         Log.i(TAG, "Using API 29 for GPU ImageReader...")
-        // GPU_SAMPLED because we redirect to OpenGL, CPU_READ because we read pixels before that.
-        val usage = HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE or HardwareBuffer.USAGE_CPU_READ_OFTEN
+        // GPU_SAMPLED because we redirect to OpenGL
+        val usage = HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE
         imageReader = ImageReader.newInstance(width, height, format, MAX_IMAGES, usage)
         imageWriter = ImageWriter.newInstance(glSurface, MAX_IMAGES, format)
       } else {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

 There's a know bug that causes a crash on random samsung devices using `frameProcessor` with `yuv` format
 



## Tested on
-  Galaxy S20 FE, Android 13
-  Galaxy S21 FE, Android 13
-  Galaxy M31, Android 12

## How to Test
- the example app with `pixelformat=yuv` should crash in the `mrousavy:main` branch and work as expected in `rodgomesc:fix/samsung-crash-yuv`

## Related issues
Fixes #2091
