### PR TITLE
fix: Fix Video `codec`, `bitRate` and `flash` being ignored on iOS

### DIFF
--- a/package/ios/Types/RecordVideoOptions.swift
+++ b/package/ios/Types/RecordVideoOptions.swift
@@ -26,5 +26,23 @@ struct RecordVideoOptions {
       }
       fileType = parsed
     }
+    // Flash
+    if let flashOption = dictionary["flash"] as? String {
+      guard let parsed = try? Torch(withString: flashOption) else {
+        throw CameraError.parameter(.invalid(unionName: "flash", receivedValue: flashOption))
+      }
+      flash = parsed
+    }
+    // Codec
+    if let codecOption = dictionary["codec"] as? String {
+      guard let parsed = try? AVVideoCodecType(withString: codecOption) else {
+        throw CameraError.parameter(.invalid(unionName: "codec", receivedValue: codecOption))
+      }
+      codec = parsed
+    }
+    // BitRate
+    if let parsed = dictionary["bitRate"] as? Double {
+      bitRate = parsed
+    }
   }
 }

--- a/package/ios/Types/RecordVideoOptions.swift
+++ b/package/ios/Types/RecordVideoOptions.swift
@@ -28,7 +28,7 @@ struct RecordVideoOptions {
     }
     // Flash
     if let flashOption = dictionary["flash"] as? String {
-      guard let parsed = try? Torch(withString: flashOption) else {
+      guard let parsed = try? Torch(jsValue: flashOption) else {
         throw CameraError.parameter(.invalid(unionName: "flash", receivedValue: flashOption))
       }
       flash = parsed


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
