### PR TITLE
fix: Handle video codec parameter from react in swift (#2109)

### DIFF
--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -211,9 +211,16 @@ extension CameraSession {
 
   private func recommendedVideoSettings(videoOutput: AVCaptureVideoDataOutput,
                                         fileType: AVFileType,
-                                        videoCodec: AVVideoCodecType?) -> [String: Any]? {
-    if videoCodec != nil {
-      return videoOutput.recommendedVideoSettings(forVideoCodecType: videoCodec!, assetWriterOutputFileType: fileType)
+                                        videoCodec: String?) -> [String: Any]? {
+    if let videoCodecName = videoCodec {
+      var codec: AVVideoCodecType
+      switch videoCodecName {
+      case "h264":
+        codec = .h264
+      default:
+        codec = .hevc
+      }
+      return videoOutput.recommendedVideoSettings(forVideoCodecType: codec, assetWriterOutputFileType: fileType)
     } else {
       return videoOutput.recommendedVideoSettingsForAssetWriter(writingTo: fileType)
     }

--- a/package/ios/Types/RecordVideoOptions.swift
+++ b/package/ios/Types/RecordVideoOptions.swift
@@ -12,13 +12,14 @@ import Foundation
 struct RecordVideoOptions {
   var fileType: AVFileType = .mov
   var flash: Torch = .off
-  var codec: AVVideoCodecType?
+  var codec: String?
   /**
    Bit-Rate of the Video, in Megabits per second (Mbps)
    */
   var bitRate: Double?
 
   init(fromJSValue dictionary: NSDictionary) throws {
+    codec = dictionary["videoCodec"] as? String
     // File Type (.mov or .mp4)
     if let fileTypeOption = dictionary["fileType"] as? String {
       guard let parsed = try? AVFileType(withString: fileTypeOption) else {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR handles video codecs in swift. Previously the parameter was ignored

## Changes

Turn options param into String; Use that string in getSettings method to set codec.

## Tested on

iPhone 15 Pro

## Related issues

- Fixes #2109
