### PR TITLE
Feat: Implement corner points for scanned codes

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -11,6 +11,7 @@ import com.google.mlkit.vision.barcode.common.Barcode
 import com.mrousavy.camera.core.CameraConfiguration
 import com.mrousavy.camera.core.CameraQueues
 import com.mrousavy.camera.core.CameraSession
+import com.mrousavy.camera.core.CodeScannerFrame
 import com.mrousavy.camera.core.PreviewView
 import com.mrousavy.camera.extensions.installHierarchyFitter
 import com.mrousavy.camera.frameprocessor.FrameProcessor
@@ -228,7 +229,7 @@ class CameraView(context: Context) :
     invokeOnInitialized()
   }
 
-  override fun onCodeScanned(codes: List<Barcode>) {
-    invokeOnCodeScanned(codes)
+  override fun onCodeScanned(codes: List<Barcode>, scannerFrame: CodeScannerFrame) {
+    invokeOnCodeScanned(codes, scannerFrame)
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -607,6 +607,6 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
   interface CameraSessionCallback {
     fun onError(error: Throwable)
     fun onInitialized()
-    fun onCodeScanned(codes: List<Barcode>)
+    fun onCodeScanned(codes: List<Barcode>, scannerFrame: CodeScannerFrame)
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerFrame.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerFrame.kt
@@ -1,0 +1,6 @@
+package com.mrousavy.camera.core
+
+data class CodeScannerFrame (
+    val width: Int = 0,
+    val height: Int = 0,
+)

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerFrame.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerFrame.kt
@@ -1,6 +1,3 @@
 package com.mrousavy.camera.core
 
-data class CodeScannerFrame (
-    val width: Int,
-    val height: Int,
-)
+data class CodeScannerFrame(val width: Int, val height: Int)

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerFrame.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerFrame.kt
@@ -1,6 +1,6 @@
 package com.mrousavy.camera.core
 
 data class CodeScannerFrame (
-    val width: Int = 0,
-    val height: Int = 0,
+    val width: Int,
+    val height: Int,
 )

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
@@ -56,7 +56,7 @@ class CodeScannerPipeline(
           image.close()
           isBusy = false
           if (barcodes.isNotEmpty()) {
-            callback.onCodeScanned(barcodes)
+            callback.onCodeScanned(barcodes, CodeScannerFrame(inputImage.width, inputImage.height))
           }
         }
         .addOnFailureListener { error ->

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -507,7 +507,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (3.6.3):
+  - VisionCamera (3.6.4):
     - React
     - React-callinvoker
     - React-Core
@@ -747,7 +747,7 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: aebb5adef1296732983129c5fe054337b15c3c0b
+  VisionCamera: db57ca079c4f933f1ddd07f2f8fb2d171a826b85
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
 
 PODFILE CHECKSUM: 27f53791141a3303d814e09b55770336416ff4eb

--- a/package/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
+++ b/package/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 				LastUpgradeCheck = 1250;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = CJW62Q77E7;
+						DevelopmentTeam = XVBSPUKE9E;
 						LastSwiftMigration = 1240;
 					};
 				};
@@ -405,7 +405,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CJW62Q77E7;
+				DEVELOPMENT_TEAM = XVBSPUKE9E;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = VisionCameraExample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Vision Camera";
@@ -437,7 +437,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CJW62Q77E7;
+				DEVELOPMENT_TEAM = XVBSPUKE9E;
 				INFOPLIST_FILE = VisionCameraExample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Vision Camera";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";

--- a/package/example/src/App.tsx
+++ b/package/example/src/App.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { PermissionsPage } from './PermissionsPage'
 import { MediaPage } from './MediaPage'
 import { CameraPage } from './CameraPage'
+import { CodeScannerPage } from './CodeScannerPage'
 import type { Routes } from './Routes'
 import { Camera, CameraPermissionStatus } from 'react-native-vision-camera'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
@@ -41,6 +42,7 @@ export function App(): React.ReactElement | null {
           initialRouteName={showPermissionsPage ? 'PermissionsPage' : 'CameraPage'}>
           <Stack.Screen name="PermissionsPage" component={PermissionsPage} />
           <Stack.Screen name="CameraPage" component={CameraPage} />
+          <Stack.Screen name="CodeScannerPage" component={CodeScannerPage} />
           <Stack.Screen
             name="MediaPage"
             component={MediaPage}

--- a/package/example/src/Routes.ts
+++ b/package/example/src/Routes.ts
@@ -1,6 +1,7 @@
 export type Routes = {
   PermissionsPage: undefined
   CameraPage: undefined
+  CodeScannerPage: undefined
   MediaPage: {
     path: string
     type: 'video' | 'photo'

--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -297,7 +297,7 @@ public final class CameraView: UIView, CameraSessionDelegate {
     }
     onCodeScanned([
       "codes": codes.map { $0.toJSValue() },
-      "frame": scannerFrame.toJSValue()
+      "frame": scannerFrame.toJSValue(),
     ])
   }
 

--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -291,12 +291,13 @@ public final class CameraView: UIView, CameraSessionDelegate {
     #endif
   }
 
-  func onCodeScanned(codes: [CameraSession.Code]) {
+  func onCodeScanned(codes: [CameraSession.Code], scannerFrame: CameraSession.CodeScannerFrame) {
     guard let onCodeScanned = onCodeScanned else {
       return
     }
     onCodeScanned([
       "codes": codes.map { $0.toJSValue() },
+      "frame": scannerFrame.toJSValue()
     ])
   }
 

--- a/package/ios/Core/CameraSession+CodeScanner.swift
+++ b/package/ios/Core/CameraSession+CodeScanner.swift
@@ -28,7 +28,7 @@ extension CameraSession: AVCaptureMetadataOutputObjectsDelegate {
     // Map codes to JS values
     let codes = metadataObjects.map { object in
       var value: String?
-      var corners:[CGPoint]?
+      var corners: [CGPoint]?
       if let code = object as? AVMetadataMachineReadableCodeObject {
         value = code.stringValue
         corners = code.corners
@@ -62,23 +62,16 @@ extension CameraSession: AVCaptureMetadataOutputObjectsDelegate {
      Location of the code on-screen, relative to the video output layer
      */
     let frame: CGRect
-      
+
     /**
-     Location of the code on-screen, relative to the video output layer
-    */
+      Location of the code on-screen, relative to the video output layer
+     */
     let corners: [CGPoint]?
 
     /**
      Converts this Code to a JS Object (Dictionary)
      */
     func toJSValue() -> [String: AnyHashable] {
-      var jsCorners: [[String: CGFloat]] = []
-      if let corners {
-          jsCorners = corners.map{ [
-            "x": $0.x,
-            "y": $0.y
-          ]}
-      }
       return [
         "type": type.descriptor,
         "value": value,
@@ -88,17 +81,19 @@ extension CameraSession: AVCaptureMetadataOutputObjectsDelegate {
           "width": frame.size.width,
           "height": frame.size.height,
         ],
-        "corners": jsCorners
+        "corners": corners?.map { [
+          "x": $0.x,
+          "y": $0.y,
+        ] } ?? [],
       ]
     }
   }
-    
+
   struct CodeScannerFrame {
-      
     let width: Int32
     let height: Int32
-      
-    func toJSValue()-> [String: AnyHashable] {
+
+    func toJSValue() -> [String: AnyHashable] {
       return [
         "width": width,
         "height": height,

--- a/package/ios/Core/CameraSession+CodeScanner.swift
+++ b/package/ios/Core/CameraSession+CodeScanner.swift
@@ -95,9 +95,6 @@ extension CameraSession: AVCaptureMetadataOutputObjectsDelegate {
     
   struct CodeScannerFrame {
       
-    /**
-    Width of the scanned frame
-    */
     let width: Int32
     let height: Int32
       

--- a/package/ios/Core/CameraSession+CodeScanner.swift
+++ b/package/ios/Core/CameraSession+CodeScanner.swift
@@ -99,9 +99,6 @@ extension CameraSession: AVCaptureMetadataOutputObjectsDelegate {
     Width of the scanned frame
     */
     let width: Int32
-    /**
-    Height of the scanned frame
-    */
     let height: Int32
       
     func toJSValue()-> [String: AnyHashable] {

--- a/package/ios/Core/CameraSession+CodeScanner.swift
+++ b/package/ios/Core/CameraSession+CodeScanner.swift
@@ -31,7 +31,9 @@ extension CameraSession: AVCaptureMetadataOutputObjectsDelegate {
       var corners: [CGPoint]?
       if let code = object as? AVMetadataMachineReadableCodeObject {
         value = code.stringValue
-        corners = code.corners
+        corners = code.corners.map {
+          CGPoint(x: $0.x * Double(size.width), y: $0.y * Double(size.height))
+        }
       }
       let x = object.bounds.origin.x * Double(size.width)
       let y = object.bounds.origin.y * Double(size.height)

--- a/package/ios/Core/CameraSessionDelegate.swift
+++ b/package/ios/Core/CameraSessionDelegate.swift
@@ -28,5 +28,5 @@ protocol CameraSessionDelegate: AnyObject {
   /**
    Called whenever a QR/Barcode has been scanned. Only if the CodeScanner Output is enabled
    */
-  func onCodeScanned(codes: [CameraSession.Code])
+  func onCodeScanned(codes: [CameraSession.Code], scannerFrame: CameraSession.CodeScannerFrame)
 }

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -11,7 +11,7 @@ import type { RecordVideoOptions, VideoFile } from './VideoFile'
 import { VisionCameraProxy } from './FrameProcessorPlugins'
 import { CameraDevices } from './CameraDevices'
 import type { EmitterSubscription } from 'react-native'
-import { Code, CodeScanner } from './CodeScanner'
+import {Code, CodeScanner, CodeScannerFrame} from './CodeScanner'
 
 //#region Types
 export type CameraPermissionStatus = 'granted' | 'not-determined' | 'denied' | 'restricted'
@@ -19,6 +19,7 @@ export type CameraPermissionRequestResult = 'granted' | 'denied'
 
 interface OnCodeScannedEvent {
   codes: Code[]
+  frame: CodeScannerFrame
 }
 interface OnErrorEvent {
   code: string
@@ -398,7 +399,7 @@ export class Camera extends React.PureComponent<CameraProps> {
     const codeScanner = this.props.codeScanner
     if (codeScanner == null) return
 
-    codeScanner.onCodeScanned(event.nativeEvent.codes)
+    codeScanner.onCodeScanned(event.nativeEvent.codes, event.nativeEvent.frame)
   }
 
   //#region Lifecycle

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -11,7 +11,7 @@ import type { RecordVideoOptions, VideoFile } from './VideoFile'
 import { VisionCameraProxy } from './FrameProcessorPlugins'
 import { CameraDevices } from './CameraDevices'
 import type { EmitterSubscription } from 'react-native'
-import {Code, CodeScanner, CodeScannerFrame} from './CodeScanner'
+import { Code, CodeScanner, CodeScannerFrame } from './CodeScanner'
 
 //#region Types
 export type CameraPermissionStatus = 'granted' | 'not-determined' | 'denied' | 'restricted'

--- a/package/src/CodeScanner.ts
+++ b/package/src/CodeScanner.ts
@@ -18,7 +18,7 @@ export type CodeType =
   | 'data-matrix'
 
 /**
- * A scanned frame.
+ * The full area that is used for code scanning. In most cases, this is 1280x720 or 1920x1080.
  */
 export interface CodeScannerFrame {
   /**

--- a/package/src/CodeScanner.ts
+++ b/package/src/CodeScanner.ts
@@ -22,7 +22,7 @@ export type CodeType =
  */
 export interface CodeScannerFrame {
   /**
-   * The width of the scanned frame
+   * The width of the frame
    */
   width: number
   /**

--- a/package/src/CodeScanner.ts
+++ b/package/src/CodeScanner.ts
@@ -26,7 +26,7 @@ export interface CodeScannerFrame {
    */
   width: number
   /**
-   * The height of the scanned frame
+   * The height of the frame
    */
   height: number
 }

--- a/package/src/CodeScanner.ts
+++ b/package/src/CodeScanner.ts
@@ -16,6 +16,20 @@ export type CodeType =
   | 'data-matrix'
 
 /**
+ * A scanned frame.
+ */
+export interface CodeScannerFrame {
+  /**
+   * The width of the scanned frame
+   */
+  width: number
+  /**
+   * The height of the scanned frame
+   */
+  height: number
+}
+
+/**
  * A scanned code.
  */
 export interface Code {
@@ -36,6 +50,13 @@ export interface Code {
     width: number
     height: number
   }
+  /**
+   * The location of each corner relative to the Camera Preview (in dp).
+   */
+  corners?: {
+    x: number
+    y: number
+  }[]
 }
 
 /**
@@ -49,7 +70,7 @@ export interface CodeScanner {
   /**
    * A callback to call whenever the scanned codes change.
    */
-  onCodeScanned: (codes: Code[]) => void
+  onCodeScanned: (codes: Code[], frame: CodeScannerFrame) => void
   /**
    * Crops the scanner's view area to the specific region of interest.
    */

--- a/package/src/CodeScanner.ts
+++ b/package/src/CodeScanner.ts
@@ -1,3 +1,5 @@
+import {Point} from './Point';
+
 /**
  * The type of the code to scan.
  */
@@ -53,10 +55,7 @@ export interface Code {
   /**
    * The location of each corner relative to the Camera Preview (in dp).
    */
-  corners?: {
-    x: number
-    y: number
-  }[]
+  corners?: Point[]
 }
 
 /**

--- a/package/src/CodeScanner.ts
+++ b/package/src/CodeScanner.ts
@@ -68,6 +68,8 @@ export interface CodeScanner {
   codeTypes: CodeType[]
   /**
    * A callback to call whenever the scanned codes change.
+   * @param codes The scanned codes, or an empty array if none.
+   * @param frame The full area that is used for scanning. Code bounds and corners are relative to this frame.
    */
   onCodeScanned: (codes: Code[], frame: CodeScannerFrame) => void
   /**

--- a/package/src/CodeScanner.ts
+++ b/package/src/CodeScanner.ts
@@ -1,4 +1,4 @@
-import {Point} from './Point';
+import { Point } from './Point'
 
 /**
  * The type of the code to scan.

--- a/package/src/hooks/useCodeScanner.ts
+++ b/package/src/hooks/useCodeScanner.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef } from 'react'
-import { Code, CodeScanner } from '../CodeScanner'
+import {Code, CodeScanner, CodeScannerFrame} from '../CodeScanner'
 
 export function useCodeScanner(codeScanner: CodeScanner): CodeScanner {
   const { onCodeScanned, ...codeScannerOptions } = codeScanner
@@ -7,8 +7,8 @@ export function useCodeScanner(codeScanner: CodeScanner): CodeScanner {
   // Memoize the  function once and use a ref on any identity changes
   const ref = useRef(onCodeScanned)
   ref.current = onCodeScanned
-  const callback = useCallback((codes: Code[]) => {
-    ref.current(codes)
+  const callback = useCallback((codes: Code[], frame: CodeScannerFrame) => {
+    ref.current(codes, frame)
   }, [])
 
   // CodeScanner needs to be memoized so it doesn't trigger a Camera Session re-build

--- a/package/src/hooks/useCodeScanner.ts
+++ b/package/src/hooks/useCodeScanner.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef } from 'react'
-import {Code, CodeScanner, CodeScannerFrame} from '../CodeScanner'
+import { Code, CodeScanner, CodeScannerFrame } from '../CodeScanner'
 
 export function useCodeScanner(codeScanner: CodeScanner): CodeScanner {
   const { onCodeScanned, ...codeScannerOptions } = codeScanner


### PR DESCRIPTION
## What

  This PR adds corner points to code scanner results, with an additional second parameter of the scanned frame in the codescanner callback which defines a widht, height proparty for scaling.


## Changes
   * This PR makes sure you can access scanned codes corner points in the corners array of the Code object. Every point has an x,y coordinate which uses the same coordinate system as the frame does.
   * This PR also adds a second param of the code scanner callback which contains width, height values for the scanned image frame.

## Tested on
   * iPhone XR, iOS 16.6
   * Samsung Galaxy S21 FE, Android 13

## Related issues

  * Fixes #2076