### PR TITLE
fix: Fix Frame Processors not building because of `hasWorklets` flag

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -107,7 +107,7 @@ android {
         cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
         arguments "-DANDROID_STL=c++_shared",
                 "-DNODE_MODULES_DIR=${nodeModules}",
-                "-DENABLE_FRAME_PROCESSORS=${hasWorklets}"
+                "-DENABLE_FRAME_PROCESSORS=${hasWorklets ? "ON" : "OFF"}"
         abiFilters (*reactNativeArchitectures())
       }
     }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Apparently passing a boolean (`true` or `false`) from Groovy (`build.gradle`) to Cmake (`CMakeLists.txt`) turns it into a string (`"true"` or `"false"`).

Instead, we now pass the value `ON` and `OFF` to CMake, which is their understanding of a boolean. God knows why.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1770

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
