### PR TITLE
fix: Fix setting FPS lower than 30 on Samsung devices

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -61,7 +61,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
     private const val TAG = "CameraSession"
 
     // TODO: Samsung advertises 60 FPS but only allows 30 FPS for some reason.
-    private val CAN_SET_FPS = !Build.MANUFACTURER.equals("samsung", true)
+    private val CAN_DO_60_FPS = !Build.MANUFACTURER.equals("samsung", true)
   }
 
   // Camera Configuration
@@ -394,8 +394,12 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
     // Set FPS
     // TODO: Check if the FPS range is actually supported in the current configuration.
-    val fps = config.fps
-    if (fps != null && CAN_SET_FPS) {
+    var fps = config.fps
+    if (fps != null) {
+      if (!CAN_DO_60_FPS) {
+        // If we can't do 60 FPS, we clamp it to 30 FPS - that's always supported.
+        fps = Math.min(30, fps)
+      }
       captureRequest.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Range(fps, fps))
     }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
