### PR TITLE
feat: Enable HDR extension for photo capture if available

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -466,6 +466,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
     val cameraCharacteristics = cameraManager.getCameraCharacteristics(captureSession.device.id)
     val orientation = outputOrientation.toSensorRelativeOrientation(cameraCharacteristics)
+    val enableHdr = configuration?.photoHdr ?: false
     val captureRequest = captureSession.device.createPhotoCaptureRequest(
       cameraManager,
       photoOutput.surface,
@@ -474,6 +475,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
       flashMode,
       enableRedEyeReduction,
       enableAutoStabilization,
+      enableHdr,
       orientation
     )
     Log.i(TAG, "Photo capture 1/3 - starting capture...")

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraDevice+createPhotoCaptureRequest.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraDevice+createPhotoCaptureRequest.kt
@@ -30,6 +30,7 @@ fun CameraDevice.createPhotoCaptureRequest(
   flashMode: Flash,
   enableRedEyeReduction: Boolean,
   enableAutoStabilization: Boolean,
+  enableHdr: Boolean,
   orientation: Orientation
 ): CaptureRequest {
   val cameraCharacteristics = cameraManager.getCameraCharacteristics(this.id)
@@ -40,6 +41,7 @@ fun CameraDevice.createPhotoCaptureRequest(
     CameraDevice.TEMPLATE_STILL_CAPTURE
   }
   val captureRequest = this.createCaptureRequest(template)
+  captureRequest.addTarget(surface)
 
   // TODO: Maybe we can even expose that prop directly?
   val jpegQuality = when (qualityPrioritization) {
@@ -50,6 +52,8 @@ fun CameraDevice.createPhotoCaptureRequest(
   captureRequest.set(CaptureRequest.JPEG_QUALITY, jpegQuality.toByte())
 
   captureRequest.set(CaptureRequest.JPEG_ORIENTATION, orientation.toDegrees())
+
+  // TODO: Use the same options as from the preview request. This is duplicate code!
 
   when (flashMode) {
     // Set the Flash Mode
@@ -87,9 +91,14 @@ fun CameraDevice.createPhotoCaptureRequest(
     }
   }
 
+  // TODO: Check if that zoom value is even supported.
   captureRequest.setZoom(zoom, cameraCharacteristics)
 
-  captureRequest.addTarget(surface)
+  // Set HDR
+  // TODO: Check if that value is even supported
+  if (enableHdr) {
+    captureRequest.set(CaptureRequest.CONTROL_SCENE_MODE, CaptureRequest.CONTROL_SCENE_MODE_HDR)
+  }
 
   return captureRequest.build()
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Enables the HDR Camera2 HAL Extension for photo capture if `photoHdr` is enabled.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
