### PR TITLE
fix: Fix `VideoPipeline` crash because ProGuard removed `mHybridData`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -8,7 +8,9 @@ import android.media.ImageWriter
 import android.os.Build
 import android.util.Log
 import android.view.Surface
+import androidx.annotation.Keep
 import com.facebook.jni.HybridData
+import com.facebook.proguard.annotations.DoNotStrip
 import com.mrousavy.camera.frameprocessor.Frame
 import com.mrousavy.camera.frameprocessor.FrameProcessor
 import com.mrousavy.camera.types.Orientation
@@ -51,6 +53,8 @@ class VideoPipeline(
     }
   }
 
+  @DoNotStrip
+  @Keep
   private val mHybridData: HybridData
   private var openGLTextureId: Int? = null
   private var transformMatrix = FloatArray(16)

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraScheduler.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraScheduler.java
@@ -1,5 +1,6 @@
 package com.mrousavy.camera.frameprocessor;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.mrousavy.camera.core.CameraQueues;
@@ -8,6 +9,7 @@ import com.mrousavy.camera.core.CameraQueues;
 public class VisionCameraScheduler {
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     @DoNotStrip
+    @Keep
     private final HybridData mHybridData;
 
     public VisionCameraScheduler() {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes a crash in release mode that was caused by ProGuard stripping the `mHybridData` field in `VideoPipeline.kt`. 

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes #2168
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1769
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2166

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
