### PR TITLE
fix: Close `CameraSession` if the View is removed

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.hardware.camera2.CameraManager
 import android.util.Log
 import android.view.ScaleGestureDetector
+import android.view.View
 import android.widget.FrameLayout
 import com.facebook.react.bridge.ReadableMap
 import com.google.mlkit.vision.barcode.common.Barcode
@@ -129,6 +130,11 @@ class CameraView(context: Context) :
   override fun onDetachedFromWindow() {
     update()
     super.onDetachedFromWindow()
+  }
+
+  override fun onViewRemoved(child: View?) {
+    cameraSession.close()
+    super.onViewRemoved(child)
   }
 
   fun update() {

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.hardware.camera2.CameraManager
 import android.util.Log
 import android.view.ScaleGestureDetector
-import android.view.View
 import android.widget.FrameLayout
 import com.facebook.react.bridge.ReadableMap
 import com.google.mlkit.vision.barcode.common.Barcode
@@ -132,9 +131,8 @@ class CameraView(context: Context) :
     super.onDetachedFromWindow()
   }
 
-  override fun onViewRemoved(child: View?) {
+  fun destroy() {
     cameraSession.close()
-    super.onViewRemoved(child)
   }
 
   fun update() {

--- a/package/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -31,6 +31,11 @@ class CameraViewManager : ViewGroupManager<CameraView>() {
 
   override fun getName(): String = TAG
 
+  override fun onDropViewInstance(view: CameraView) {
+    view.destroy()
+    super.onDropViewInstance(view)
+  }
+
   @ReactProp(name = "cameraId")
   fun setCameraId(view: CameraView, cameraId: String) {
     view.cameraId = cameraId

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -172,6 +172,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
     codeScannerOutput?.close()
     codeScannerOutput = null
 
+    configuration = null
     isRunning = false
   }
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -363,15 +363,15 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
   }
 
   private fun configureCaptureRequest(config: CameraConfiguration) {
-    val device = cameraDevice ?: throw NoCameraDeviceError()
-    val captureSession = captureSession ?: throw CameraNotReadyError()
-
     if (!config.isActive) {
       // TODO: Do we want to do stopRepeating() or entirely destroy the session?
       // If the Camera is not active, we don't do anything.
-      captureSession.stopRepeating()
+      captureSession?.stopRepeating()
       return
     }
+
+    val device = cameraDevice ?: throw NoCameraDeviceError()
+    val captureSession = captureSession ?: throw CameraNotReadyError()
 
     val previewOutput = previewOutput
     if (previewOutput == null) {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Closes the `CameraSession` and performs necessary cleanup (`CaptureSession`, `CameraDevice`, OpenGL context, Video & Photo outputs, `RecordingSession`, `FrameProcessor` and Photo Synchronizer) to free the Camera Hardware once the View is removed from the React hierarchy ("unmounted").

I previously simply forgot to do that. lol.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes #2149 
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2152
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/516
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1102
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1032
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1018
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/905
* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/232

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
