### PR TITLE
fix: Expose `minExposure`/`maxExposure` in `format`

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -187,14 +187,14 @@ extension CameraSession {
 
     ReactLogger.log(level: .info, message: "Configuring Format (\(targetFormat))...")
 
-    let currentFormat = CameraDeviceFormat(fromFormat: device.activeFormat)
+    let currentFormat = CameraDeviceFormat(fromFormat: device.activeFormat, forDevice: device)
     if currentFormat == targetFormat {
       ReactLogger.log(level: .info, message: "Already selected active format, no need to configure.")
       return
     }
 
     // Find matching format (JS Dictionary -> strongly typed Swift class)
-    let format = device.formats.first { targetFormat.isEqualTo(format: $0) }
+    let format = device.formats.first { targetFormat.isEqualTo(format: $0, device: device) }
     guard let format else {
       throw CameraError.format(.invalidFormat)
     }

--- a/package/ios/Extensions/AVCaptureDevice+toDictionary.swift
+++ b/package/ios/Extensions/AVCaptureDevice+toDictionary.swift
@@ -10,7 +10,7 @@ import AVFoundation
 
 extension AVCaptureDevice {
   func toDictionary() -> [String: Any] {
-    let formats = formats.map { CameraDeviceFormat(fromFormat: $0) }
+    let formats = formats.map { CameraDeviceFormat(fromFormat: $0, forDevice: self) }
 
     return [
       "id": uniqueID,

--- a/package/ios/Types/CameraDeviceFormat.swift
+++ b/package/ios/Types/CameraDeviceFormat.swift
@@ -21,6 +21,9 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
 
   let minFps: Double
   let maxFps: Double
+  
+  let minExposure: Float
+  let maxExposure: Float
 
   let minISO: Float
   let maxISO: Float
@@ -38,13 +41,15 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
 
   let supportsDepthCapture: Bool
 
-  init(fromFormat format: AVCaptureDevice.Format) {
+  init(fromFormat format: AVCaptureDevice.Format, forDevice device: AVCaptureDevice) {
     videoWidth = Int(format.videoDimensions.width)
     videoHeight = Int(format.videoDimensions.height)
     photoWidth = Int(format.photoDimensions.width)
     photoHeight = Int(format.photoDimensions.height)
     minFps = format.minFps
     maxFps = format.maxFps
+    minExposure = device.minExposureTargetBias
+    maxExposure = device.maxExposureTargetBias
     minISO = format.minISO
     maxISO = format.maxISO
     fieldOfView = format.videoFieldOfView
@@ -67,6 +72,8 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
     maxFps = jsValue["maxFps"] as! Double
     minISO = jsValue["minISO"] as! Float
     maxISO = jsValue["maxISO"] as! Float
+    minExposure = jsValue["minExposure"] as! Float
+    maxExposure = jsValue["maxExposure"] as! Float
     fieldOfView = jsValue["fieldOfView"] as! Float
     maxZoom = jsValue["maxZoom"] as! Double
     let jsVideoStabilizationModes = jsValue["videoStabilizationModes"] as! [String]
@@ -81,8 +88,8 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
     // swiftlint:enable force_cast
   }
 
-  func isEqualTo(format other: AVCaptureDevice.Format) -> Bool {
-    let other = CameraDeviceFormat(fromFormat: other)
+  func isEqualTo(format other: AVCaptureDevice.Format, device otherDevice: AVCaptureDevice) -> Bool {
+    let other = CameraDeviceFormat(fromFormat: other, forDevice: otherDevice)
     return self == other
   }
 
@@ -94,8 +101,10 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
       "photoWidth": photoWidth,
       "videoHeight": videoHeight,
       "videoWidth": videoWidth,
-      "maxISO": maxISO,
       "minISO": minISO,
+      "maxISO": maxISO,
+      "minExposure": minExposure,
+      "maxExposure": maxExposure,
       "fieldOfView": fieldOfView,
       "maxZoom": maxZoom,
       "supportsVideoHdr": supportsVideoHdr,

--- a/package/ios/Types/CameraDeviceFormat.swift
+++ b/package/ios/Types/CameraDeviceFormat.swift
@@ -21,7 +21,7 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
 
   let minFps: Double
   let maxFps: Double
-  
+
   let minExposure: Float
   let maxExposure: Float
 


### PR DESCRIPTION
I forgot to do that on iOS before

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
