### PR TITLE
fix: Fix iOS not reading `videoCodec` and `videoBitRate` from options

### DIFF
--- a/package/ios/Parsers/AVVideoCodecType+descriptor.swift
+++ b/package/ios/Parsers/AVVideoCodecType+descriptor.swift
@@ -19,7 +19,7 @@ extension AVVideoCodecType {
       self = .hevc
       return
     default:
-      throw CameraError.parameter(.invalid(unionName: "codec", receivedValue: string))
+      throw CameraError.parameter(.invalid(unionName: "videoCodec", receivedValue: string))
     }
   }
 }

--- a/package/ios/Types/RecordVideoOptions.swift
+++ b/package/ios/Types/RecordVideoOptions.swift
@@ -28,11 +28,11 @@ struct RecordVideoOptions {
       flash = try Torch(jsValue: flashOption)
     }
     // Codec
-    if let codecOption = dictionary["codec"] as? String {
+    if let codecOption = dictionary["videoCodec"] as? String {
       codec = try AVVideoCodecType(withString: codecOption)
     }
     // BitRate
-    if let parsed = dictionary["bitRate"] as? Double {
+    if let parsed = dictionary["videoBitRate"] as? Double {
       bitRate = parsed
     }
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

On iOS, the `videoBitRate` and `videoCodec` options were ignored because I used the wrong prop name for them. This PR fixes this, now they are used.

Hopefully TurboModules/CodeGen will make mistakes like these go away.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
