### PR TITLE
fix: Fully synchronize buffers in `RecordingSession` to account for late-running frames

### DIFF
--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -128,7 +128,8 @@ extension CameraSession {
         recordingSession.initializeVideoWriter(withSettings: videoSettings)
 
         // start recording session with or without audio.
-        try recordingSession.startAssetWriter()
+        // Use Video [AVCaptureSession] clock as a timebase - all other sessions (here; audio) have to be synced to that Clock.
+        try recordingSession.start(clock: self.captureSession.clock)
         self.recordingSession = recordingSession
         self.isRecording = true
 
@@ -156,7 +157,8 @@ extension CameraSession {
         guard let recordingSession = self.recordingSession else {
           throw CameraError.capture(.noRecordingInProgress)
         }
-        recordingSession.finish()
+        // Use Video [AVCaptureSession] clock as a timebase - all other sessions (here; audio) have to be synced to that Clock.
+        recordingSession.stop(clock: self.captureSession.clock)
         return nil
       }
     }

--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -151,14 +151,13 @@ extension CameraSession {
    */
   func stopRecording(promise: Promise) {
     CameraQueues.cameraQueue.async {
-      self.isRecording = false
-
       withPromise(promise) {
         guard let recordingSession = self.recordingSession else {
           throw CameraError.capture(.noRecordingInProgress)
         }
         // Use Video [AVCaptureSession] clock as a timebase - all other sessions (here; audio) have to be synced to that Clock.
         recordingSession.stop(clock: self.captureSession.clock)
+        // There might be late frames, so maybe we need to still provide more Frames to the RecordingSession. Let's keep isRecording true for now.
         return nil
       }
     }

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -273,11 +273,11 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
       switch captureOutput {
       case is AVCaptureVideoDataOutput:
         // Write the Video Buffer to the .mov/.mp4 file, this is the first timestamp if nothing has been recorded yet
-        recordingSession.appendBuffer(sampleBuffer, type: .video)
+        recordingSession.appendBuffer(sampleBuffer, clock: captureSession.clock, type: .video)
       case is AVCaptureAudioDataOutput:
         // Synchronize the Audio Buffer with the Video Session's time because it's two separate AVCaptureSessions
         audioCaptureSession.synchronizeBuffer(sampleBuffer, toSession: captureSession)
-        recordingSession.appendBuffer(sampleBuffer, type: .audio)
+        recordingSession.appendBuffer(sampleBuffer, clock: audioCaptureSession.clock, type: .audio)
       default:
         break
       }

--- a/package/ios/Core/RecordingSession.swift
+++ b/package/ios/Core/RecordingSession.swift
@@ -254,7 +254,7 @@ class RecordingSession {
     
     // 5. If we finished writing both the last video and audio buffers, finish the recording
     if hasWrittenLastAudioFrame && hasWrittenLastVideoFrame {
-      ReactLogger.log(level: .info, message: "Successfully appended last \(bufferType) Buffer (at \(timestamp)), finishing RecordingSession...")
+      ReactLogger.log(level: .info, message: "Successfully appended last \(bufferType) Buffer (at \(timestamp.seconds) seconds), finishing RecordingSession...")
       finish()
     }
   }

--- a/package/ios/Core/RecordingSession.swift
+++ b/package/ios/Core/RecordingSession.swift
@@ -241,7 +241,6 @@ class RecordingSession {
       ReactLogger.log(level: .warning, message: "\(bufferType) AssetWriter is not ready for more data, dropping this Frame...")
       return
     }
-    ReactLogger.log(level: .info, message: "Writing \(bufferType) Sample at \(timestamp.seconds)...")
     writer.append(buffer)
     lastWrittenTimestamp = timestamp
 

--- a/package/ios/Core/RecordingSession.swift
+++ b/package/ios/Core/RecordingSession.swift
@@ -289,13 +289,6 @@ class RecordingSession {
       ReactLogger.log(level: .warning, message: "Tried calling finish() twice while AssetWriter is still writing!")
       return
     }
-    guard lastWrittenTimestamp != nil else {
-      let error = NSError(domain: "capture/aborted",
-                          code: 1,
-                          userInfo: [NSLocalizedDescriptionKey: "Stopped Recording Session too early, no frames have been recorded!"])
-      completionHandler(self, .failed, error)
-      return
-    }
     guard assetWriter.status == .writing else {
       completionHandler(self, assetWriter.status, assetWriter.error)
       return

--- a/package/ios/Core/RecordingSession.swift
+++ b/package/ios/Core/RecordingSession.swift
@@ -176,7 +176,7 @@ class RecordingSession {
     // Start a timeout that will force-stop the session if none of the late frames actually arrive
     CameraQueues.cameraQueue.asyncAfter(deadline: .now() + automaticallyStopTimeoutSeconds) {
       if !self.isFinishing {
-        ReactLogger.log(level: .info, message: "Waited \(self.automaticallyStopTimeoutSeconds) seconds but no late Frames came in, aborting capture...")
+        ReactLogger.log(level: .error, message: "Waited \(self.automaticallyStopTimeoutSeconds) seconds but no late Frames came in, aborting capture...")
         self.finish()
       }
     }
@@ -250,10 +250,6 @@ class RecordingSession {
     case .audio:
       guard let audioWriter = audioWriter, audioWriter.isReadyForMoreMediaData else {
         ReactLogger.log(level: .error, message: "Audio Frame arrived but AudioWriter was not ready!")
-        return
-      }
-      guard lastWrittenVideoTimestamp != nil else {
-        // First video frame has not been written yet, so skip this audio frame.
         return
       }
       

--- a/package/ios/Extensions/AVCaptureSession+synchronizeBuffer.swift
+++ b/package/ios/Extensions/AVCaptureSession+synchronizeBuffer.swift
@@ -27,7 +27,6 @@ extension AVCaptureSession {
   func synchronizeBuffer(_ buffer: CMSampleBuffer, toSession to: AVCaptureSession) {
     let timestamp = CMSampleBufferGetPresentationTimeStamp(buffer)
     let synchronizedTimestamp = CMSyncConvertTime(timestamp, from: clock, to: to.clock)
-    ReactLogger.log(level: .info, message: "Synchronized Timestamp \(timestamp.seconds) -> \(synchronizedTimestamp.seconds)")
     CMSampleBufferSetOutputPresentationTimeStamp(buffer, newValue: synchronizedTimestamp)
   }
 }

--- a/package/ios/Extensions/AVCaptureSession+synchronizeBuffer.swift
+++ b/package/ios/Extensions/AVCaptureSession+synchronizeBuffer.swift
@@ -10,7 +10,10 @@ import AVFoundation
 import Foundation
 
 extension AVCaptureSession {
-  private var clock: CMClock {
+  /**
+   Returns the clock that is used by this AVCaptureSession.
+   */
+  var clock: CMClock {
     if #available(iOS 15.4, *), let synchronizationClock {
       return synchronizationClock
     }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

When using `videoStabilizationMode="cinematic-extended"`, I noticed a weird bug.

As you can see, in this screen recording I start recording a video once the timer hits 5:00 seconds, and I stop recording once it hits 10:00 seconds.

https://github.com/mrousavy/react-native-vision-camera/assets/15199031/f7d71ade-dbd5-4fba-bc88-604bc36cb9a8

Weirdly enough, this was the resulting video:

https://github.com/mrousavy/react-native-vision-camera/assets/15199031/923b0c97-c4f3-47b6-b9da-076816a1a44d

...it contains frames from **before** I even pressed the recording button (first frame is at 3:86, but I started recording at 5:00!), and there is no audio in the beginning. Audio starts later, at 5:00 which is the correct beginning.

The video stops when the clock hits ~8:86 and starts to freeze. Audio continues to play until the point where the timer would've hit 10:00, again this is the correct ending.

So it looks like the video track is offset to the audio track by almost a full second:

![Screenshot 2023-11-23 at 18 09 19](https://github.com/mrousavy/react-native-vision-camera/assets/15199031/50e5348b-b72c-49ba-86de-8af6ad23505f)


I was pulling my hairs out on this bug and it was so weird to me that this couldn't be reproduced in the VisionCamera example app - at first I thought it was an LLDB apple bug where LLDB just hangs for whatever reason, then I thought it was the Audio Session that was not properly synced to the main Video Session, etc etc.

I spent days and days on this until I finally figured it out. This was always a bug, but with video stabilization it was just more noticeable.

The Video Stabilization mode "cinematic-extended" actually caused a huge delay in the Video Pipeline because it keeps an internal buffer of frames to stabilize them. This just takes time. Apparently this takes up to 1 second on my modern iPhone 15 Pro.
The way the `RecordingSession` was designed is that I just wrote the Video and Audio buffers to the session once I received them, and I used their presentation timestamps as the timestamp for the video.

What I didn't account for here was that the presentation timestamp is not the same value as the current time, the frame might be older and we just got it after it has went through a bunch of processing (stabilization)!

E.g. relative to the timer we see on screen - when I start recording, the time is 5:00, but the first frame that actually arrives at 5:00 still has a presentation timestamp of 3:86, because that's when it was captured from the Camera.

The mistake we previously made here was that we wrote this Frame to the file - which we shouldn't do, it's from the past! 

This PR fixes that behaviour and only writes Frames to the file that have a presentation timestamp later than when we actually started recording, so the first frame that should've been written to the file was the one with the presentation timestamp 5:00, which might come in when the current time is already 6:86, so it's 1:86 seconds too late.

#### What about the audio?

The reason the audio and video tracks were so out of sync was because the audio actually had the true current timestamp. When it is 5:00, the audio buffer's presentation timestamp was also roughly 5:00, so it matches the current time.

#### What about the freeze at the end?

To avoid the video freezing at the end, we now need to keep the `RecordingSession` running for longer until all late video frames have been successfully written.

For example, if we stop at 10:00, the last video frame that was written came in at 8:86. So now we need to wait until the video frame with a presentation timestamp of 10:00 actually came in, which might happen at the real time of 11:14.

#### What if no more Frames come in?

The RecordingSession stays active until the last video frame is in, and it also has a fallback mechanism to stop the RecordingSession after a given timeout if no more frames came in (e.g. Camera crash, app minimized, etc.)



<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2186

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
