### PR TITLE
fix: Fix `torch` not being reset after video recording

### DIFF
--- a/package/ios/CameraView+RecordVideo.swift
+++ b/package/ios/CameraView+RecordVideo.swift
@@ -18,6 +18,13 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
     do {
       let options = try RecordVideoOptions(fromJSValue: options)
 
+      // If flash is on, just enable torch
+      if options.flash != .off {
+        cameraSession.configure { config in
+          config.torch = options.flash
+        }
+      }
+
       // Start Recording with success and error callbacks
       cameraSession.startRecording(
         options: options,
@@ -40,6 +47,11 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
 
   func stopRecording(promise: Promise) {
     cameraSession.stopRecording(promise: promise)
+
+    // If flash was used, we had the torch enabled. Now set it back to it's original state.
+    cameraSession.configure { config in
+      config.torch = try Torch(jsValue: torch)
+    }
   }
 
   func pauseRecording(promise: Promise) {

--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -214,7 +214,7 @@ public final class CameraView: UIView, CameraSessionDelegate {
       // Side-Props
       config.fps = fps?.int32Value
       config.enableLowLightBoost = lowLightBoost
-      config.torch = getTorch()
+      config.torch = try Torch(jsValue: torch)
 
       // Zoom
       config.zoom = zoom.doubleValue

--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -22,13 +22,6 @@ extension CameraSession {
       let start = DispatchTime.now()
       ReactLogger.log(level: .info, message: "Starting Video recording...")
 
-      if options.flash != .off {
-        // use the torch as the video's flash
-        self.configure { config in
-          config.torch = options.flash
-        }
-      }
-
       // Get Video Output
       guard let videoOutput = self.videoOutput else {
         if self.configuration?.video == .disabled {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Previously we didn't disable the torch again after enabling it for video recordings. This fixes the issue and toggles torch off once you stop recording

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
