### PR TITLE
fix: App crashes when Camera using scanner is closed

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.Dispatchers
 
 class CameraSession(private val context: Context, private val cameraManager: CameraManager, private val callback: CameraSessionCallback) :
   Closeable,
@@ -210,7 +211,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
   private fun destroyPreviewOutputSync() {
     Log.i(TAG, "Destroying Preview Output...")
-    runBlocking {
+    launch(Dispatchers.Main) {
       configure { config ->
         config.preview = CameraConfiguration.Output.Disabled.create()
       }


### PR DESCRIPTION
## What
The App crashes when the Camera component with the code scanner after returning results is closed and unmounted. 

## Changes
The PR changes the destroyPreviewOutputSync and makes it run within the main dispatcher. 

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on
OPPO A36, Android 11

## Related issues
- Fixes #2189

## Note
I'm 100% sure this is the correct solution, but it works for me and others. I have not fully tested other features except for code scanner and photo capture which satisfy my needs, so I have not further debugged either.

What's more, I have another solution. This function aims to let `configure` compare out a difference, and forcing `diff` to be `true` can also resolve this issue. So that, 

```kotlin
  suspend fun configure(lambda: (configuration: CameraConfiguration) -> Unit) {
    mutex.withLock {
      Log.i(TAG, "Updating CameraSession Configuration...")

      val config = CameraConfiguration.copyOf(this.configuration)
      lambda(config)
//      val diff = CameraConfiguration.difference(this.configuration, config)
      val diff = CameraConfiguration.Difference(true, true, true);
```

Of course, this is a more inappropriate solution, but just to give a clue of what's going on here.

Let me know if you need another PR or more information
