### PR TITLE
fix: Use `bitRate` multiplier instead of setting it to an absolute value

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
@@ -9,13 +9,15 @@ import com.mrousavy.camera.core.MicrophonePermissionError
 import com.mrousavy.camera.core.RecorderError
 import com.mrousavy.camera.core.RecordingSession
 import com.mrousavy.camera.core.code
+import com.mrousavy.camera.types.Flash
+import com.mrousavy.camera.types.RecordVideoOptions
 import com.mrousavy.camera.types.Torch
 import com.mrousavy.camera.types.VideoCodec
 import com.mrousavy.camera.types.VideoFileType
 import com.mrousavy.camera.utils.makeErrorMap
 import java.util.*
 
-suspend fun CameraView.startRecording(options: ReadableMap, onRecordCallback: Callback) {
+suspend fun CameraView.startRecording(jsOptions: ReadableMap, onRecordCallback: Callback) {
   // check audio permission
   if (audio == true) {
     if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
@@ -23,28 +25,14 @@ suspend fun CameraView.startRecording(options: ReadableMap, onRecordCallback: Ca
     }
   }
 
-  val enableFlash = options.getString("flash") == "on"
+  val options = RecordVideoOptions(jsOptions)
+
+  val enableFlash = options.flash == Flash.ON
   if (enableFlash) {
     // overrides current torch mode value to enable flash while recording
     cameraSession.configure { config ->
       config.torch = Torch.ON
     }
-  }
-  var codec = VideoCodec.H264
-  if (options.hasKey("videoCodec")) {
-    codec = VideoCodec.fromUnionValue(options.getString("videoCodec"))
-  }
-  var fileType = VideoFileType.MP4
-  if (options.hasKey("fileType")) {
-    fileType = VideoFileType.fromUnionValue(options.getString("fileType"))
-  }
-  var bitRate: Double? = null
-  if (options.hasKey("videoBitRateOverride")) {
-    bitRate = options.getDouble("videoBitRateOverride")
-  }
-  var bitRateMultiplier: Double? = null
-  if (options.hasKey("videoBitRateMultiplier")) {
-    bitRateMultiplier = options.getDouble("videoBitRateMultiplier")
   }
 
   val callback = { video: RecordingSession.Video ->
@@ -57,7 +45,7 @@ suspend fun CameraView.startRecording(options: ReadableMap, onRecordCallback: Ca
     val errorMap = makeErrorMap(error.code, error.message)
     onRecordCallback(null, errorMap)
   }
-  cameraSession.startRecording(audio == true, codec, fileType, bitRate, callback, onError)
+  cameraSession.startRecording(audio == true, options, callback, onError)
 }
 
 @SuppressLint("RestrictedApi")

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
@@ -39,8 +39,8 @@ suspend fun CameraView.startRecording(options: ReadableMap, onRecordCallback: Ca
     fileType = VideoFileType.fromUnionValue(options.getString("fileType"))
   }
   var bitRate: Double? = null
-  if (options.hasKey("videoBitRate")) {
-    bitRate = options.getDouble("videoBitRate")
+  if (options.hasKey("videoBitRateOverride")) {
+    bitRate = options.getDouble("videoBitRateOverride")
   }
   var bitRateMultiplier: Double? = null
   if (options.hasKey("videoBitRateMultiplier")) {

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
@@ -15,15 +15,13 @@ import com.mrousavy.camera.types.Torch
 import com.mrousavy.camera.utils.makeErrorMap
 import java.util.*
 
-suspend fun CameraView.startRecording(jsOptions: ReadableMap, onRecordCallback: Callback) {
+suspend fun CameraView.startRecording(options: RecordVideoOptions, onRecordCallback: Callback) {
   // check audio permission
   if (audio == true) {
     if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
       throw MicrophonePermissionError()
     }
   }
-
-  val options = RecordVideoOptions(jsOptions)
 
   val enableFlash = options.flash == Flash.ON
   if (enableFlash) {

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
@@ -42,6 +42,10 @@ suspend fun CameraView.startRecording(options: ReadableMap, onRecordCallback: Ca
   if (options.hasKey("videoBitRate")) {
     bitRate = options.getDouble("videoBitRate")
   }
+  var bitRateMultiplier: Double? = null
+  if (options.hasKey("videoBitRateMultiplier")) {
+    bitRateMultiplier = options.getDouble("videoBitRateMultiplier")
+  }
 
   val callback = { video: RecordingSession.Video ->
     val map = Arguments.createMap()

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
@@ -12,8 +12,6 @@ import com.mrousavy.camera.core.code
 import com.mrousavy.camera.types.Flash
 import com.mrousavy.camera.types.RecordVideoOptions
 import com.mrousavy.camera.types.Torch
-import com.mrousavy.camera.types.VideoCodec
-import com.mrousavy.camera.types.VideoFileType
 import com.mrousavy.camera.utils.makeErrorMap
 import java.util.*
 

--- a/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -83,10 +83,11 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
 
   // TODO: startRecording() cannot be awaited, because I can't have a Promise and a onRecordedCallback in the same function. Hopefully TurboModules allows that
   @ReactMethod
-  fun startRecording(viewTag: Int, options: ReadableMap, onRecordCallback: Callback) {
+  fun startRecording(viewTag: Int, jsOptions: ReadableMap, onRecordCallback: Callback) {
     coroutineScope.launch {
       val view = findCameraView(viewTag)
       try {
+        val options = RecordVideoOptions(jsOptions)
         view.startRecording(options, onRecordCallback)
       } catch (error: CameraError) {
         val map = makeErrorMap("${error.domain}/${error.id}", error.message, error)

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -43,8 +43,6 @@ import com.mrousavy.camera.types.Orientation
 import com.mrousavy.camera.types.QualityPrioritization
 import com.mrousavy.camera.types.RecordVideoOptions
 import com.mrousavy.camera.types.Torch
-import com.mrousavy.camera.types.VideoCodec
-import com.mrousavy.camera.types.VideoFileType
 import com.mrousavy.camera.types.VideoStabilizationMode
 import java.io.Closeable
 import java.util.concurrent.CancellationException
@@ -526,10 +524,12 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
       val videoOutput = videoOutput ?: throw VideoNotEnabledError()
       val cameraDevice = cameraDevice ?: throw CameraNotReadyError()
 
+      // TODO: Implement HDR
+      val hdr = configuration?.videoHdr ?: false
       val fps = configuration?.fps ?: 30
 
       val recording =
-        RecordingSession(context, cameraDevice.id, videoOutput.size, enableAudio, fps, orientation, options, callback, onError)
+        RecordingSession(context, cameraDevice.id, videoOutput.size, enableAudio, fps, hdr, orientation, options, callback, onError)
       recording.start()
       this.recording = recording
     }

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -41,6 +41,7 @@ import com.mrousavy.camera.frameprocessor.FrameProcessor
 import com.mrousavy.camera.types.Flash
 import com.mrousavy.camera.types.Orientation
 import com.mrousavy.camera.types.QualityPrioritization
+import com.mrousavy.camera.types.RecordVideoOptions
 import com.mrousavy.camera.types.Torch
 import com.mrousavy.camera.types.VideoCodec
 import com.mrousavy.camera.types.VideoFileType
@@ -516,20 +517,19 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
   suspend fun startRecording(
     enableAudio: Boolean,
-    codec: VideoCodec,
-    fileType: VideoFileType,
-    bitRate: Double?,
+    options: RecordVideoOptions,
     callback: (video: RecordingSession.Video) -> Unit,
     onError: (error: RecorderError) -> Unit
   ) {
     mutex.withLock {
       if (recording != null) throw RecordingInProgressError()
       val videoOutput = videoOutput ?: throw VideoNotEnabledError()
+      val cameraDevice = cameraDevice ?: throw CameraNotReadyError()
 
       val fps = configuration?.fps ?: 30
 
       val recording =
-        RecordingSession(context, videoOutput.size, enableAudio, fps, codec, orientation, fileType, bitRate, callback, onError)
+        RecordingSession(context, cameraDevice.id, videoOutput.size, enableAudio, fps, orientation, options, callback, onError)
       recording.start()
       this.recording = recording
     }

--- a/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
@@ -18,6 +18,7 @@ class RecordingSession(
   val size: Size,
   private val enableAudio: Boolean,
   private val fps: Int? = null,
+  private val hdr: Boolean = false,
   private val orientation: Orientation,
   private val options: RecordVideoOptions,
   private val callback: (video: Video) -> Unit,
@@ -128,7 +129,7 @@ class RecordingSession(
    * This can either be overridden, multiplied, or just left at the recommended value.
    */
   private fun getBitRate(): Int {
-    var bitRate = getRecommendedBitRate()
+    var bitRate = getRecommendedBitRate(fps ?: 30, options.videoCodec, hdr)
     options.videoBitRateOverride?.let { override ->
       // Mbps -> bps
       bitRate = (override * 1_000_000).toInt()
@@ -143,6 +144,6 @@ class RecordingSession(
   override fun toString(): String {
     val audio = if (enableAudio) "with audio" else "without audio"
     return "${size.width} x ${size.height} @ $fps FPS ${options.videoCodec} ${options.fileType} " +
-        "$orientation ${bitRate / 1_000_000.0} Mbps RecordingSession ($audio)"
+      "$orientation ${bitRate / 1_000_000.0} Mbps RecordingSession ($audio)"
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
@@ -7,20 +7,19 @@ import android.os.Build
 import android.util.Log
 import android.util.Size
 import android.view.Surface
+import com.mrousavy.camera.extensions.getRecommendedBitRate
 import com.mrousavy.camera.types.Orientation
-import com.mrousavy.camera.types.VideoCodec
-import com.mrousavy.camera.types.VideoFileType
+import com.mrousavy.camera.types.RecordVideoOptions
 import java.io.File
 
 class RecordingSession(
   context: Context,
+  val cameraId: String,
   val size: Size,
   private val enableAudio: Boolean,
   private val fps: Int? = null,
-  private val codec: VideoCodec = VideoCodec.H264,
   private val orientation: Orientation,
-  private val fileType: VideoFileType = VideoFileType.MP4,
-  videoBitRate: Double? = null,
+  private val options: RecordVideoOptions,
   private val callback: (video: Video) -> Unit,
   private val onError: (error: RecorderError) -> Unit
 ) {
@@ -34,14 +33,14 @@ class RecordingSession(
 
   data class Video(val path: String, val durationMs: Long)
 
-  private val bitRate = videoBitRate ?: getDefaultBitRate()
+  private val bitRate = getBitRate()
   private val recorder: MediaRecorder
   private val outputFile: File
   private var startTime: Long? = null
   val surface: Surface = MediaCodec.createPersistentInputSurface()
 
   init {
-    outputFile = File.createTempFile("mrousavy", fileType.toExtension(), context.cacheDir)
+    outputFile = File.createTempFile("mrousavy", options.fileType.toExtension(), context.cacheDir)
 
     Log.i(TAG, "Creating RecordingSession for ${outputFile.absolutePath}")
 
@@ -52,12 +51,12 @@ class RecordingSession(
 
     recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
     recorder.setOutputFile(outputFile.absolutePath)
-    recorder.setVideoEncodingBitRate((bitRate * 1_000_000).toInt())
+    recorder.setVideoEncodingBitRate(bitRate)
     recorder.setVideoSize(size.height, size.width)
     if (fps != null) recorder.setVideoFrameRate(fps)
 
-    Log.i(TAG, "Using $codec Video Codec at $bitRate Mbps..")
-    recorder.setVideoEncoder(codec.toVideoCodec())
+    Log.i(TAG, "Using ${options.videoCodec} Video Codec at $bitRate Mbps..")
+    recorder.setVideoEncoder(options.videoCodec.toVideoEncoder())
     if (enableAudio) {
       Log.i(TAG, "Adding Audio Channel..")
       recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
@@ -124,22 +123,25 @@ class RecordingSession(
     }
   }
 
-  private fun getDefaultBitRate(): Double {
-    var baseBitRate = when (size.width * size.height) {
-      in 0..640 * 480 -> 2.0
-      in 640 * 480..1280 * 720 -> 5.0
-      in 1280 * 720..1920 * 1080 -> 10.0
-      in 1920 * 1080..3840 * 2160 -> 30.0
-      in 3840 * 2160..7680 * 4320 -> 100.0
-      else -> 100.0
+  /**
+   * Get the bit-rate to use, in bits per seconds.
+   * This can either be overridden, multiplied, or just left at the recommended value.
+   */
+  private fun getBitRate(): Int {
+    var bitRate = getRecommendedBitRate()
+    options.videoBitRateOverride?.let { override ->
+      // Mbps -> bps
+      bitRate = (override * 1_000_000).toInt()
     }
-    baseBitRate = baseBitRate / 30.0 * (fps ?: 30).toDouble()
-    if (this.codec == VideoCodec.H265) baseBitRate *= 0.8
-    return baseBitRate
+    options.videoBitRateMultiplier?.let { multiplier ->
+      // multiply by 1.2, 0.8, ...
+      bitRate = (bitRate * multiplier).toInt()
+    }
+    return bitRate
   }
 
   override fun toString(): String {
     val audio = if (enableAudio) "with audio" else "without audio"
-    return "${size.width} x ${size.height} @ $fps FPS $codec $fileType $orientation $bitRate Mbps RecordingSession ($audio)"
+    return "${size.width} x ${size.height} @ $fps FPS ${options.videoCodec} ${options.fileType} $orientation $bitRate Mbps RecordingSession ($audio)"
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
@@ -55,7 +55,7 @@ class RecordingSession(
     recorder.setVideoSize(size.height, size.width)
     if (fps != null) recorder.setVideoFrameRate(fps)
 
-    Log.i(TAG, "Using ${options.videoCodec} Video Codec at $bitRate Mbps..")
+    Log.i(TAG, "Using ${options.videoCodec} Video Codec at ${bitRate / 1_000_000.0} Mbps..")
     recorder.setVideoEncoder(options.videoCodec.toVideoEncoder())
     if (enableAudio) {
       Log.i(TAG, "Adding Audio Channel..")
@@ -142,6 +142,7 @@ class RecordingSession(
 
   override fun toString(): String {
     val audio = if (enableAudio) "with audio" else "without audio"
-    return "${size.width} x ${size.height} @ $fps FPS ${options.videoCodec} ${options.fileType} $orientation $bitRate Mbps RecordingSession ($audio)"
+    return "${size.width} x ${size.height} @ $fps FPS ${options.videoCodec} ${options.fileType} " +
+        "$orientation ${bitRate / 1_000_000.0} Mbps RecordingSession ($audio)"
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
@@ -1,0 +1,59 @@
+package com.mrousavy.camera.extensions
+
+import android.media.CamcorderProfile
+import android.os.Build
+import android.util.Log
+import android.util.Size
+import com.mrousavy.camera.core.RecordingSession
+import kotlin.math.abs
+
+fun RecordingSession.getRecommendedBitRate(): Int {
+  val targetResolution = size
+  val quality = findClosestCamcorderProfileQuality(targetResolution)
+  Log.i("CamcorderProfile", "Closest matching CamcorderProfile: $quality")
+
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    val profiles = CamcorderProfile.getAll(cameraId, quality)
+    if (profiles != null) {
+      val best = profiles.videoProfiles.minBy { abs(it.width * it.height - targetResolution.width * targetResolution.height) }
+      return best.bitrate
+    }
+  }
+
+  val cameraIdInt = cameraId.toIntOrNull()
+  if (cameraIdInt != null) {
+    val profile = CamcorderProfile.get(cameraIdInt, quality)
+    return profile.videoBitRate
+  }
+
+  val profile = CamcorderProfile.get(quality)
+  return profile.videoBitRate
+}
+
+private fun getResolutionForCamcorderProfileQuality(camcorderProfile: Int): Int {
+  return when (camcorderProfile) {
+    CamcorderProfile.QUALITY_QCIF -> 176 * 144
+    CamcorderProfile.QUALITY_QVGA -> 320 * 240
+    CamcorderProfile.QUALITY_CIF -> 352 * 288
+    CamcorderProfile.QUALITY_VGA -> 640 * 480
+    CamcorderProfile.QUALITY_480P -> 720 * 480
+    CamcorderProfile.QUALITY_720P -> 1280 * 720
+    CamcorderProfile.QUALITY_1080P -> 1920 * 1080
+    CamcorderProfile.QUALITY_2K -> 2048 * 1080
+    CamcorderProfile.QUALITY_QHD -> 2560 * 1440
+    CamcorderProfile.QUALITY_2160P -> 3840 * 2160
+    CamcorderProfile.QUALITY_4KDCI -> 4096 * 2160
+    CamcorderProfile.QUALITY_8KUHD -> 7680 * 4320
+    else -> throw Error("Invalid CamcorderProfile \"$camcorderProfile\"!")
+  }
+}
+
+private fun findClosestCamcorderProfileQuality(resolution: Size): Int {
+  // Iterate through all available CamcorderProfiles and find the one that matches the closest
+  val targetResolution = resolution.width * resolution.height
+  val closestProfile = (CamcorderProfile.QUALITY_QCIF..CamcorderProfile.QUALITY_8KUHD).minBy { profile ->
+    val currentResolution = getResolutionForCamcorderProfileQuality(profile)
+    return@minBy abs(currentResolution - targetResolution)
+  }
+  return closestProfile
+}

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
@@ -72,8 +72,8 @@ fun RecordingSession.getRecommendedBitRate(fps: Int, codec: VideoCodec, hdr: Boo
   return bitRate.toInt()
 }
 
-private fun getResolutionForCamcorderProfileQuality(camcorderProfile: Int): Int {
-  return when (camcorderProfile) {
+private fun getResolutionForCamcorderProfileQuality(camcorderProfile: Int): Int =
+  when (camcorderProfile) {
     CamcorderProfile.QUALITY_QCIF -> 176 * 144
     CamcorderProfile.QUALITY_QVGA -> 320 * 240
     CamcorderProfile.QUALITY_CIF -> 352 * 288
@@ -88,7 +88,6 @@ private fun getResolutionForCamcorderProfileQuality(camcorderProfile: Int): Int 
     CamcorderProfile.QUALITY_8KUHD -> 7680 * 4320
     else -> throw Error("Invalid CamcorderProfile \"$camcorderProfile\"!")
   }
-}
 
 private fun findClosestCamcorderProfileQuality(resolution: Size): Int {
   // Iterate through all available CamcorderProfiles and find the one that matches the closest

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
@@ -1,33 +1,75 @@
 package com.mrousavy.camera.extensions
 
 import android.media.CamcorderProfile
+import android.media.MediaRecorder.VideoEncoder
 import android.os.Build
 import android.util.Log
 import android.util.Size
 import com.mrousavy.camera.core.RecordingSession
+import com.mrousavy.camera.types.VideoCodec
 import kotlin.math.abs
 
-fun RecordingSession.getRecommendedBitRate(): Int {
+data class RecommendedProfile(
+  val bitRate: Int,
+  // VideoEncoder.H264 or VideoEncoder.HEVC
+  val codec: Int,
+  // 8-bit or 10-bit
+  val bitDepth: Int,
+  // 30 or 60 FPS
+  val fps: Int
+)
+
+fun RecordingSession.getRecommendedBitRate(fps: Int, codec: VideoCodec, hdr: Boolean): Int {
   val targetResolution = size
+  val encoder = codec.toVideoEncoder()
+  val bitDepth = if (hdr) 10 else 8
   val quality = findClosestCamcorderProfileQuality(targetResolution)
   Log.i("CamcorderProfile", "Closest matching CamcorderProfile: $quality")
+
+  var recommendedProfile: RecommendedProfile? = null
 
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
     val profiles = CamcorderProfile.getAll(cameraId, quality)
     if (profiles != null) {
       val best = profiles.videoProfiles.minBy { abs(it.width * it.height - targetResolution.width * targetResolution.height) }
-      return best.bitrate
+
+      recommendedProfile = RecommendedProfile(
+        best.bitrate,
+        best.codec,
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) best.bitDepth else 8,
+        best.frameRate
+      )
     }
   }
 
-  val cameraIdInt = cameraId.toIntOrNull()
-  if (cameraIdInt != null) {
-    val profile = CamcorderProfile.get(cameraIdInt, quality)
-    return profile.videoBitRate
+  if (recommendedProfile == null) {
+    val cameraIdInt = cameraId.toIntOrNull()
+    val profile = if (cameraIdInt != null) {
+      CamcorderProfile.get(cameraIdInt, quality)
+    } else {
+      CamcorderProfile.get(quality)
+    }
+    recommendedProfile = RecommendedProfile(
+      profile.videoBitRate,
+      profile.videoCodec,
+      8,
+      profile.videoFrameRate
+    )
   }
 
-  val profile = CamcorderProfile.get(quality)
-  return profile.videoBitRate
+  var bitRate = recommendedProfile.bitRate.toDouble()
+  // the target bit-rate is for e.g. 30 FPS, but we use 60 FPS. up-scale it
+  bitRate = bitRate / recommendedProfile.fps * fps
+  // the target bit-rate might be in 8-bit SDR, but we record in 10-bit HDR. up-scale it
+  bitRate = bitRate / recommendedProfile.bitDepth * bitDepth
+  if (recommendedProfile.codec == VideoEncoder.H264 && encoder == VideoEncoder.HEVC) {
+    // the target bit-rate is for H.264, but we use H.265, which is 20% smaller
+    bitRate *= 0.8
+  } else if (recommendedProfile.codec == VideoEncoder.HEVC && encoder == VideoEncoder.H264) {
+    // the target bit-rate is for H.265, but we use H.264, which is 20% larger
+    bitRate *= 1.2
+  }
+  return bitRate.toInt()
 }
 
 private fun getResolutionForCamcorderProfileQuality(camcorderProfile: Int): Int {

--- a/package/android/src/main/java/com/mrousavy/camera/types/RecordVideoOptions.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/types/RecordVideoOptions.kt
@@ -1,0 +1,29 @@
+package com.mrousavy.camera.types
+
+import com.facebook.react.bridge.ReadableMap
+
+class RecordVideoOptions(map: ReadableMap) {
+  var fileType: VideoFileType = VideoFileType.MOV
+  var flash: Flash = Flash.OFF
+  var videoCodec = VideoCodec.H264
+  var videoBitRateOverride: Double? = null
+  var videoBitRateMultiplier: Double? = null
+
+  init {
+    if (map.hasKey("fileType")) {
+      fileType = VideoFileType.fromUnionValue(map.getString("fileType"))
+    }
+    if (map.hasKey("flash")) {
+      flash = Flash.fromUnionValue(map.getString("flash"))
+    }
+    if (map.hasKey("videoCodec")) {
+      videoCodec = VideoCodec.fromUnionValue(map.getString("fileType"))
+    }
+    if (map.hasKey("videoBitRateOverride")) {
+      videoBitRateOverride = map.getDouble("videoBitRateOverride")
+    }
+    if (map.hasKey("videoBitRateMultiplier")) {
+      videoBitRateMultiplier = map.getDouble("videoBitRateMultiplier")
+    }
+  }
+}

--- a/package/android/src/main/java/com/mrousavy/camera/types/VideoCodec.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/types/VideoCodec.kt
@@ -6,7 +6,7 @@ enum class VideoCodec(override val unionValue: String) : JSUnionValue {
   H264("h264"),
   H265("h265");
 
-  fun toVideoCodec(): Int =
+  fun toVideoEncoder(): Int =
     when (this) {
       H264 -> MediaRecorder.VideoEncoder.H264
       H265 -> MediaRecorder.VideoEncoder.HEVC

--- a/package/ios/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
+++ b/package/ios/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
@@ -24,9 +24,9 @@ extension AVCaptureVideoDataOutput {
       throw CameraError.capture(.createRecorderError(message: "Failed to get video settings!"))
     }
 
-    if let bitRate = options.bitRate {
+    if let bitRateOverride = options.bitRateOverride {
       // Convert from Mbps -> bps
-      let bitsPerSecond = bitRate * 1_000_000
+      let bitsPerSecond = bitRateOverride * 1_000_000
       if settings[AVVideoCompressionPropertiesKey] == nil {
         settings[AVVideoCompressionPropertiesKey] = [:]
       }

--- a/package/ios/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
+++ b/package/ios/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
@@ -27,9 +27,17 @@ extension AVCaptureVideoDataOutput {
     if let bitRate = options.bitRate {
       // Convert from Mbps -> bps
       let bitsPerSecond = bitRate * 1_000_000
-      settings[AVVideoCompressionPropertiesKey] = [
-        AVVideoAverageBitRateKey: NSNumber(value: bitsPerSecond),
-      ]
+      if (settings[AVVideoCompressionPropertiesKey] == nil) {
+        settings[AVVideoCompressionPropertiesKey] = [:]
+      }
+      settings[AVVideoCompressionPropertiesKey][AVVideoAverageBitRateKey] = NSNumber(value: bitsPerSecond)
+    }
+
+    if let bitRateMultiplier = options.bitRateMultiplier {
+      // Convert from Mbps -> bps
+      let bitsPerSecond = bitRate * 1_000_000
+      let compressionSettings = settings[AVVideoCompressionPropertiesKey] ?? [:]
+      compressionSettings[AVVideoAverageBitRateKey] = compressionSettings[AVVideoAverageBitRateKey] * NSNumber(value: bitRateMultiplier)
     }
 
     return settings

--- a/package/ios/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
+++ b/package/ios/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
@@ -30,14 +30,25 @@ extension AVCaptureVideoDataOutput {
       if (settings[AVVideoCompressionPropertiesKey] == nil) {
         settings[AVVideoCompressionPropertiesKey] = [:]
       }
-      settings[AVVideoCompressionPropertiesKey][AVVideoAverageBitRateKey] = NSNumber(value: bitsPerSecond)
+      var compressionSettings = settings[AVVideoCompressionPropertiesKey] as? [String: Any] ?? [:]
+      let currentBitRate = compressionSettings[AVVideoAverageBitRateKey] as? NSNumber
+      ReactLogger.log(level: .info, message: "Setting Video Bit-Rate from \(currentBitRate?.doubleValue.description ?? "nil") bps to \(bitsPerSecond) bps...")
+      
+      compressionSettings[AVVideoAverageBitRateKey] = NSNumber(value: bitsPerSecond)
+      settings[AVVideoCompressionPropertiesKey] = compressionSettings
     }
 
     if let bitRateMultiplier = options.bitRateMultiplier {
-      // Convert from Mbps -> bps
-      let bitsPerSecond = bitRate * 1_000_000
-      let compressionSettings = settings[AVVideoCompressionPropertiesKey] ?? [:]
-      compressionSettings[AVVideoAverageBitRateKey] = compressionSettings[AVVideoAverageBitRateKey] * NSNumber(value: bitRateMultiplier)
+      // Check if the bit-rate even exists in the settings
+      if var compressionSettings = settings[AVVideoCompressionPropertiesKey] as? [String: Any],
+         let currentBitRate = compressionSettings[AVVideoAverageBitRateKey] as? NSNumber {
+        // Multiply the current value by the given multiplier
+        let newBitRate = Int(currentBitRate.doubleValue * bitRateMultiplier)
+        ReactLogger.log(level: .info, message: "Setting Video Bit-Rate from \(currentBitRate) bps to \(newBitRate) bps...")
+        
+        compressionSettings[AVVideoAverageBitRateKey] = NSNumber(value: newBitRate)
+        settings[AVVideoCompressionPropertiesKey] = compressionSettings
+      }
     }
 
     return settings

--- a/package/ios/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
+++ b/package/ios/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
@@ -27,13 +27,13 @@ extension AVCaptureVideoDataOutput {
     if let bitRate = options.bitRate {
       // Convert from Mbps -> bps
       let bitsPerSecond = bitRate * 1_000_000
-      if (settings[AVVideoCompressionPropertiesKey] == nil) {
+      if settings[AVVideoCompressionPropertiesKey] == nil {
         settings[AVVideoCompressionPropertiesKey] = [:]
       }
       var compressionSettings = settings[AVVideoCompressionPropertiesKey] as? [String: Any] ?? [:]
       let currentBitRate = compressionSettings[AVVideoAverageBitRateKey] as? NSNumber
       ReactLogger.log(level: .info, message: "Setting Video Bit-Rate from \(currentBitRate?.doubleValue.description ?? "nil") bps to \(bitsPerSecond) bps...")
-      
+
       compressionSettings[AVVideoAverageBitRateKey] = NSNumber(value: bitsPerSecond)
       settings[AVVideoCompressionPropertiesKey] = compressionSettings
     }
@@ -45,7 +45,7 @@ extension AVCaptureVideoDataOutput {
         // Multiply the current value by the given multiplier
         let newBitRate = Int(currentBitRate.doubleValue * bitRateMultiplier)
         ReactLogger.log(level: .info, message: "Setting Video Bit-Rate from \(currentBitRate) bps to \(newBitRate) bps...")
-        
+
         compressionSettings[AVVideoAverageBitRateKey] = NSNumber(value: newBitRate)
         settings[AVVideoCompressionPropertiesKey] = compressionSettings
       }

--- a/package/ios/Types/RecordVideoOptions.swift
+++ b/package/ios/Types/RecordVideoOptions.swift
@@ -37,7 +37,7 @@ struct RecordVideoOptions {
       codec = try AVVideoCodecType(withString: codecOption)
     }
     // BitRate Override
-    if let parsed = dictionary["videoBitRate"] as? Double {
+    if let parsed = dictionary["videoBitRateOverride"] as? Double {
       bitRate = parsed
     }
     // BitRate Multiplier

--- a/package/ios/Types/RecordVideoOptions.swift
+++ b/package/ios/Types/RecordVideoOptions.swift
@@ -16,7 +16,7 @@ struct RecordVideoOptions {
   /**
    * Full Bit-Rate override for the Video Encoder, in Megabits per second (Mbps)
    */
-  var bitRate: Double?
+  var bitRateOverride: Double?
   /**
    * A multiplier applied to whatever the currently set bit-rate is, whether it's automatically computed by the OS Encoder,
    * or set via bitRate, in Megabits per second (Mbps)
@@ -38,7 +38,7 @@ struct RecordVideoOptions {
     }
     // BitRate Override
     if let parsed = dictionary["videoBitRateOverride"] as? Double {
-      bitRate = parsed
+      bitRateOverride = parsed
     }
     // BitRate Multiplier
     if let parsed = dictionary["videoBitRateMultiplier"] as? Double {

--- a/package/ios/Types/RecordVideoOptions.swift
+++ b/package/ios/Types/RecordVideoOptions.swift
@@ -14,9 +14,14 @@ struct RecordVideoOptions {
   var flash: Torch = .off
   var codec: AVVideoCodecType?
   /**
-   Bit-Rate of the Video, in Megabits per second (Mbps)
+   * Full Bit-Rate override for the Video Encoder, in Megabits per second (Mbps)
    */
   var bitRate: Double?
+  /**
+   * A multiplier applied to whatever the currently set bit-rate is, whether it's automatically computed by the OS Encoder,
+   * or set via bitRate, in Megabits per second (Mbps)
+   */
+  var bitRateMultiplier: Double?
 
   init(fromJSValue dictionary: NSDictionary) throws {
     // File Type (.mov or .mp4)
@@ -31,9 +36,13 @@ struct RecordVideoOptions {
     if let codecOption = dictionary["videoCodec"] as? String {
       codec = try AVVideoCodecType(withString: codecOption)
     }
-    // BitRate
+    // BitRate Override
     if let parsed = dictionary["videoBitRate"] as? Double {
       bitRate = parsed
+    }
+    // BitRate Multiplier
+    if let parsed = dictionary["videoBitRateMultiplier"] as? Double {
+      bitRateMultiplier = parsed
     }
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Uses a bit-rate multiplier instead of trying to calculate bit-rate. This is much more reliable as the single source of truth comes from the hardware encoder.

The following values give the following bitrates on my iPhone 8:

```
undefined: 23328000
'low':     18662400
'normal':  23328000
'high':    27993600
12.345678: 12345678
50:        50000000
```

Also, this fixes the bit-rate settings for Android by actually using recommended values instead of just calculating it ourselves, which was often wrong.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

* Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2208

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
