### PR TITLE
fix: Fix `focus(..)` on iOS

### DIFF
--- a/package/ios/CameraView+Focus.swift
+++ b/package/ios/CameraView+Focus.swift
@@ -12,7 +12,8 @@ import Foundation
 extension CameraView {
   func focus(point: CGPoint, promise: Promise) {
     withPromise(promise) {
-      try cameraSession.focus(point: point)
+      let normalized = previewView.captureDevicePointConverted(fromLayerPoint: point)
+      try cameraSession.focus(point: normalized)
       return nil
     }
   }

--- a/package/ios/Core/CameraSession+Focus.swift
+++ b/package/ios/Core/CameraSession+Focus.swift
@@ -21,6 +21,8 @@ extension CameraSession {
       throw CameraError.device(DeviceError.focusNotSupported)
     }
 
+    ReactLogger.log(level: .info, message: "Focusing (\(point.x), \(point.y))...")
+
     do {
       try device.lockForConfiguration()
       defer {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the `focus(..)` method not properly focusing on iOS by properly normalizing the point from layout coordinates.

Now it works perfectly!

https://github.com/mrousavy/react-native-vision-camera/assets/15199031/3ae8f73f-be42-47db-ac95-6b721c40be22



<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2120
- Resolves https://github.com/mrousavy/react-native-vision-camera/issues/1967
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1938

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
