### PR TITLE
fix: Fix Recordings with `audio={false}` timeouting

### DIFF
--- a/package/ios/Core/RecordingSession.swift
+++ b/package/ios/Core/RecordingSession.swift
@@ -152,6 +152,11 @@ class RecordingSession {
     assetWriter.startSession(atSourceTime: currentTime)
     startTimestamp = currentTime
     ReactLogger.log(level: .info, message: "Started RecordingSession at time: \(currentTime.seconds)")
+
+    if audioWriter == nil {
+      // Audio was enabled, mark the Audio track as finished so we won't wait for it.
+      hasWrittenLastAudioFrame = true
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes Recordings with `audio={false}` from timeouting by finishing the audio track immediately when it is not enabled.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2218

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
