### PR TITLE
feat: Add `extra-low` and `extra-high` bit-rate options

### DIFF
--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -127,13 +127,18 @@ export class Camera extends React.PureComponent<CameraProps> {
   }
 
   private getBitRateMultiplier(bitRate: RecordVideoOptions['videoBitRate']): number {
+    if (typeof bitRate === 'number' || bitRate == null) return 1
     switch (bitRate) {
+      case 'extra-low':
+        return 0.6
       case 'low':
         return 0.8
+      case 'normal':
+        return 1
       case 'high':
         return 1.2
-      default:
-        return 1
+      case 'extra-high':
+        return 1.4
     }
   }
 
@@ -159,14 +164,12 @@ export class Camera extends React.PureComponent<CameraProps> {
       throw new CameraRuntimeError('parameter/invalid-parameter', 'The onRecordingError or onRecordingFinished functions were not set!')
 
     const nativeOptions: NativeRecordVideoOptions = passThruOptions
-    if (typeof videoBitRate === 'string') {
-      // If the user passed 'low'/'normal'/'high', we need to apply this as a multiplier to the native bitrate instead of absolutely setting it
-      delete nativeOptions.videoBitRateOverride
-      nativeOptions.videoBitRateMultiplier = this.getBitRateMultiplier(videoBitRate)
-    } else {
+    if (typeof videoBitRate === 'number') {
       // If the user passed an absolute number as a bit-rate, we just use this as a full override.
-      delete nativeOptions.videoBitRateOverride
       nativeOptions.videoBitRateOverride = videoBitRate
+    } else if (typeof videoBitRate === 'string' && videoBitRate !== 'normal') {
+      // If the user passed 'low'/'normal'/'high', we need to apply this as a multiplier to the native bitrate instead of absolutely setting it
+      nativeOptions.videoBitRateMultiplier = this.getBitRateMultiplier(videoBitRate)
     }
 
     const onRecordCallback = (video?: VideoFile, error?: CameraCaptureError): void => {

--- a/package/src/VideoFile.ts
+++ b/package/src/VideoFile.ts
@@ -21,20 +21,26 @@ export interface RecordVideoOptions {
   /**
    * The Video Codec to record in.
    * - `h264`: Widely supported, but might be less efficient, especially with larger sizes or framerates.
-   * - `h265`: The HEVC (High-Efficient-Video-Codec) for higher efficient video recordings.
+   * - `h265`: The HEVC (High-Efficient-Video-Codec) for higher efficient video recordings. Results in up to 50% smaller file-sizes.
    */
   videoCodec?: 'h264' | 'h265'
   /**
    * The bit-rate for encoding the video into a file, in Mbps (Megabits per second).
    *
-   * Bit-rate is dependant on various factors such as resolution, FPS, pixel format (whether it's 10 bit HDR or not), and codec.
+   * Bit-rate is dependant on various factors such as resolution, FPS, pixel format (whether it's 10 bit HDR or not), and video codec.
    *
-   * By default, it will be calculated using those factors.
-   * For example, at 1080p, 30 FPS, H.264 codec, without HDR it will result to 10 Mbps.
+   * By default, it will be calculated by the hardware encoder, which takes all those factors into account.
+   *
+   * * `extra-low`: 40% lower than whatever the hardware encoder recommends.
+   * * `low`: 20% lower than whatever the hardware encoder recommends.
+   * * `normal`: The recommended value by the hardware encoder.
+   * * `high`: 20% higher than whatever the hardware encoder recommends.
+   * * `extra-high`: 40% higher than whatever the hardware encoder recommends.
+   * * `number`: Any custom number for the bit-rate, in Mbps.
    *
    * @default 'normal'
    */
-  videoBitRate?: 'low' | 'normal' | 'high' | number
+  videoBitRate?: 'extra-low' | 'low' | 'normal' | 'high' | 'extra-high' | number
 }
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds the `extra-low` (-40%) and `extra-high` (+40%) bit-rate options

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
