### PR TITLE
fix: Fix first Frame not being written in Video

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -507,7 +507,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (3.6.9):
+  - VisionCamera (3.6.11):
     - React
     - React-callinvoker
     - React-Core
@@ -747,9 +747,9 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: aa2ce576c146a5e9afcbfe30e5464a311e275b8a
+  VisionCamera: b35fc51a521ce0a9b9da41d8b13127e3d414d195
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
 
 PODFILE CHECKSUM: 27f53791141a3303d814e09b55770336416ff4eb
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the resulting video starting with a blank frame, which was caused by the `RecordingSession` skipping the first frame instead of just writing it.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
