### PR TITLE
fix: Fix `VideoProfile` possibly being null

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
@@ -31,7 +31,9 @@ fun RecordingSession.getRecommendedBitRate(fps: Int, codec: VideoCodec, hdr: Boo
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
     val profiles = CamcorderProfile.getAll(cameraId, quality)
     if (profiles != null) {
-      val best = profiles.videoProfiles.filterNotNull().minBy { abs(it.width * it.height - targetResolution.width * targetResolution.height) }
+      val best = profiles.videoProfiles.filterNotNull().minBy {
+        abs(it.width * it.height - targetResolution.width * targetResolution.height)
+      }
 
       if (best != null) {
         recommendedProfile = RecommendedProfile(

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
@@ -31,14 +31,16 @@ fun RecordingSession.getRecommendedBitRate(fps: Int, codec: VideoCodec, hdr: Boo
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
     val profiles = CamcorderProfile.getAll(cameraId, quality)
     if (profiles != null) {
-      val best = profiles.videoProfiles.minBy { abs(it.width * it.height - targetResolution.width * targetResolution.height) }
+      val best = profiles.videoProfiles.filterNotNull().minBy { abs(it.width * it.height - targetResolution.width * targetResolution.height) }
 
-      recommendedProfile = RecommendedProfile(
-        best.bitrate,
-        best.codec,
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) best.bitDepth else 8,
-        best.frameRate
-      )
+      if (best != null) {
+        recommendedProfile = RecommendedProfile(
+          best.bitrate,
+          best.codec,
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) best.bitDepth else 8,
+          best.frameRate
+        )
+      }
     }
   }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the `Attempt to invoke virtual method 'int android.media.EncoderProfiles$VideoProfile.getBitrate()' on a null object reference` error, which happened because `profiles.getVideoProfiles()` _could_ return an empty list.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
