### PR TITLE
expo-cli package deprecated snippet fix

### DIFF
--- a/docs/docs/guides/SETUP.mdx
+++ b/docs/docs/guides/SETUP.mdx
@@ -36,7 +36,7 @@ npx pod-install
 <TabItem value="expo">
 
 ```bash
-expo install react-native-vision-camera
+npx expo install react-native-vision-camera
 ```
 
 </TabItem>
@@ -111,7 +111,7 @@ Add the VisionCamera plugin to your Expo config (`app.json`, `app.config.json` o
 Finally, compile the mods:
 
 ```bash
-expo prebuild
+npx expo prebuild
 ```
 
 To apply the changes, build a new binary with EAS:


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
Updated The terminal snippets from `expo` to `npx expo` since the The global expo-cli package has been deprecated.


## Changes
Snippet from
  1) `expo install react-native-vision-camera` to `npx expo install react-native-vision-camera` 
  2) `expo prebuild ` to `npx expo prebuild`
## Tested on
Windows Command Prompt with expo 0.10.16

## Related issues
None
