### PR TITLE
fix: Fix `minFps` being wrong

### DIFF
--- a/package/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
+++ b/package/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
@@ -15,10 +15,10 @@ extension AVCaptureDevice.Format {
   }
 
   var minFps: Float64 {
-    let maxRange = videoSupportedFrameRateRanges.max { l, r in
-      return l.maxFrameRate < r.maxFrameRate
+    let minRange = videoSupportedFrameRateRanges.min { l, r in
+      return l.minFrameRate < r.minFrameRate
     }
-    return maxRange?.maxFrameRate ?? 0
+    return maxRange?.minFrameRate ?? 0
   }
 
   var maxFps: Float64 {

--- a/package/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
+++ b/package/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
@@ -18,7 +18,7 @@ extension AVCaptureDevice.Format {
     let minRange = videoSupportedFrameRateRanges.min { l, r in
       return l.minFrameRate < r.minFrameRate
     }
-    return maxRange?.minFrameRate ?? 0
+    return minRange?.minFrameRate ?? 0
   }
 
   var maxFps: Float64 {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes `minFps` being wrong on iOS

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
