### PR TITLE
feat: provide permission status in hooks

### DIFF
--- a/package/src/hooks/useCameraPermission.ts
+++ b/package/src/hooks/useCameraPermission.ts
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Camera } from '../Camera'
+import { Camera, CameraPermissionStatus } from '../Camera'
 
 interface PermissionState {
+  /**
+   * The current permission status, initially `not-determined`.
+   * You can use this to distinguish between when permission status is not yet known,
+   * and when it's determined (`granted`, `denied` and more)
+   */
+  status: CameraPermissionStatus
   /**
    * Whether the specified permission has explicitly been granted.
    * By default, this will be `false`. To request permission, call `requestPermission()`.
@@ -31,21 +37,22 @@ interface PermissionState {
  * ```
  */
 export function useCameraPermission(): PermissionState {
-  const [hasPermission, setHasPermission] = useState(false)
+  const [status, setStatus] = useState<CameraPermissionStatus>('not-determined')
 
   const requestPermission = useCallback(async () => {
     const result = await Camera.requestCameraPermission()
     const hasPermissionNow = result === 'granted'
-    setHasPermission(hasPermissionNow)
+    setStatus(result)
     return hasPermissionNow
   }, [])
 
   useEffect(() => {
-    Camera.getCameraPermissionStatus().then((s) => setHasPermission(s === 'granted'))
+    Camera.getCameraPermissionStatus().then(setStatus)
   }, [])
 
   return {
-    hasPermission,
+    status,
+    hasPermission: status === 'granted',
     requestPermission,
   }
 }
@@ -65,21 +72,22 @@ export function useCameraPermission(): PermissionState {
  * ```
  */
 export function useMicrophonePermission(): PermissionState {
-  const [hasPermission, setHasPermission] = useState(false)
+  const [status, setStatus] = useState<CameraPermissionStatus>('not-determined')
 
   const requestPermission = useCallback(async () => {
     const result = await Camera.requestMicrophonePermission()
     const hasPermissionNow = result === 'granted'
-    setHasPermission(hasPermissionNow)
+    setStatus(result)
     return hasPermissionNow
   }, [])
 
   useEffect(() => {
-    Camera.getMicrophonePermissionStatus().then((s) => setHasPermission(s === 'granted'))
+    Camera.getMicrophonePermissionStatus().then(setStatus)
   }, [])
 
   return {
-    hasPermission,
+    status,
+    hasPermission: status === 'granted',
     requestPermission,
   }
 }

--- a/package/src/hooks/useCameraPermission.ts
+++ b/package/src/hooks/useCameraPermission.ts
@@ -20,6 +20,30 @@ interface PermissionState {
   requestPermission: () => Promise<boolean>
 }
 
+const usePermission = (
+  getPermissionStatus: () => Promise<CameraPermissionStatus>,
+  requestPermissionFunc: () => Promise<CameraPermissionStatus>,
+): PermissionState => {
+  const [status, setStatus] = useState<CameraPermissionStatus>('not-determined')
+
+  const requestPermission = useCallback(async () => {
+    const result = await requestPermissionFunc()
+    const hasPermissionNow = result === 'granted'
+    setStatus(result)
+    return hasPermissionNow
+  }, [requestPermissionFunc])
+
+  useEffect(() => {
+    getPermissionStatus().then(setStatus)
+  }, [getPermissionStatus])
+
+  return {
+    status,
+    hasPermission: status === 'granted',
+    requestPermission,
+  }
+}
+
 /**
  * Returns whether the user has granted permission to use the Camera, or not.
  *
@@ -36,26 +60,7 @@ interface PermissionState {
  * }
  * ```
  */
-export function useCameraPermission(): PermissionState {
-  const [status, setStatus] = useState<CameraPermissionStatus>('not-determined')
-
-  const requestPermission = useCallback(async () => {
-    const result = await Camera.requestCameraPermission()
-    const hasPermissionNow = result === 'granted'
-    setStatus(result)
-    return hasPermissionNow
-  }, [])
-
-  useEffect(() => {
-    Camera.getCameraPermissionStatus().then(setStatus)
-  }, [])
-
-  return {
-    status,
-    hasPermission: status === 'granted',
-    requestPermission,
-  }
-}
+export const useCameraPermission = () => usePermission(Camera.getCameraPermissionStatus, Camera.requestCameraPermission)
 
 /**
  * Returns whether the user has granted permission to use the Microphone, or not.
@@ -71,23 +76,4 @@ export function useCameraPermission(): PermissionState {
  * return <Camera video={true} audio={canRecordAudio} />
  * ```
  */
-export function useMicrophonePermission(): PermissionState {
-  const [status, setStatus] = useState<CameraPermissionStatus>('not-determined')
-
-  const requestPermission = useCallback(async () => {
-    const result = await Camera.requestMicrophonePermission()
-    const hasPermissionNow = result === 'granted'
-    setStatus(result)
-    return hasPermissionNow
-  }, [])
-
-  useEffect(() => {
-    Camera.getMicrophonePermissionStatus().then(setStatus)
-  }, [])
-
-  return {
-    status,
-    hasPermission: status === 'granted',
-    requestPermission,
-  }
-}
+export const useMicrophonePermission = () => usePermission(Camera.getMicrophonePermissionStatus, Camera.requestMicrophonePermission)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Motivation: let's say I'm using the `useCameraPermission` hook on a screen along with the CameraView. (sure, I could call the hook even sooner to learn about the permission status, but let's but that aside). The user has already given my app the permission to render Camera View. Initially, however, `hasPermission` is going to be false, even though the permission is granted (and after `getCameraPermissionStatus` resolves, it'll switch to true). This PR adds extra `status` field that can be used to distinguish this case.

let me know if there's need to add docs for this, can do 👍 

Thanks for reviewing


## Changes

* add a `status` field to `useCameraPermission` and `useMicrophonePermission`

## Tested on

iphone 12 device
android 10 device (huawei)



## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
