### PR TITLE
fix: RN 0.73 support by solving #2263: Kotlin compilation fails due to "'hasConstants' overrides nothing" at CameraDevicesManager.kt

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
@@ -71,8 +71,6 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
     eventEmitter.emit("CameraDevicesChanged", getDevicesJson())
   }
 
-  override fun hasConstants(): Boolean = true
-
   override fun getConstants(): MutableMap<String, Any?> {
     val devices = getDevicesJson()
     val preferredDevice = if (devices.size() > 0) devices.getMap(0) else null


### PR DESCRIPTION
fix: RN 0.73 support by solving #2263: Kotlin compilation fails due to "'hasConstants' overrides nothing" at CameraDevicesManager.kt