### PR TITLE
Fix java.util.NoSuchElementException at com.mrousavy.camera.extensions.RecordingSession_getRecommendedBitRateKt.getRecommendedBitRate(RecordingSession+getRecommendedBitRate.kt:107)

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
@@ -71,8 +71,6 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
     eventEmitter.emit("CameraDevicesChanged", getDevicesJson())
   }
 
-  override fun hasConstants(): Boolean = true
-
   override fun getConstants(): MutableMap<String, Any?> {
     val devices = getDevicesJson()
     val preferredDevice = if (devices.size() > 0) devices.getMap(0) else null

--- a/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraDevicesManager.kt
@@ -71,6 +71,8 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
     eventEmitter.emit("CameraDevicesChanged", getDevicesJson())
   }
 
+  override fun hasConstants(): Boolean = true
+
   override fun getConstants(): MutableMap<String, Any?> {
     val devices = getDevicesJson()
     val preferredDevice = if (devices.size() > 0) devices.getMap(0) else null

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
@@ -31,7 +31,7 @@ fun RecordingSession.getRecommendedBitRate(fps: Int, codec: VideoCodec, hdr: Boo
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
     val profiles = CamcorderProfile.getAll(cameraId, quality)
     if (profiles != null) {
-      val best = profiles.videoProfiles.filterNotNull().minBy {
+      val best = profiles.videoProfiles.filterNotNull().minByOrNull {
         abs(it.width * it.height - targetResolution.width * targetResolution.height)
       }
 


### PR DESCRIPTION
Android Xiaomi Redmi Note 11 Pro 5G issue:
```
Short message: An unknown error occurred while trying to start a video recording! null.
 ERROR  {"cause": {"message": null, "stacktrace": "java.util.NoSuchElementException
	at com.mrousavy.camera.extensions.RecordingSession_getRecommendedBitRateKt.getRecommendedBitRate(RecordingSession+getRecommendedBitRate.kt:107)
	at com.mrousavy.camera.core.RecordingSession.getBitRate(RecordingSession.kt:132)
	at com.mrousavy.camera.core.RecordingSession.<init>(RecordingSession.kt:37)
	at com.mrousavy.camera.core.CameraSession.startRecording(CameraSession.kt:532)
	at com.mrousavy.camera.CameraView_RecordVideoKt.startRecording(CameraView+RecordVideo.kt:34)
	at com.mrousavy.camera.CameraViewModule$startRecording$1.invokeSuspend(CameraViewModule.kt:91)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
"}, "code": "capture/unknown", "message": "An unknown error occurred while trying to start a video recording! null", "userInfo": null}
```