### PR TITLE
[v2] fix: set `NDEBUG=1` preprocessor flag in release mode

### DIFF
--- a/VisionCamera.podspec
+++ b/VisionCamera.podspec
@@ -28,7 +28,8 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" "
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" ",
+    "GCC_PREPROCESSOR_DEFINITIONS[config=Release]" => "$(inherited) NDEBUG=1"
   }
   s.compiler_flags = folly_compiler_flags + ' ' + boost_compiler_flags
   s.xcconfig = {


### PR DESCRIPTION
## What

This PR fixes the following error reported in #2265 that occurs when trying to build a RN app with Reanimated 3.6.x and RNVisionCamera 2.16.5 with Frame Processors enabled in release mode on iOS on Paper:

```
Undefined symbols for architecture x86_64:
  "reanimated::getCallGuard(facebook::jsi::Runtime&)", referenced from:
      void reanimated::WorkletRuntime::runGuarded<facebook::jsi::Object&>(std::__1::shared_ptr<reanimated::ShareableWorklet> const&, facebook::jsi::Object&) const in libVisionCamera.a(FrameProcessorRuntimeManager.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The root cause of this issue is that Reanimated 3.6.0 uses a well-known `NDEBUG` flag but unfortunately React Native does not set it on iOS on Paper (it is set correctly on Fabric, though). The workaround is to set environmental variable `PRODUCTION=1` when running `pod install` (so that `RNReanimated.podspec` knows that it should inject `NDEBUG` flag) but this flag is not well-documented so many people don't know about it.

## Changes

* Added `NDEBUG=1` flag to `GCC_PREPROCESSOR_DEFINITIONS` for `Release` variant in `VisionCamera.podspec`

## Tested on

I reproduced the error on a fresh RN 0.72.7 app with Reanimated 3.6.0 and RNVisionCamera 2.16.5 on iOS in release mode. Then I made the change in VisionCamera's podspec and the error was gone.

## Related issues

Fixes #2265.

See https://github.com/software-mansion/react-native-reanimated/pull/5366 for full explanation.
