### PR TITLE
fix: Fix `Only the original thread that created a view hierarchy can touch it's views` error

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -9,6 +9,7 @@ import android.view.Gravity
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.widget.FrameLayout
+import com.facebook.react.bridge.UiThreadUtil
 import com.mrousavy.camera.extensions.bigger
 import com.mrousavy.camera.extensions.getMaximumPreviewSize
 import com.mrousavy.camera.extensions.getPreviewTargetSize
@@ -21,19 +22,15 @@ import kotlin.math.roundToInt
 class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceView(context) {
   var size: Size = getMaximumPreviewSize()
     set(value) {
+      field = value
       Log.i(TAG, "Resizing PreviewView to ${value.width} x ${value.height}...")
       holder.setFixedSize(value.width, value.height)
-      requestLayout()
-      invalidate()
-      field = value
+      updateLayout()
     }
   var resizeMode: ResizeMode = ResizeMode.COVER
     set(value) {
-      if (value != field) {
-        requestLayout()
-        invalidate()
-      }
       field = value
+      updateLayout()
     }
 
   init {
@@ -52,6 +49,13 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
     val targetPreviewSize = format?.videoSize
     val formatAspectRatio = if (targetPreviewSize != null) targetPreviewSize.bigger.toDouble() / targetPreviewSize.smaller else null
     size = characteristics.getPreviewTargetSize(formatAspectRatio)
+  }
+
+  private fun updateLayout() {
+    UiThreadUtil.runOnUiThread {
+      requestLayout()
+      invalidate()
+    }
   }
 
   private fun getSize(contentSize: Size, containerSize: Size, resizeMode: ResizeMode): Size {

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -23,14 +23,20 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
   var size: Size = getMaximumPreviewSize()
     set(value) {
       field = value
-      Log.i(TAG, "Resizing PreviewView to ${value.width} x ${value.height}...")
-      holder.setFixedSize(value.width, value.height)
-      updateLayout()
+      UiThreadUtil.runOnUiThread {
+        Log.i(TAG, "Resizing PreviewView to ${value.width} x ${value.height}...")
+        holder.setFixedSize(value.width, value.height)
+        requestLayout()
+        invalidate()
+      }
     }
   var resizeMode: ResizeMode = ResizeMode.COVER
     set(value) {
       field = value
-      updateLayout()
+      UiThreadUtil.runOnUiThread {
+        requestLayout()
+        invalidate()
+      }
     }
 
   init {
@@ -49,13 +55,6 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
     val targetPreviewSize = format?.videoSize
     val formatAspectRatio = if (targetPreviewSize != null) targetPreviewSize.bigger.toDouble() / targetPreviewSize.smaller else null
     size = characteristics.getPreviewTargetSize(formatAspectRatio)
-  }
-
-  private fun updateLayout() {
-    UiThreadUtil.runOnUiThread {
-      requestLayout()
-      invalidate()
-    }
   }
 
   private fun getSize(contentSize: Size, containerSize: Size, resizeMode: ResizeMode): Size {


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the UI Thread checker error by running `requestLayout` and `invalidate` on UI Thread.



<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2276
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2184

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
