### PR TITLE
fix: Fix RN 0.73 compatibility for v2

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt
@@ -40,7 +40,10 @@ class FrameProcessorRuntimeManager(context: ReactApplicationContext, frameProces
       val holder = context.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl
       mScheduler = VisionCameraScheduler(frameProcessorThread)
       mContext = WeakReference(context)
-      mHybridData = initHybrid(context.javaScriptContextHolder.get(), holder, mScheduler!!)
+
+      val jsRuntimeHolder = context.javaScriptContextHolder?.get() ?: throw Error("JSI Runtime is null! VisionCamera does not yet support bridgeless mode..")
+
+      mHybridData = initHybrid(jsRuntimeHolder, holder, mScheduler!!)
       initializeRuntime()
 
       Log.i(TAG, "Installing JSI Bindings on JS Thread...")


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes build error on RN 0.73

`file:///.../react-native-vision-camera/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorRuntimeManager.kt:43:63 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type JavaScriptContextHolder?`

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes
Updated the `init` block in `FrameProcessorRuntimeManager.kt` based on the changes proposed in https://github.com/mrousavy/react-native-vision-camera/pull/2260.

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on
* Emulator (Pixel 2 API 31)
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
