### PR TITLE
perf: Make `getCameraPermission` and `getMicrophonePermission` synchronous

### DIFF
--- a/docs/docs/guides/SETUP.mdx
+++ b/docs/docs/guides/SETUP.mdx
@@ -164,8 +164,8 @@ There could be three states to this:
 Simply use the **get** functions to find out if a user has granted or denied permission before:
 
 ```ts
-const cameraPermission = await Camera.getCameraPermissionStatus()
-const microphonePermission = await Camera.getMicrophonePermissionStatus()
+const cameraPermission = Camera.getCameraPermissionStatus()
+const microphonePermission = Camera.getMicrophonePermissionStatus()
 ```
 
 A permission status can have the following values:

--- a/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -149,24 +149,24 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     return activity?.shouldShowRequestPermissionRationale(permission) ?: false
   }
 
-  @ReactMethod
-  fun getCameraPermissionStatus(promise: Promise) {
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  fun getCameraPermissionStatus(): String {
     val status = ContextCompat.checkSelfPermission(reactApplicationContext, Manifest.permission.CAMERA)
     var parsed = PermissionStatus.fromPermissionStatus(status)
     if (parsed == PermissionStatus.DENIED && canRequestPermission(Manifest.permission.CAMERA)) {
       parsed = PermissionStatus.NOT_DETERMINED
     }
-    promise.resolve(parsed.unionValue)
+    return parsed.unionValue
   }
 
-  @ReactMethod
-  fun getMicrophonePermissionStatus(promise: Promise) {
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  fun getMicrophonePermissionStatus(): String {
     val status = ContextCompat.checkSelfPermission(reactApplicationContext, Manifest.permission.RECORD_AUDIO)
     var parsed = PermissionStatus.fromPermissionStatus(status)
     if (parsed == PermissionStatus.DENIED && canRequestPermission(Manifest.permission.RECORD_AUDIO)) {
       parsed = PermissionStatus.NOT_DETERMINED
     }
-    promise.resolve(parsed.unionValue)
+    return parsed.unionValue
   }
 
   @ReactMethod

--- a/package/example/src/App.tsx
+++ b/package/example/src/App.tsx
@@ -1,12 +1,12 @@
 import { NavigationContainer } from '@react-navigation/native'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { PermissionsPage } from './PermissionsPage'
 import { MediaPage } from './MediaPage'
 import { CameraPage } from './CameraPage'
 import { CodeScannerPage } from './CodeScannerPage'
 import type { Routes } from './Routes'
-import { Camera, CameraPermissionStatus } from 'react-native-vision-camera'
+import { Camera } from 'react-native-vision-camera'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { StyleSheet } from 'react-native'
 import { DevicesPage } from './DevicesPage'
@@ -14,20 +14,10 @@ import { DevicesPage } from './DevicesPage'
 const Stack = createNativeStackNavigator<Routes>()
 
 export function App(): React.ReactElement | null {
-  const [cameraPermission, setCameraPermission] = useState<CameraPermissionStatus>()
-  const [microphonePermission, setMicrophonePermission] = useState<CameraPermissionStatus>()
-
-  useEffect(() => {
-    Camera.getCameraPermissionStatus().then(setCameraPermission)
-    Camera.getMicrophonePermissionStatus().then(setMicrophonePermission)
-  }, [])
+  const cameraPermission = Camera.getCameraPermissionStatus()
+  const microphonePermission = Camera.getMicrophonePermissionStatus()
 
   console.log(`Re-rendering Navigator. Camera: ${cameraPermission} | Microphone: ${microphonePermission}`)
-
-  if (cameraPermission == null || microphonePermission == null) {
-    // still loading
-    return null
-  }
 
   const showPermissionsPage = cameraPermission !== 'granted' || microphonePermission === 'not-determined'
   return (

--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -31,7 +31,7 @@ type Props = NativeStackScreenProps<Routes, 'CameraPage'>
 export function CameraPage({ navigation }: Props): React.ReactElement {
   const camera = useRef<Camera>(null)
   const [isCameraInitialized, setIsCameraInitialized] = useState(false)
-  const [hasMicrophonePermission, setHasMicrophonePermission] = useState(false)
+  const hasMicrophonePermission = useMemo(() => Camera.getMicrophonePermissionStatus() === 'granted', [])
   const zoom = useSharedValue(0)
   const isPressingButton = useSharedValue(false)
 
@@ -131,10 +131,6 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
     // Run everytime the neutralZoomScaled value changes. (reset zoom when device changes)
     zoom.value = neutralZoom
   }, [neutralZoom, zoom])
-
-  useEffect(() => {
-    Camera.getMicrophonePermissionStatus().then((status) => setHasMicrophonePermission(status === 'granted'))
-  }, [])
   //#endregion
 
   //#region Pinch to Zoom Gesture

--- a/package/ios/CameraViewManager.m
+++ b/package/ios/CameraViewManager.m
@@ -14,8 +14,8 @@
 @interface RCT_EXTERN_REMAP_MODULE (CameraView, CameraViewManager, RCTViewManager)
 
 // Module Functions
-RCT_EXTERN_METHOD(getCameraPermissionStatus : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject);
-RCT_EXTERN_METHOD(getMicrophonePermissionStatus : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject);
+RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(getCameraPermissionStatus);
+RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(getMicrophonePermissionStatus);
 RCT_EXTERN_METHOD(requestCameraPermission : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(requestMicrophonePermission : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject);
 

--- a/package/ios/CameraViewManager.swift
+++ b/package/ios/CameraViewManager.swift
@@ -84,19 +84,15 @@ final class CameraViewManager: RCTViewManager {
   }
 
   @objc
-  final func getCameraPermissionStatus(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-    withPromise(resolve: resolve, reject: reject) {
-      let status = AVCaptureDevice.authorizationStatus(for: .video)
-      return status.descriptor
-    }
+  final func getCameraPermissionStatus() -> String {
+    let status = AVCaptureDevice.authorizationStatus(for: .video)
+    return status.descriptor
   }
 
   @objc
-  final func getMicrophonePermissionStatus(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-    withPromise(resolve: resolve, reject: reject) {
-      let status = AVCaptureDevice.authorizationStatus(for: .audio)
-      return status.descriptor
-    }
+  final func getMicrophonePermissionStatus() -> String {
+    let status = AVCaptureDevice.authorizationStatus(for: .audio)
+    return status.descriptor
   }
 
   @objc

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -345,30 +345,18 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
    * the user has permitted the app to use the camera.
    *
    * To actually prompt the user for camera permission, use {@linkcode Camera.requestCameraPermission | requestCameraPermission()}.
-   *
-   * @throws {@linkcode CameraRuntimeError} When any kind of error occured while getting the current permission status. Use the {@linkcode CameraRuntimeError.code | code} property to get the actual error
    */
-  public static async getCameraPermissionStatus(): Promise<CameraPermissionStatus> {
-    try {
-      return await CameraModule.getCameraPermissionStatus()
-    } catch (e) {
-      throw tryParseNativeCameraError(e)
-    }
+  public static getCameraPermissionStatus(): CameraPermissionStatus {
+    return CameraModule.getCameraPermissionStatus()
   }
   /**
    * Gets the current Microphone-Recording Permission Status. Check this before mounting the Camera to ensure
    * the user has permitted the app to use the microphone.
    *
    * To actually prompt the user for microphone permission, use {@linkcode Camera.requestMicrophonePermission | requestMicrophonePermission()}.
-   *
-   * @throws {@linkcode CameraRuntimeError} When any kind of error occured while getting the current permission status. Use the {@linkcode CameraRuntimeError.code | code} property to get the actual error
    */
-  public static async getMicrophonePermissionStatus(): Promise<CameraPermissionStatus> {
-    try {
-      return await CameraModule.getMicrophonePermissionStatus()
-    } catch (e) {
-      throw tryParseNativeCameraError(e)
-    }
+  public static getMicrophonePermissionStatus(): CameraPermissionStatus {
+    return CameraModule.getMicrophonePermissionStatus()
   }
   /**
    * Shows a "request permission" alert to the user, and resolves with the new camera permission status.

--- a/package/src/hooks/useCameraPermission.ts
+++ b/package/src/hooks/useCameraPermission.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Camera } from '../Camera'
 
 interface PermissionState {
@@ -31,17 +31,13 @@ interface PermissionState {
  * ```
  */
 export function useCameraPermission(): PermissionState {
-  const [hasPermission, setHasPermission] = useState(false)
+  const [hasPermission, setHasPermission] = useState(() => Camera.getCameraPermissionStatus() === 'granted')
 
   const requestPermission = useCallback(async () => {
     const result = await Camera.requestCameraPermission()
     const hasPermissionNow = result === 'granted'
     setHasPermission(hasPermissionNow)
     return hasPermissionNow
-  }, [])
-
-  useEffect(() => {
-    Camera.getCameraPermissionStatus().then((s) => setHasPermission(s === 'granted'))
   }, [])
 
   return {
@@ -65,17 +61,13 @@ export function useCameraPermission(): PermissionState {
  * ```
  */
 export function useMicrophonePermission(): PermissionState {
-  const [hasPermission, setHasPermission] = useState(false)
+  const [hasPermission, setHasPermission] = useState(() => Camera.getMicrophonePermissionStatus() === 'granted')
 
   const requestPermission = useCallback(async () => {
     const result = await Camera.requestMicrophonePermission()
     const hasPermissionNow = result === 'granted'
     setHasPermission(hasPermissionNow)
     return hasPermissionNow
-  }, [])
-
-  useEffect(() => {
-    Camera.getMicrophonePermissionStatus().then((s) => setHasPermission(s === 'granted'))
   }, [])
 
   return {


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Makes `Camera.getCameraPermissionStatus()` and `Camera.getMicrophonePermissionStatus()` synchronous.

The benefit is that the permission status will be immediately available and there is no loading state anymore.

Before:

```tsx
function App() {
  const [cameraPermission, setCameraPermission] = useState<CameraPermissionStatus>()
  const [microphonePermission, setMicrophonePermission] = useState<CameraPermissionStatus>()

  useEffect(() => {
    Camera.getCameraPermissionStatus().then(setCameraPermission)
    Camera.getMicrophonePermissionStatus().then(setMicrophonePermission)
  }, [])


  if (cameraPermission == null || microphonePermission == null) {
    // still loading
    return null
  }

  // now we can actually check if we have permission or not
}
```

After:

```tsx
function App() {
  const cameraPermission = Camera.getCameraPermissionStatus()
  const microphonePermission = Camera.getMicrophonePermissionStatus()

  // now we can actually check if we have permission or not
}
```

(or wrap it in `useMemo` to prevent it from being called a lot)

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

- **BREAKING:** Change return type of `Camera.getCameraPermissionStatus()`: From `Promise<CameraPermissionStatus>` to `CameraPermissionStatus`
- **BREAKING:** Change return type of `Camera.getMicrophonePermissionStatus()`: From `Promise<CameraPermissionStatus>` to `CameraPermissionStatus`

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
