### PR TITLE
fix: Allow 60+ FPS on Samsung phones

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -15,7 +15,6 @@ import android.hardware.camera2.params.MeteringRectangle
 import android.hardware.camera2.params.OutputConfiguration
 import android.media.Image
 import android.media.ImageReader
-import android.os.Build
 import android.util.Log
 import android.util.Range
 import android.util.Size
@@ -58,9 +57,6 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
   CoroutineScope {
   companion object {
     private const val TAG = "CameraSession"
-
-    // TODO: Samsung advertises 60 FPS but only allows 30 FPS for some reason.
-    private val CAN_DO_60_FPS = !Build.MANUFACTURER.equals("samsung", true)
   }
 
   // Camera Configuration
@@ -417,12 +413,8 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
     // Set FPS
     // TODO: Check if the FPS range is actually supported in the current configuration.
-    var fps = config.fps
+    val fps = config.fps
     if (fps != null) {
-      if (!CAN_DO_60_FPS) {
-        // If we can't do 60 FPS, we clamp it to 30 FPS - that's always supported.
-        fps = 30.coerceAtMost(fps)
-      }
       captureRequest.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Range(fps, fps))
     }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Newer Samsung phones such as the Samsung S21 actually support third party 60 FPS or higher.

This PR removes the lock we had that disabled 60 FPS on Samsung devices, so now we can do more than that.

If you are trying to use 60 FPS on an older Samsung where it does not work, you might see a blackscreen. This is Samsung's fault, because they report 60 FPS as supported but then simply don't open the Camera when you try to use 60 FPS - so in that case please report a bug with the exact device model so we can disable 60 FPS for those specific devices. 

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

- Samsung S21

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
