### PR TITLE
fix: Fix for inset of SENSOR_INFO_ACTIVE_ARRAY_SIZE for Android < 11

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/extensions/Rect+zoomed.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/Rect+zoomed.kt
@@ -5,9 +5,9 @@ import android.graphics.Rect
 fun Rect.zoomed(zoomFactor: Float): Rect {
   val dx = (width() / zoomFactor / 2).toInt()
   val dy = (height() / zoomFactor / 2).toInt()
-  val left = centerX() - dx
-  val top = centerY() - dy
-  val right = centerX() + dx
-  val bottom = centerY() + dy
+  val left = centerX() - this.left - dx
+  val top = centerY() - this.top - dy
+  val right = centerX() - this.left + dx
+  val bottom = centerY() - this.top + dy
   return Rect(left, top, right, bottom)
 }


### PR DESCRIPTION
## What
On my Nokia 7.1 the SENSOR_INFO_ACTIVE_ARRAY_SIZE rect has an offset of 8px (Rect(8, 8 - 4040, 3032)).
This leads to a camera disconnect if the codeScanner is used.

## Changes
This PR just subtracts the left and top offset so that the new rect starts at 0,0.

## Tested on
Nokia 7.1, Android 10

## Related issues
Possible fix for: #2257 
