### PR TITLE
fix: Fix accessing `Frame` from multiple Threads by making it Thread-safe

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
@@ -78,7 +78,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
       auto width = this->frame->getWidth();
       auto height = this->frame->getHeight();
       auto format = this->frame->getPixelFormat();
-      auto str = std::to_string(width) + " x " + std::to_string(height) + " " + format->toString() + " Frame";
+      auto formatString = format->getUnionValue();
+      auto str = std::to_string(width) + " x " + std::to_string(height) + " " + formatString->toString() + " Frame";
       return jsi::String::createFromUtf8(runtime, str);
     };
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "toString"), 0, toString);
@@ -142,11 +143,13 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     return jsi::Value(this->frame->getIsMirrored());
   }
   if (name == "orientation") {
-    auto string = this->frame->getOrientation();
+    auto orientation = this->frame->getOrientation();
+    auto string = orientation->getUnionValue();
     return jsi::String::createFromUtf8(runtime, string->toStdString());
   }
   if (name == "pixelFormat") {
-    auto string = this->frame->getPixelFormat();
+    auto pixelFormat = this->frame->getPixelFormat();
+    auto string = pixelFormat->getUnionValue();
     return jsi::String::createFromUtf8(runtime, string->toStdString());
   }
   if (name == "timestamp") {

--- a/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
@@ -77,7 +77,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
       }
       auto width = this->frame->getWidth();
       auto height = this->frame->getHeight();
-      auto str = std::to_string(width) + " x " + std::to_string(height) + " Frame";
+      auto format = this->frame->getPixelFormat();
+      auto str = std::to_string(width) + " x " + std::to_string(height) + " " + format->toString() + " Frame";
       return jsi::String::createFromUtf8(runtime, str);
     };
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "toString"), 0, toString);

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
@@ -4,10 +4,10 @@
 
 #include "JFrame.h"
 
+#include "JOrientation.h"
+#include "JPixelFormat.h"
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#include "JPixelFormat.h"
-#include "JOrientation.h"
 
 #include <android/hardware_buffer_jni.h>
 

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
@@ -77,9 +77,4 @@ void JFrame::decrementRefCount() {
   decrementRefCountMethod(self());
 }
 
-void JFrame::close() {
-  static const auto closeMethod = getClass()->getMethod<void()>("close");
-  closeMethod(self());
-}
-
 } // namespace vision

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.cpp
@@ -6,6 +6,8 @@
 
 #include <fbjni/fbjni.h>
 #include <jni.h>
+#include "JPixelFormat.h"
+#include "JOrientation.h"
 
 #include <android/hardware_buffer_jni.h>
 
@@ -39,13 +41,13 @@ jlong JFrame::getTimestamp() const {
   return getTimestampMethod(self());
 }
 
-local_ref<JString> JFrame::getOrientation() const {
-  static const auto getOrientationMethod = getClass()->getMethod<JString()>("getOrientation");
+local_ref<JOrientation> JFrame::getOrientation() const {
+  static const auto getOrientationMethod = getClass()->getMethod<JOrientation()>("getOrientation");
   return getOrientationMethod(self());
 }
 
-local_ref<JString> JFrame::getPixelFormat() const {
-  static const auto getPixelFormatMethod = getClass()->getMethod<JString()>("getPixelFormat");
+local_ref<JPixelFormat> JFrame::getPixelFormat() const {
+  static const auto getPixelFormatMethod = getClass()->getMethod<JPixelFormat()>("getPixelFormat");
   return getPixelFormatMethod(self());
 }
 

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "JOrientation.h"
+#include "JPixelFormat.h"
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#include "JPixelFormat.h"
-#include "JOrientation.h"
 
 #include <android/hardware_buffer.h>
 

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
@@ -33,7 +33,6 @@ public:
 
   void incrementRefCount();
   void decrementRefCount();
-  void close();
 };
 
 } // namespace vision

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrame.h
@@ -6,6 +6,8 @@
 
 #include <fbjni/fbjni.h>
 #include <jni.h>
+#include "JPixelFormat.h"
+#include "JOrientation.h"
 
 #include <android/hardware_buffer.h>
 
@@ -25,8 +27,8 @@ public:
   int getPlanesCount() const;
   int getBytesPerRow() const;
   jlong getTimestamp() const;
-  local_ref<JString> getOrientation() const;
-  local_ref<JString> getPixelFormat() const;
+  local_ref<JOrientation> getOrientation() const;
+  local_ref<JPixelFormat> getPixelFormat() const;
 #if __ANDROID_API__ >= 26
   AHardwareBuffer* getHardwareBuffer() const;
 #endif

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JJSUnionValue.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JJSUnionValue.h
@@ -12,13 +12,13 @@ namespace vision {
 using namespace facebook;
 using namespace jni;
 
-struct JJSUnionValue: public JavaClass<JJSUnionValue> {
-    static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/JSUnionValue;";
+struct JJSUnionValue : public JavaClass<JJSUnionValue> {
+  static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/JSUnionValue;";
 
-    local_ref<JString> getUnionValue() {
-        const auto getUnionValueMethod = getClass()->getMethod<JString()>("getUnionValue");
-        return getUnionValueMethod(self());
-    }
+  local_ref<JString> getUnionValue() {
+    const auto getUnionValueMethod = getClass()->getMethod<JString()>("getUnionValue");
+    return getUnionValueMethod(self());
+  }
 };
 
 } // namespace vision

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JJSUnionValue.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JJSUnionValue.h
@@ -1,0 +1,24 @@
+//
+// Created by Marc Rousavy on 29.12.23.
+//
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jni.h>
+
+namespace vision {
+
+using namespace facebook;
+using namespace jni;
+
+struct JJSUnionValue: public JavaClass<JJSUnionValue> {
+    static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/JSUnionValue;";
+
+    local_ref<JString> getUnionValue() {
+        const auto getUnionValueMethod = getClass()->getMethod<JString()>("getUnionValue");
+        return getUnionValueMethod(self());
+    }
+};
+
+} // namespace vision

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JOrientation.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JOrientation.h
@@ -1,0 +1,20 @@
+//
+// Created by Marc Rousavy on 29.12.23.
+//
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jni.h>
+#include "JJSUnionValue.h"
+
+namespace vision {
+
+using namespace facebook;
+using namespace jni;
+
+struct JOrientation: public JavaClass<JOrientation, JJSUnionValue> {
+    static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/Orientation;";
+};
+
+} // namespace vision

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JOrientation.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JOrientation.h
@@ -4,17 +4,17 @@
 
 #pragma once
 
+#include "JJSUnionValue.h"
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#include "JJSUnionValue.h"
 
 namespace vision {
 
 using namespace facebook;
 using namespace jni;
 
-struct JOrientation: public JavaClass<JOrientation, JJSUnionValue> {
-    static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/Orientation;";
+struct JOrientation : public JavaClass<JOrientation, JJSUnionValue> {
+  static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/Orientation;";
 };
 
 } // namespace vision

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JPixelFormat.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JPixelFormat.h
@@ -1,0 +1,20 @@
+//
+// Created by Marc Rousavy on 29.12.23.
+//
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jni.h>
+#include "JJSUnionValue.h"
+
+namespace vision {
+
+using namespace facebook;
+using namespace jni;
+
+struct JPixelFormat: public JavaClass<JPixelFormat, JJSUnionValue> {
+    static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/PixelFormat;";
+};
+
+} // namespace vision

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JPixelFormat.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JPixelFormat.h
@@ -4,17 +4,17 @@
 
 #pragma once
 
+#include "JJSUnionValue.h"
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#include "JJSUnionValue.h"
 
 namespace vision {
 
 using namespace facebook;
 using namespace jni;
 
-struct JPixelFormat: public JavaClass<JPixelFormat, JJSUnionValue> {
-    static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/PixelFormat;";
+struct JPixelFormat : public JavaClass<JPixelFormat, JJSUnionValue> {
+  static constexpr auto kJavaDescriptor = "Lcom/mrousavy/camera/types/PixelFormat;";
 };
 
 } // namespace vision

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
@@ -82,15 +82,14 @@ public class Frame {
 
     @SuppressWarnings("unused")
     @DoNotStrip
-    public String getOrientation() {
-        return orientation.getUnionValue();
+    public Orientation getOrientation() {
+        return orientation;
     }
 
     @SuppressWarnings("unused")
     @DoNotStrip
-    public String getPixelFormat() {
-        PixelFormat format = PixelFormat.Companion.fromImageFormat(getImage().getFormat());
-        return format.getUnionValue();
+    public PixelFormat getPixelFormat() {
+        return PixelFormat.Companion.fromImageFormat(getImage().getFormat());
     }
 
     @SuppressWarnings("unused")

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
@@ -7,6 +7,7 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.mrousavy.camera.core.HardwareBuffersNotAvailableError;
 import com.mrousavy.camera.types.PixelFormat;
 import com.mrousavy.camera.types.Orientation;
+import java.lang.IllegalStateException;
 
 public class Frame {
     private final Image image;
@@ -24,30 +25,40 @@ public class Frame {
     }
 
     public Image getImage() {
-        return image;
+        synchronized (this) {
+            Image img = image;
+            if (!getIsImageValid(img)) {
+                throw new RuntimeException("Frame is already closed! Are you trying to access the Image data outside of a Frame Processor's lifetime? If yes, increment it's ref-count: `frame.incrementRefCount()`");
+            }
+            return img;
+        }
     }
 
     @SuppressWarnings("unused")
     @DoNotStrip
     public int getWidth() {
-        return image.getWidth();
+        return getImage().getWidth();
     }
 
     @SuppressWarnings("unused")
     @DoNotStrip
     public int getHeight() {
-        return image.getHeight();
+        return getImage().getHeight();
     }
 
     @SuppressWarnings("unused")
     @DoNotStrip
     public boolean getIsValid() {
+        return getIsImageValid(getImage());
+    }
+
+    private boolean getIsImageValid(Image image) {
         try {
             // will throw an exception if the image is already closed
-            image.getCropRect();
+            image.getFormat();
             // no exception thrown, image must still be valid.
             return true;
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             // exception thrown, image has already been closed.
             return false;
         }
@@ -74,20 +85,20 @@ public class Frame {
     @SuppressWarnings("unused")
     @DoNotStrip
     public String getPixelFormat() {
-        PixelFormat format = PixelFormat.Companion.fromImageFormat(image.getFormat());
+        PixelFormat format = PixelFormat.Companion.fromImageFormat(getImage().getFormat());
         return format.getUnionValue();
     }
 
     @SuppressWarnings("unused")
     @DoNotStrip
     public int getPlanesCount() {
-        return image.getPlanes().length;
+        return getImage().getPlanes().length;
     }
 
     @SuppressWarnings("unused")
     @DoNotStrip
     public int getBytesPerRow() {
-        return image.getPlanes()[0].getRowStride();
+        return getImage().getPlanes()[0].getRowStride();
     }
 
     @SuppressWarnings("unused")
@@ -101,7 +112,7 @@ public class Frame {
             throw new HardwareBuffersNotAvailableError();
         }
         if (hardwareBuffer == null) {
-            hardwareBuffer = image.getHardwareBuffer();
+            hardwareBuffer = getImage().getHardwareBuffer();
         }
         return hardwareBuffer;
     }
@@ -121,17 +132,17 @@ public class Frame {
             refCount--;
             if (refCount <= 0) {
                 // If no reference is held on this Image, close it.
-                image.close();
+                close();
             }
         }
     }
 
-    @SuppressWarnings("unused")
-    @DoNotStrip
-    private void close() {
-        if (hardwareBuffer != null) {
-            hardwareBuffer.close();
+    private synchronized void close() {
+        synchronized (this) {
+            if (hardwareBuffer != null) {
+                hardwareBuffer.close();
+            }
+            image.close();
         }
-        image.close();
     }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
@@ -28,7 +28,9 @@ public class Frame {
         synchronized (this) {
             Image img = image;
             if (!getIsImageValid(img)) {
-                throw new RuntimeException("Frame is already closed! Are you trying to access the Image data outside of a Frame Processor's lifetime? If yes, increment it's ref-count: `frame.incrementRefCount()`");
+                throw new RuntimeException("Frame is already closed! " +
+                    "Are you trying to access the Image data outside of a Frame Processor's lifetime? " +
+                    "If yes, increment it's ref-count: `frame.incrementRefCount()`");
             }
             return img;
         }

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
@@ -29,8 +29,10 @@ public class Frame {
             Image img = image;
             if (!getIsImageValid(img)) {
                 throw new RuntimeException("Frame is already closed! " +
-                    "Are you trying to access the Image data outside of a Frame Processor's lifetime? " +
-                    "If yes, increment it's ref-count: `frame.incrementRefCount()`");
+                    "Are you trying to access the Image data outside of a Frame Processor's lifetime?\n" +
+                    "- If you want to use `console.log(frame)`, use `console.log(frame.toString())` instead.\n" +
+                    "- If you want to do async processing, use `runAsync(...)` instead.\n" +
+                    "- If you want to use runOnJS, increment it's ref-count: `frame.incrementRefCount()`");
             }
             return img;
         }

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
@@ -59,7 +59,7 @@ public class Frame {
     private boolean getIsImageValid(Image image) {
         try {
             // will throw an exception if the image is already closed
-            image.getFormat();
+            synchronized (this) { image.getFormat(); }
             // no exception thrown, image must still be valid.
             return true;
         } catch (IllegalStateException e) {

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -484,7 +484,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (3.6.16):
+  - VisionCamera (3.6.17):
     - React
     - React-callinvoker
     - React-Core
@@ -724,9 +724,9 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 06f5b990082ec783a58dcadc5bac677974f7a580
+  VisionCamera: 361df29347b7b7ecc47b3d173daa17751a11ffc1
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: 27f53791141a3303d814e09b55770336416ff4eb
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.14.3

--- a/package/ios/Frame Processor/Frame.h
+++ b/package/ios/Frame Processor/Frame.h
@@ -19,14 +19,14 @@
 @property(nonatomic, readonly) CMSampleBufferRef _Nonnull buffer;
 
 // Getters
-- (NSString* _Nonnull) pixelFormat;
-- (NSString* _Nonnull) orientation;
-- (BOOL) isMirrored;
-- (BOOL) isValid;
-- (size_t) width;
-- (size_t) height;
-- (double) timestamp;
-- (size_t) bytesPerRow;
-- (size_t) planesCount;
+- (NSString* _Nonnull)pixelFormat;
+- (NSString* _Nonnull)orientation;
+- (BOOL)isMirrored;
+- (BOOL)isValid;
+- (size_t)width;
+- (size_t)height;
+- (double)timestamp;
+- (size_t)bytesPerRow;
+- (size_t)planesCount;
 
 @end

--- a/package/ios/Frame Processor/Frame.h
+++ b/package/ios/Frame Processor/Frame.h
@@ -17,6 +17,16 @@
 - (instancetype _Nonnull)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation;
 
 @property(nonatomic, readonly) CMSampleBufferRef _Nonnull buffer;
-@property(nonatomic, readonly) UIImageOrientation orientation;
+
+// Getters
+- (NSString* _Nonnull) pixelFormat;
+- (NSString* _Nonnull) orientation;
+- (BOOL) isMirrored;
+- (BOOL) isValid;
+- (size_t) width;
+- (size_t) height;
+- (double) timestamp;
+- (size_t) bytesPerRow;
+- (size_t) planesCount;
 
 @end

--- a/package/ios/Frame Processor/Frame.h
+++ b/package/ios/Frame Processor/Frame.h
@@ -17,10 +17,10 @@
 - (instancetype _Nonnull)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation;
 
 @property(nonatomic, readonly) CMSampleBufferRef _Nonnull buffer;
+@property(nonatomic, readonly) UIImageOrientation orientation;
 
 // Getters
 - (NSString* _Nonnull)pixelFormat;
-- (NSString* _Nonnull)orientation;
 - (BOOL)isMirrored;
 - (BOOL)isValid;
 - (size_t)width;

--- a/package/ios/Frame Processor/Frame.m
+++ b/package/ios/Frame Processor/Frame.m
@@ -12,7 +12,7 @@
 
 @implementation Frame {
   CMSampleBufferRef _Nonnull buffer;
-  UIImageOrientation _orientation;
+  UIImageOrientation orientation;
 }
 
 - (instancetype)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation {
@@ -30,23 +30,7 @@
 }
 
 @synthesize buffer = _buffer;
-
-- (NSString*)orientation {
-  switch (_orientation) {
-    case UIImageOrientationUp:
-    case UIImageOrientationUpMirrored:
-      return @"portrait";
-    case UIImageOrientationDown:
-    case UIImageOrientationDownMirrored:
-      return @"portrait-upside-down";
-    case UIImageOrientationLeft:
-    case UIImageOrientationLeftMirrored:
-      return @"landscape-left";
-    case UIImageOrientationRight:
-    case UIImageOrientationRightMirrored:
-      return @"landscape-right";
-  }
-}
+@synthesize orientation = _orientation;
 
 - (NSString*)pixelFormat {
   CMFormatDescriptionRef format = CMSampleBufferGetFormatDescription(_buffer);

--- a/package/ios/Frame Processor/Frame.m
+++ b/package/ios/Frame Processor/Frame.m
@@ -31,7 +31,7 @@
 
 @synthesize buffer = _buffer;
 
-- (NSString*) orientation {
+- (NSString*)orientation {
   switch (_orientation) {
     case UIImageOrientationUp:
     case UIImageOrientationUpMirrored:
@@ -48,7 +48,7 @@
   }
 }
 
-- (NSString*) pixelFormat {
+- (NSString*)pixelFormat {
   CMFormatDescriptionRef format = CMSampleBufferGetFormatDescription(_buffer);
   FourCharCode mediaType = CMFormatDescriptionGetMediaSubType(format);
   switch (mediaType) {
@@ -68,7 +68,7 @@
   }
 }
 
-- (BOOL) isMirrored {
+- (BOOL)isMirrored {
   switch (_orientation) {
     case UIImageOrientationUp:
     case UIImageOrientationDown:
@@ -83,31 +83,31 @@
   }
 }
 
-- (BOOL) isValid {
+- (BOOL)isValid {
   return _buffer != nil && CMSampleBufferIsValid(_buffer);
 }
 
-- (size_t) width {
+- (size_t)width {
   CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
   return CVPixelBufferGetWidth(imageBuffer);
 }
 
-- (size_t) height {
+- (size_t)height {
   CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
   return CVPixelBufferGetHeight(imageBuffer);
 }
 
-- (double) timestamp {
+- (double)timestamp {
   CMTime timestamp = CMSampleBufferGetPresentationTimeStamp(_buffer);
   return CMTimeGetSeconds(timestamp) * 1000.0;
 }
 
-- (size_t) bytesPerRow {
+- (size_t)bytesPerRow {
   CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
   return CVPixelBufferGetBytesPerRow(imageBuffer);
 }
 
-- (size_t) planesCount {
+- (size_t)planesCount {
   CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
   return CVPixelBufferGetPlaneCount(imageBuffer);
 }

--- a/package/ios/Frame Processor/Frame.m
+++ b/package/ios/Frame Processor/Frame.m
@@ -12,7 +12,7 @@
 
 @implementation Frame {
   CMSampleBufferRef _Nonnull buffer;
-  UIImageOrientation orientation;
+  UIImageOrientation _orientation;
 }
 
 - (instancetype)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation {
@@ -30,6 +30,86 @@
 }
 
 @synthesize buffer = _buffer;
-@synthesize orientation = _orientation;
+
+- (NSString*) orientation {
+  switch (_orientation) {
+    case UIImageOrientationUp:
+    case UIImageOrientationUpMirrored:
+      return @"portrait";
+    case UIImageOrientationDown:
+    case UIImageOrientationDownMirrored:
+      return @"portrait-upside-down";
+    case UIImageOrientationLeft:
+    case UIImageOrientationLeftMirrored:
+      return @"landscape-left";
+    case UIImageOrientationRight:
+    case UIImageOrientationRightMirrored:
+      return @"landscape-right";
+  }
+}
+
+- (NSString*) pixelFormat {
+  CMFormatDescriptionRef format = CMSampleBufferGetFormatDescription(_buffer);
+  FourCharCode mediaType = CMFormatDescriptionGetMediaSubType(format);
+  switch (mediaType) {
+    case kCVPixelFormatType_32BGRA:
+    case kCVPixelFormatType_Lossy_32BGRA:
+      return @"rgb";
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarVideoRange:
+      return @"yuv";
+    default:
+      return @"unknown";
+  }
+}
+
+- (BOOL) isMirrored {
+  switch (_orientation) {
+    case UIImageOrientationUp:
+    case UIImageOrientationDown:
+    case UIImageOrientationLeft:
+    case UIImageOrientationRight:
+      return false;
+    case UIImageOrientationDownMirrored:
+    case UIImageOrientationUpMirrored:
+    case UIImageOrientationLeftMirrored:
+    case UIImageOrientationRightMirrored:
+      return true;
+  }
+}
+
+- (BOOL) isValid {
+  return _buffer != nil && CMSampleBufferIsValid(_buffer);
+}
+
+- (size_t) width {
+  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
+  return CVPixelBufferGetWidth(imageBuffer);
+}
+
+- (size_t) height {
+  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
+  return CVPixelBufferGetHeight(imageBuffer);
+}
+
+- (double) timestamp {
+  CMTime timestamp = CMSampleBufferGetPresentationTimeStamp(_buffer);
+  return CMTimeGetSeconds(timestamp) * 1000.0;
+}
+
+- (size_t) bytesPerRow {
+  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
+  return CVPixelBufferGetBytesPerRow(imageBuffer);
+}
+
+- (size_t) planesCount {
+  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
+  return CVPixelBufferGetPlaneCount(imageBuffer);
+}
 
 @end

--- a/package/ios/Frame Processor/Frame.m
+++ b/package/ios/Frame Processor/Frame.m
@@ -20,8 +20,13 @@
   if (self) {
     _buffer = buffer;
     _orientation = orientation;
+    CFRetain(buffer);
   }
   return self;
+}
+
+- (void)dealloc {
+  CFRelease(_buffer);
 }
 
 @synthesize buffer = _buffer;

--- a/package/ios/Frame Processor/FrameHostObject.h
+++ b/package/ios/Frame Processor/FrameHostObject.h
@@ -28,5 +28,9 @@ public:
   Frame* frame;
   
 private:
+  Frame* getFrame();
+  
+private:
   std::mutex _mutex;
+  size_t _refCount = 0;
 };

--- a/package/ios/Frame Processor/FrameHostObject.h
+++ b/package/ios/Frame Processor/FrameHostObject.h
@@ -26,10 +26,10 @@ public:
 
 public:
   Frame* frame;
-  
+
 private:
   Frame* getFrame();
-  
+
 private:
   std::mutex _mutex;
   size_t _refCount = 0;

--- a/package/ios/Frame Processor/FrameHostObject.h
+++ b/package/ios/Frame Processor/FrameHostObject.h
@@ -10,6 +10,7 @@
 
 #import <CoreMedia/CMSampleBuffer.h>
 #import <jsi/jsi.h>
+#import <mutex>
 
 #import "Frame.h"
 
@@ -25,4 +26,7 @@ public:
 
 public:
   Frame* frame;
+  
+private:
+  std::mutex _mutex;
 };

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -153,14 +153,14 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "orientation") {
     // Lock Frame so it cannot be deallocated while we access it
     std::lock_guard lock(this->_mutex);
-    
+
     Frame* frame = this->getFrame();
     return jsi::String::createFromUtf8(runtime, frame.orientation.UTF8String);
   }
   if (name == "isMirrored") {
     // Lock Frame so it cannot be deallocated while we access it
     std::lock_guard lock(this->_mutex);
-    
+
     Frame* frame = this->getFrame();
     return jsi::Value(frame.isMirrored);
   }

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -7,10 +7,10 @@
 //
 
 #import "FrameHostObject.h"
+#import "UIImageOrientation+descriptor.h"
 #import "WKTJsiHostObject.h"
 #import <Foundation/Foundation.h>
 #import <jsi/jsi.h>
-#import "UIImageOrientation+descriptor.h"
 
 #import "../../cpp/JSITypedArray.h"
 

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -37,8 +37,11 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
 Frame* FrameHostObject::getFrame() {
   Frame* frame = this->frame;
   if (frame == nil || !CMSampleBufferIsValid(frame.buffer)) {
-    throw std::runtime_error("Frame is already closed! Are you trying to access the Image data outside of a Frame Processor's lifetime? "
-                             "If yes, increment it's ref-count: `frame.incrementRefCount()`");
+    throw std::runtime_error("Frame is already closed! "
+                             "Are you trying to access the Image data outside of a Frame Processor's lifetime?\n"
+                             "- If you want to use `console.log(frame)`, use `console.log(frame.toString())` instead.\n"
+                             "- If you want to do async processing, use `runAsync(...)` instead.\n"
+                             "- If you want to use runOnJS, increment it's ref-count: `frame.incrementRefCount()`");
   }
   return frame;
 }

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -47,9 +47,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   auto name = propName.utf8(runtime);
 
   if (name == "toString") {
-    auto toString = [this](jsi::Runtime & runtime,
-                           const jsi::Value &thisValue,
-                           const jsi::Value *arguments, size_t count) -> jsi::Value {
+    auto toString = [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
       // Lock Frame so it cannot be deallocated while we access it
       std::lock_guard lock(this->_mutex);
 
@@ -65,9 +63,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "toString"), 0, toString);
   }
   if (name == "incrementRefCount") {
-    auto incrementRefCount = [this](jsi::Runtime & runtime,
-                                    const jsi::Value &thisValue,
-                                    const jsi::Value *arguments, size_t count) -> jsi::Value {
+    auto incrementRefCount = [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
+                                    size_t count) -> jsi::Value {
       // Lock Frame so it cannot be deallocated while we access it
       std::lock_guard lock(this->_mutex);
 
@@ -78,9 +75,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "incrementRefCount"), 0, incrementRefCount);
   }
   if (name == "decrementRefCount") {
-    auto decrementRefCount = [this](jsi::Runtime & runtime,
-                                    const jsi::Value &thisValue,
-                                    const jsi::Value *arguments, size_t count) -> jsi::Value {
+    auto decrementRefCount = [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
+                                    size_t count) -> jsi::Value {
       // Lock Frame so it cannot be deallocated while we access it
       std::lock_guard lock(this->_mutex);
 
@@ -96,9 +92,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "decrementRefCount"), 0, decrementRefCount);
   }
   if (name == "toArrayBuffer") {
-    auto toArrayBuffer = [this](jsi::Runtime & runtime,
-                                const jsi::Value &thisValue,
-                                const jsi::Value *arguments, size_t count) -> jsi::Value {
+    auto toArrayBuffer = [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
+                                size_t count) -> jsi::Value {
       // Lock Frame so it cannot be deallocated while we access it
       std::lock_guard lock(this->_mutex);
 

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -10,6 +10,7 @@
 #import "WKTJsiHostObject.h"
 #import <Foundation/Foundation.h>
 #import <jsi/jsi.h>
+#import "UIImageOrientation+descriptor.h"
 
 #import "../../cpp/JSITypedArray.h"
 
@@ -155,7 +156,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     std::lock_guard lock(this->_mutex);
 
     Frame* frame = this->getFrame();
-    return jsi::String::createFromUtf8(runtime, frame.orientation.UTF8String);
+    NSString* orientation = [NSString stringWithParsed:frame.orientation];
+    return jsi::String::createFromUtf8(runtime, orientation.UTF8String);
   }
   if (name == "isMirrored") {
     // Lock Frame so it cannot be deallocated while we access it

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -127,7 +127,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     // Lock Frame so it cannot be deallocated while we access it
     std::lock_guard lock(this->_mutex);
     
-    auto isValid = frame != nil && frame.buffer != nil && CFGetRetainCount(frame.buffer) > 0 && CMSampleBufferIsValid(frame.buffer);
+    auto isValid = frame != nil && frame.buffer != nil && CMSampleBufferIsValid(frame.buffer);
     return jsi::Value(isValid);
   }
   if (name == "width") {

--- a/package/ios/Frame Processor/UIImageOrientation+descriptor.h
+++ b/package/ios/Frame Processor/UIImageOrientation+descriptor.h
@@ -1,0 +1,39 @@
+//
+//  UIImageOrientation+descriptor.h
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 29.12.23.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIImage.h>
+
+@interface NSString (UIImageOrientationJSDescriptor)
+
++ (NSString*) stringWithParsed:(UIImageOrientation)orientation;
+
+@end
+
+@implementation UIImageOrientation
+
++ (NSString*) stringWithParsed:(UIImageOrientation)orientation {
+  switch (orientation) {
+    case UIImageOrientationUp:
+    case UIImageOrientationUpMirrored:
+      return @"portrait";
+    case UIImageOrientationDown:
+    case UIImageOrientationDownMirrored:
+      return @"portrait-upside-down";
+    case UIImageOrientationLeft:
+    case UIImageOrientationLeftMirrored:
+      return @"landscape-left";
+    case UIImageOrientationRight:
+    case UIImageOrientationRightMirrored:
+      return @"landscape-right";
+  }
+}
+
+@end

--- a/package/ios/Frame Processor/UIImageOrientation+descriptor.h
+++ b/package/ios/Frame Processor/UIImageOrientation+descriptor.h
@@ -13,13 +13,13 @@
 
 @interface NSString (UIImageOrientationJSDescriptor)
 
-+ (NSString*) stringWithParsed:(UIImageOrientation)orientation;
++ (NSString*)stringWithParsed:(UIImageOrientation)orientation;
 
 @end
 
-@implementation UIImageOrientation
+@implementation NSString (UIImageOrientationJSDescriptor)
 
-+ (NSString*) stringWithParsed:(UIImageOrientation)orientation {
++ (NSString*)stringWithParsed:(UIImageOrientation)orientation {
   switch (orientation) {
     case UIImageOrientationUp:
     case UIImageOrientationUpMirrored:

--- a/package/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/package/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		B887518425E0102000DB86D6 /* CameraView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		B88873E5263D46C7008B1D0E /* FrameProcessorPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameProcessorPlugin.h; sourceTree = "<group>"; };
 		B8994E6B263F03E100069589 /* JSINSObjectConversion.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSINSObjectConversion.mm; sourceTree = "<group>"; };
+		B89A79692B3EF60F005E0357 /* UIImageOrientation+descriptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImageOrientation+descriptor.h"; sourceTree = "<group>"; };
 		B8A1AEC32AD7EDE800169C0D /* AVCaptureVideoDataOutput+pixelFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureVideoDataOutput+pixelFormat.swift"; sourceTree = "<group>"; };
 		B8A1AEC52AD7F08E00169C0D /* CameraView+Focus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CameraView+Focus.swift"; sourceTree = "<group>"; };
 		B8A1AEC72AD8005400169C0D /* CameraSession+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CameraSession+Configuration.swift"; sourceTree = "<group>"; };
@@ -334,6 +335,7 @@
 				B81D41EF263C86F900B041FD /* JSINSObjectConversion.h */,
 				B8994E6B263F03E100069589 /* JSINSObjectConversion.mm */,
 				B85F7AE82A77BB680089C539 /* FrameProcessorPlugin.m */,
+				B89A79692B3EF60F005E0357 /* UIImageOrientation+descriptor.h */,
 			);
 			path = "Frame Processor";
 			sourceTree = "<group>";


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Accessing `Frame` from multiple Threads was unsafe. The Frame could've been deallocated by now.

With this PR, we check if the Frame is still valid and execute all unsafe methods under a `synchronized` block/Lock to make sure the app doesn't crash with null-unwrap errors.

### `frame.isValid`

The only property that will not throw when trying to access a closed frame is `isValid`:

```ts
console.log(frame.isValid)
```
```
false
```

 If you access any other property (e.g. `width`) on a closed Frame, it will throw an error:

```ts
console.log(frame.width)
```
```
Error: Exception in HostObject::get for prop 'width': Frame is already closed! Are you trying to access the Image data outside of a Frame Processor's lifetime? If yes, increment it's ref-count: `frame.incrementRefCount()`, js engine: hermes
```

### `console.log(frame)`

Since `console.log` is a function defined on the JS Thread only, calling it inside a Frame Processor will require a Thread hop - essentially doing a `runOnJS`/`Worklets.createRunInJSFunc`. When you pass the `frame` to that function, it will transfer the Frame over to the JS Thread, and try to log the properties of the Frame later. The problem here is, that by the time the `console.log` function tries to log the `frame`, the `frame` will already be deallocated since the Frame Processor has already finished it's execution in the meantime and a new Frame arrives.

So this will throw an error:

```ts
console.log(frame)
```

Because the frame will be no longer valid when `console.log` runs.

Instead, try this to debug Frames:

```ts
console.log(frame.toString())
```


### Java/Kotlin Changes

The Java/Kotlin `Frame` type brings two changes:

- `frame.orientation`: This is no longer just a `String`, but instead the actual type-safe `Orientation` enum. This improves developer experience for native Java/Kotlin Frame Processor Plugins
- `frame.pixelFormat`: This is no longer just a `String`, but instead the actual type-safe `PixelFormat` enum. This improves developer experience for native Java/Kotlin Frame Processor Plugins

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Resolves a debug issue in https://github.com/mrousavy/react-native-fast-tflite/issues/13

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
