### PR TITLE
fix: Fix iOS native `enableZoomGesture` zoom logic

### DIFF
--- a/package/ios/CameraView+Zoom.swift
+++ b/package/ios/CameraView+Zoom.swift
@@ -20,7 +20,7 @@ extension CameraView {
 
     // Update zoom React prop
     zoom = NSNumber(value: scale)
-    didSetProps(["zoom"])
+    didSetProps([])
   }
 
   func addPinchGestureRecognizer() {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

There was a bug since version `3.16.13` described in #2280.
The bug was there because, the call to `didSetProps(["zoom"])` was assigning `pinchGestureOffset` value all the time instead of mutating it only when the gesture ended.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

The simplest fix I could find was to pass an empty array to `didSetProps` which properly manages zoom value but does not change the `pinchGestureOffset` value. Like it already was, the `pinchGestureOffset` value is changed manually when the gesture recognizer enters `ended` state.

The fix is not very elegant, but for sure does the job. Since I don't know the whole codebase I would love any suggestions from you @mrousavy 

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

iPhone 13 with example app installed. I changed the code to not use reanimated for zoom, but used the `enableZoomGesture` prop instead.

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

Fixes #2280

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
