### PR TITLE
fix: Fix crash when trying to `console.log(frame)`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
@@ -90,14 +90,25 @@ data class CameraConfiguration(
     fun difference(left: CameraConfiguration?, right: CameraConfiguration): Difference {
       val deviceChanged = left?.cameraId != right.cameraId
 
-      val outputsChanged = deviceChanged || // input device
-        left?.photo != right.photo || left.video != right.video || left.codeScanner != right.codeScanner ||
-        left.preview != right.preview || // outputs
-        left.videoHdr != right.videoHdr || left.photoHdr != right.photoHdr || left.format != right.format // props that affect the outputs
+      val outputsChanged = deviceChanged ||
+        // input device
+        left?.photo != right.photo ||
+        left.video != right.video ||
+        left.codeScanner != right.codeScanner ||
+        left.preview != right.preview ||
+        // outputs
+        left.videoHdr != right.videoHdr ||
+        left.photoHdr != right.photoHdr ||
+        left.format != right.format // props that affect the outputs
 
-      val sidePropsChanged = outputsChanged || // depend on outputs
-        left?.torch != right.torch || left.enableLowLightBoost != right.enableLowLightBoost || left.fps != right.fps ||
-        left.zoom != right.zoom || left.videoStabilizationMode != right.videoStabilizationMode || left.isActive != right.isActive ||
+      val sidePropsChanged = outputsChanged ||
+        // depend on outputs
+        left?.torch != right.torch ||
+        left.enableLowLightBoost != right.enableLowLightBoost ||
+        left.fps != right.fps ||
+        left.zoom != right.zoom ||
+        left.videoStabilizationMode != right.videoStabilizationMode ||
+        left.isActive != right.isActive ||
         left.exposure != right.exposure
 
       val isActiveChanged = left?.isActive != right.isActive

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -16,21 +16,25 @@
 
 std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt) {
   std::vector<jsi::PropNameID> result;
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("width")));
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("height")));
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("bytesPerRow")));
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("planesCount")));
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("orientation")));
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("isMirrored")));
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("timestamp")));
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("pixelFormat")));
-  // Conversion
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toString")));
-  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toArrayBuffer")));
   // Ref Management
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("isValid")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("incrementRefCount")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("decrementRefCount")));
+  
+  if (frame != nil && frame.isValid) {
+    // Frame Properties
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("width")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("height")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("bytesPerRow")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("planesCount")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("orientation")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("isMirrored")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("timestamp")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("pixelFormat")));
+    // Conversion
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toString")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toArrayBuffer")));
+  }
 
   return result;
 }
@@ -53,29 +57,7 @@ Frame* FrameHostObject::getFrame() {
 
 jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {
   auto name = propName.utf8(runtime);
-
-  if (name == "toJSON") {
-    // Overrides `console.log(frame)` behaviour
-    auto toJSON = JSI_FUNC {
-      // Lock Frame so it cannot be deallocated while we access it
-      std::lock_guard lock(this->_mutex);
-
-      // Print debug description (width, height)
-      Frame* frame = this->frame;
-      jsi::Object object(runtime);
-      if (frame != nil && frame.isValid) {
-        object.setProperty(runtime, "width", frame.width);
-        object.setProperty(runtime, "height", frame.height);
-        object.setProperty(runtime, "pixelFormat", frame.pixelFormat);
-        object.setProperty(runtime, "orientation", frame.orientation);
-        object.setProperty(runtime, "isValid", true);
-      } else {
-        object.setProperty(runtime, "isValid", false);
-      }
-      return object;
-    };
-    return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "toJSON"), 0, toJSON);
-  }
+  
   if (name == "toString") {
     auto toString = JSI_FUNC {
       // Lock Frame so it cannot be deallocated while we access it

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -41,7 +41,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
 
 Frame* FrameHostObject::getFrame() {
   Frame* frame = this->frame;
-  if (frame == nil || !CMSampleBufferIsValid(frame.buffer)) {
+  if (frame == nil || !frame.isValid) {
     throw std::runtime_error("Frame is already closed! "
                              "Are you trying to access the Image data outside of a Frame Processor's lifetime?\n"
                              "- If you want to use `console.log(frame)`, use `console.log(frame.toString())` instead.\n"

--- a/package/ios/Frame Processor/FrameHostObject.mm
+++ b/package/ios/Frame Processor/FrameHostObject.mm
@@ -20,7 +20,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("isValid")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("incrementRefCount")));
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("decrementRefCount")));
-  
+
   if (frame != nil && frame.isValid) {
     // Frame Properties
     result.push_back(jsi::PropNameID::forUtf8(rt, std::string("width")));
@@ -51,13 +51,11 @@ Frame* FrameHostObject::getFrame() {
   return frame;
 }
 
-#define JSI_FUNC                                               \
-  [=](jsi::Runtime & runtime, const jsi::Value &thisValue,     \
-      const jsi::Value *arguments, size_t count) -> jsi::Value
+#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value
 
 jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {
   auto name = propName.utf8(runtime);
-  
+
   if (name == "toString") {
     auto toString = JSI_FUNC {
       // Lock Frame so it cannot be deallocated while we access it


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
