### PR TITLE
fix: Unwrap boxed JNI types directly

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/JSIJNIConversion.cpp
+++ b/package/android/src/main/cpp/frameprocessor/JSIJNIConversion.cpp
@@ -103,21 +103,18 @@ jsi::Value JSIJNIConversion::convertJNIObjectToJSIValue(jsi::Runtime& runtime, c
   } else if (object->isInstanceOf(jni::JBoolean::javaClassStatic())) {
     // Boolean
 
-    static const auto getBooleanFunc = jni::findClassLocal("java/lang/Boolean")->getMethod<jboolean()>("booleanValue");
-    auto boolean = getBooleanFunc(object.get());
-    return jsi::Value(boolean == true);
+    auto boxed = static_ref_cast<JBoolean>(object);
+    return jsi::Value(boxed->value());
   } else if (object->isInstanceOf(jni::JDouble::javaClassStatic())) {
     // Double
 
-    static const auto getDoubleFunc = jni::findClassLocal("java/lang/Double")->getMethod<jdouble()>("doubleValue");
-    auto d = getDoubleFunc(object.get());
-    return jsi::Value(d);
+    auto boxed = static_ref_cast<JDouble>(object);
+    return jsi::Value(boxed->value());
   } else if (object->isInstanceOf(jni::JInteger::javaClassStatic())) {
     // Integer
 
-    static const auto getIntegerFunc = jni::findClassLocal("java/lang/Integer")->getMethod<jint()>("intValue");
-    auto i = getIntegerFunc(object.get());
-    return jsi::Value(i);
+    auto boxed = static_ref_cast<JInteger>(object);
+    return jsi::Value(boxed->value());
   } else if (object->isInstanceOf(jni::JString::javaClassStatic())) {
     // String
 

--- a/package/android/src/main/cpp/frameprocessor/JSIJNIConversion.cpp
+++ b/package/android/src/main/cpp/frameprocessor/JSIJNIConversion.cpp
@@ -104,12 +104,14 @@ jsi::Value JSIJNIConversion::convertJNIObjectToJSIValue(jsi::Runtime& runtime, c
     // Boolean
 
     auto boxed = static_ref_cast<JBoolean>(object);
-    return jsi::Value(boxed->value());
+    bool value = boxed->value();
+    return jsi::Value(value);
   } else if (object->isInstanceOf(jni::JDouble::javaClassStatic())) {
     // Double
 
     auto boxed = static_ref_cast<JDouble>(object);
-    return jsi::Value(boxed->value());
+    double value = boxed->value();
+    return jsi::Value(value);
   } else if (object->isInstanceOf(jni::JInteger::javaClassStatic())) {
     // Integer
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Unwraps boxed JNI types directly using the `value()` method on `JBoolean`/`JInteger`/`JDouble`. Should make returning bools, ints, and doubles faster.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
