### PR TITLE
fix: Fix "maxImages (3) has already been acquired" error

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -298,7 +298,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
       val imageFormat = ImageFormat.JPEG
       val sizes = characteristics.getPhotoSizes(imageFormat)
       val size = sizes.closestToOrMax(format?.photoSize)
-      val maxImages = 3
+      val maxImages = 10
 
       Log.i(TAG, "Adding ${size.width} x ${size.height} Photo Output in Format #$imageFormat...")
       val imageReader = ImageReader.newInstance(size.width, size.height, imageFormat, maxImages)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2288 by increasing maxImages to 10, as 3 images could be quickly reached when capturing fast.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2288

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
