### PR TITLE
feat: Re-throw error on JS side instead of just logging on native side

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JFrameProcessor.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JFrameProcessor.cpp
@@ -36,22 +36,12 @@ void JFrameProcessor::callWithFrameHostObject(const std::shared_ptr<FrameHostObj
   // Call the Frame Processor on the Worklet Runtime
   jsi::Runtime& runtime = _workletContext->getWorkletRuntime();
 
-  try {
-    // Wrap HostObject as JSI Value
-    auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);
-    jsi::Value jsValue(std::move(argument));
+  // Wrap HostObject as JSI Value
+  auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);
+  jsi::Value jsValue(std::move(argument));
 
-    // Call the Worklet with the Frame JS Host Object as an argument
-    _workletInvoker->call(runtime, jsi::Value::undefined(), &jsValue, 1);
-  } catch (jsi::JSError& jsError) {
-    // JS Error occured, print it to console.
-    const std::string& message = jsError.getMessage();
-
-    _workletContext->invokeOnJsThread([message](jsi::Runtime& jsRuntime) {
-      auto logFn = jsRuntime.global().getPropertyAsObject(jsRuntime, "console").getPropertyAsFunction(jsRuntime, "error");
-      logFn.call(jsRuntime, jsi::String::createFromUtf8(jsRuntime, "Frame Processor threw an error: " + message));
-    });
-  }
+  // Call the Worklet with the Frame JS Host Object as an argument
+  _workletInvoker->call(runtime, jsi::Value::undefined(), &jsValue, 1);
 }
 
 void JFrameProcessor::call(jni::alias_ref<JFrame::javaobject> frame) {

--- a/package/ios/Frame Processor/FrameProcessor.mm
+++ b/package/ios/Frame Processor/FrameProcessor.mm
@@ -34,22 +34,12 @@ using namespace facebook;
   // Call the Frame Processor on the Worklet Runtime
   jsi::Runtime& runtime = _workletContext->getWorkletRuntime();
 
-  try {
-    // Wrap HostObject as JSI Value
-    auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);
-    jsi::Value jsValue(std::move(argument));
+  // Wrap HostObject as JSI Value
+  auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);
+  jsi::Value jsValue(std::move(argument));
 
-    // Call the Worklet with the Frame JS Host Object as an argument
-    _workletInvoker->call(runtime, jsi::Value::undefined(), &jsValue, 1);
-  } catch (jsi::JSError& jsError) {
-    // JS Error occured, print it to console.
-    auto message = jsError.getMessage();
-
-    _workletContext->invokeOnJsThread([message](jsi::Runtime& jsRuntime) {
-      auto logFn = jsRuntime.global().getPropertyAsObject(jsRuntime, "console").getPropertyAsFunction(jsRuntime, "error");
-      logFn.call(jsRuntime, jsi::String::createFromUtf8(jsRuntime, "Frame Processor threw an error: " + message));
-    });
-  }
+  // Call the Worklet with the Frame JS Host Object as an argument
+  _workletInvoker->call(runtime, jsi::Value::undefined(), &jsValue, 1);
 }
 
 - (void)call:(Frame* _Nonnull)frame {

--- a/package/src/FrameProcessorPlugins.ts
+++ b/package/src/FrameProcessorPlugins.ts
@@ -48,7 +48,7 @@ let isAsyncContextBusy = { value: false }
 let runOnAsyncContext = (_frame: Frame, _func: () => void): void => {
   throw new CameraRuntimeError('system/frame-processors-unavailable', errorMessage)
 }
-let throwJSError = (error: unknown): Promise<void> => {
+let throwJSError = (error: unknown): void => {
   throw error
 }
 
@@ -58,9 +58,12 @@ try {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { Worklets } = require('react-native-worklets-core') as typeof TWorklets
 
-  throwJSError = Worklets.createRunInJsFn((error) => {
-    throw error
-  })
+  throwJSError = (error) => {
+    'worklet'
+    const message = (error as Error | undefined)?.message ?? JSON.stringify(error)
+    // TODO: Can we throw on the JS Thread (+ LogBox) instead of only using console.log?
+    console.error(`Frame Processor threw an error: ${message}`)
+  }
 
   isAsyncContextBusy = Worklets.createSharedValue(false)
   const asyncContext = Worklets.createContext('VisionCamera.async')

--- a/package/src/FrameProcessorPlugins.ts
+++ b/package/src/FrameProcessorPlugins.ts
@@ -95,7 +95,7 @@ let proxy: TVisionCameraProxy = {
   setFrameProcessor: () => {
     throw new CameraRuntimeError('system/frame-processors-unavailable', errorMessage)
   },
-  throwJSError: throwJSError
+  throwJSError: throwJSError,
 }
 if (hasWorklets) {
   // Install native Frame Processor Runtime Manager
@@ -118,7 +118,7 @@ export const VisionCameraProxy: TVisionCameraProxy = {
   initFrameProcessorPlugin: proxy.initFrameProcessorPlugin,
   removeFrameProcessor: proxy.removeFrameProcessor,
   setFrameProcessor: proxy.setFrameProcessor,
-  throwJSError: proxy.throwJSError,
+  throwJSError: throwJSError,
   // TODO: Remove this in the next version
   // @ts-expect-error
   getFrameProcessorPlugin: (name, options) => {

--- a/package/src/hooks/useFrameProcessor.ts
+++ b/package/src/hooks/useFrameProcessor.ts
@@ -1,6 +1,7 @@
 import { DependencyList, useMemo } from 'react'
 import type { Frame, FrameInternal } from '../Frame'
 import { FrameProcessor } from '../CameraProps'
+import { VisionCameraProxy } from '../FrameProcessorPlugins'
 
 /**
  * Create a new Frame Processor function which you can pass to the `<Camera>`.
@@ -20,6 +21,9 @@ export function createFrameProcessor(frameProcessor: FrameProcessor['frameProces
       try {
         // Call sync frame processor
         frameProcessor(frame)
+      } catch (e) {
+        // Re-throw error on JS Thread
+        VisionCameraProxy.throwJSError(e)
       } finally {
         // Potentially delete Frame if we were the last ref (no runAsync)
         internal.decrementRefCount()


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Inspired by Reanimated (thanks @tomekzaw!!), we now also re-throw errors on the JS side using `runOnJS` (or the Worklets equivalent of it) instead of doing that part natively.

This simplifies the native code a tiny bit, and makes catching errors easier (hopefully).

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
