### PR TITLE
fix: Fix Preview stretching on Android

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -245,6 +245,8 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
   private fun destroyPreviewOutputSync() {
     Log.i(TAG, "Destroying Preview Output...")
+    // This needs to run synchronously because after this method returns, the Preview Surface is no longer valid,
+    // and trying to use it will crash. This might result in a short UI Thread freeze though.
     runBlocking {
       configure { config ->
         config.preview = CameraConfiguration.Output.Disabled.create()

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.lang.IllegalStateException
 
 class CameraSession(private val context: Context, private val cameraManager: CameraManager, private val callback: CameraSessionCallback) :
   CameraManager.AvailabilityCallback(),
@@ -515,7 +516,11 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
     if (!config.isActive) {
       isRunning = false
-      captureSession?.stopRepeating()
+      try {
+        captureSession?.stopRepeating()
+      } catch (e: IllegalStateException) {
+        // ignore - captureSession is already closed.
+      }
       return
     }
     if (captureSession == null) {

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -392,7 +392,8 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
         enableHdr
       )
       outputs.add(output)
-      previewView?.size = size
+      // Size is usually landscape, so we flip it here
+      previewView?.size = Size(size.height, size.width)
     }
 
     // CodeScanner Output

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -379,12 +379,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
     if (preview != null) {
       // Compute Preview Size based on chosen video size
       val videoSize = videoOutput?.size ?: format?.videoSize
-      val size = if (videoSize != null) {
-        val formatAspectRatio = videoSize.bigger.toDouble() / videoSize.smaller
-        characteristics.getPreviewTargetSize(formatAspectRatio)
-      } else {
-        characteristics.getPreviewTargetSize(null)
-      }
+      val size = characteristics.getPreviewTargetSize(videoSize)
 
       val enableHdr = video?.config?.enableHdr ?: false
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -28,7 +28,6 @@ import com.mrousavy.camera.core.outputs.BarcodeScannerOutput
 import com.mrousavy.camera.core.outputs.PhotoOutput
 import com.mrousavy.camera.core.outputs.SurfaceOutput
 import com.mrousavy.camera.core.outputs.VideoPipelineOutput
-import com.mrousavy.camera.extensions.bigger
 import com.mrousavy.camera.extensions.capture
 import com.mrousavy.camera.extensions.closestToOrMax
 import com.mrousavy.camera.extensions.createCaptureSession
@@ -38,7 +37,6 @@ import com.mrousavy.camera.extensions.getPreviewTargetSize
 import com.mrousavy.camera.extensions.getVideoSizes
 import com.mrousavy.camera.extensions.openCamera
 import com.mrousavy.camera.extensions.setZoom
-import com.mrousavy.camera.extensions.smaller
 import com.mrousavy.camera.frameprocessor.FrameProcessor
 import com.mrousavy.camera.types.Flash
 import com.mrousavy.camera.types.Orientation
@@ -48,6 +46,7 @@ import com.mrousavy.camera.types.Torch
 import com.mrousavy.camera.types.VideoStabilizationMode
 import com.mrousavy.camera.utils.ImageFormatUtils
 import java.io.Closeable
+import java.lang.IllegalStateException
 import java.util.concurrent.CancellationException
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
@@ -55,7 +54,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.lang.IllegalStateException
 
 class CameraSession(private val context: Context, private val cameraManager: CameraManager, private val callback: CameraSessionCallback) :
   CameraManager.AvailabilityCallback(),

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -18,12 +18,7 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
   var size: Size = getMaximumPreviewSize()
     set(value) {
       field = value
-      UiThreadUtil.runOnUiThread {
-        Log.i(TAG, "Resizing PreviewView to ${value.width} x ${value.height}...")
-        holder.setFixedSize(value.width, value.height)
-        requestLayout()
-        invalidate()
-      }
+      holder.setFixedSize(value.width, value.height)
     }
   var resizeMode: ResizeMode = ResizeMode.COVER
     set(value) {
@@ -48,6 +43,7 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
       override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
         callback.surfaceChanged(holder, format, width, height)
         UiThreadUtil.runOnUiThread {
+          Log.i(TAG, "Resizing PreviewView to $width x $height...")
           requestLayout()
           invalidate()
         }
@@ -55,16 +51,8 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
     })
   }
 
-  /*fun resizeToInputCamera(cameraId: String, cameraManager: CameraManager, format: CameraDeviceFormat?) {
-    val characteristics = cameraManager.getCameraCharacteristics(cameraId)
-
-    val targetPreviewSize = format?.videoSize
-    val formatAspectRatio = if (targetPreviewSize != null) targetPreviewSize.bigger.toDouble() / targetPreviewSize.smaller else null
-    size = characteristics.getPreviewTargetSize(formatAspectRatio)
-  }*/
-
   private fun getSize(contentSize: Size, containerSize: Size, resizeMode: ResizeMode): Size {
-    val contentAspectRatio = contentSize.height.toDouble() / contentSize.width // <-- content size is landscape, to be rendered in portrait
+    val contentAspectRatio = contentSize.width.toDouble() / contentSize.height
     val containerAspectRatio = containerSize.width.toDouble() / containerSize.height
 
     Log.i(TAG, "Content Size: $contentSize ($contentAspectRatio) | Container Size: $containerSize ($containerAspectRatio)")

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -41,7 +41,18 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
       FrameLayout.LayoutParams.MATCH_PARENT,
       Gravity.CENTER
     )
-    holder.addCallback(callback)
+    holder.addCallback(object: SurfaceHolder.Callback {
+      override fun surfaceCreated(holder: SurfaceHolder) = callback.surfaceCreated(holder)
+      override fun surfaceDestroyed(holder: SurfaceHolder) = callback.surfaceDestroyed(holder)
+
+      override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+        callback.surfaceChanged(holder, format, width, height)
+        UiThreadUtil.runOnUiThread {
+          requestLayout()
+          invalidate()
+        }
+      }
+    })
   }
 
   /*fun resizeToInputCamera(cameraId: String, cameraManager: CameraManager, format: CameraDeviceFormat?) {
@@ -53,7 +64,7 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
   }*/
 
   private fun getSize(contentSize: Size, containerSize: Size, resizeMode: ResizeMode): Size {
-    val contentAspectRatio = contentSize.height.toDouble() / contentSize.width
+    val contentAspectRatio = contentSize.height.toDouble() / contentSize.width // <-- content size is landscape, to be rendered in portrait
     val containerAspectRatio = containerSize.width.toDouble() / containerSize.height
 
     Log.i(TAG, "Content Size: $contentSize ($contentAspectRatio) | Container Size: $containerSize ($containerAspectRatio)")

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -41,7 +41,7 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
       FrameLayout.LayoutParams.MATCH_PARENT,
       Gravity.CENTER
     )
-    holder.addCallback(object: SurfaceHolder.Callback {
+    holder.addCallback(object : SurfaceHolder.Callback {
       override fun surfaceCreated(holder: SurfaceHolder) = callback.surfaceCreated(holder)
       override fun surfaceDestroyed(holder: SurfaceHolder) = callback.surfaceDestroyed(holder)
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -20,7 +20,7 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
       field = value
       UiThreadUtil.runOnUiThread {
         Log.i(TAG, "Setting PreviewView Surface Size to $width x $height...")
-        holder.setFixedSize(value.width, value.height)
+        holder.setFixedSize(value.height, value.width)
         requestLayout()
         invalidate()
       }

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -55,11 +55,11 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) : SurfaceV
 
     return if (widthOverHeight) {
       // Scale by width to cover height
-      val scaledWidth = containerSize.width * contentAspectRatio
+      val scaledWidth = containerSize.height * contentAspectRatio
       Size(scaledWidth.roundToInt(), containerSize.height)
     } else {
       // Scale by height to cover width
-      val scaledHeight = containerSize.height * contentAspectRatio
+      val scaledHeight = containerSize.width / contentAspectRatio
       Size(containerSize.width, scaledHeight.roundToInt())
     }
   }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getPreviewSize.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getPreviewSize.kt
@@ -9,7 +9,7 @@ fun getMaximumPreviewSize(): Size {
   // See https://developer.android.com/reference/android/hardware/camera2/params/StreamConfigurationMap
   // According to the Android Developer documentation, PREVIEW streams can have a resolution
   // of up to the phone's display's resolution, with a maximum of 1920x1080.
-  val display1080p = Size(1920, 1080)
+  val display1080p = Size(1080, 1920)
   val displaySize = Size(
     Resources.getSystem().displayMetrics.widthPixels,
     Resources.getSystem().displayMetrics.heightPixels

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getPreviewSize.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getPreviewSize.kt
@@ -4,7 +4,6 @@ import android.content.res.Resources
 import android.hardware.camera2.CameraCharacteristics
 import android.util.Size
 import android.view.SurfaceHolder
-import kotlin.math.abs
 
 fun getMaximumPreviewSize(): Size {
   // See https://developer.android.com/reference/android/hardware/camera2/params/StreamConfigurationMap
@@ -24,7 +23,7 @@ fun CameraCharacteristics.getPreviewTargetSize(targetSize: Size?): Size {
   val config = this.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)!!
   val maximumPreviewSize = getMaximumPreviewSize()
   val outputSizes = config.getOutputSizes(SurfaceHolder::class.java)
-      .filter { it.bigger <= maximumPreviewSize.bigger && it.smaller <= maximumPreviewSize.smaller }
+    .filter { it.bigger <= maximumPreviewSize.bigger && it.smaller <= maximumPreviewSize.smaller }
 
   return outputSizes.closestToOrMax(targetSize)
 }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getPreviewSize.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCharacteristics+getPreviewSize.kt
@@ -26,11 +26,5 @@ fun CameraCharacteristics.getPreviewTargetSize(targetSize: Size?): Size {
   val outputSizes = config.getOutputSizes(SurfaceHolder::class.java)
       .filter { it.bigger <= maximumPreviewSize.bigger && it.smaller <= maximumPreviewSize.smaller }
 
-  return if (targetSize != null) {
-    // Find closest resolution match
-    outputSizes.minBy { abs((it.width * it.height) - (targetSize.width * targetSize.height)) }
-  } else {
-    // Find maximum available preview resolution
-    outputSizes.maxBy { it.width * it.height }
-  }
+  return outputSizes.closestToOrMax(targetSize)
 }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/Size+Extensions.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/Size+Extensions.kt
@@ -9,7 +9,7 @@ import kotlin.math.min
 
 fun List<Size>.closestToOrMax(size: Size?): Size =
   if (size != null) {
-    this.minBy { abs(it.width - size.width) + abs(it.height - size.height) }
+    this.minBy { abs((it.width * it.height) - (size.width * size.height)) }
   } else {
     this.maxBy { it.width * it.height }
   }

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessor.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessor.java
@@ -10,7 +10,6 @@ import com.facebook.proguard.annotations.DoNotStrip;
 /**
  * Represents a JS Frame Processor
  */
-@SuppressWarnings("JavaJniMissingFunction") // we're using fbjni.
 public final class FrameProcessor {
     /**
      * Call the JS Frame Processor function with the given Frame

--- a/package/example/android/gradle.properties
+++ b/package/example/android/gradle.properties
@@ -42,4 +42,4 @@ hermesEnabled=true
 # Can be set to true to disable the build setup
 #VisionCamera_disableFrameProcessors=true
 # Can be set to true to include the full 2.4 MB MLKit dependency
-#VisionCamera_enableCodeScanner=true
+VisionCamera_enableCodeScanner=true


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the Preview View stretching issue on Android by making sure we always re-compute the layout size when either the surface or the view changes.

If you benefit from this change, say **thanks** by [💖 **sponsoring me on GitHub** 💖](https://github.com/sponsors/mrousavy/)

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
