### PR TITLE
fix: Release `MediaActionSound` after playing

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+capture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+capture.kt
@@ -29,7 +29,10 @@ suspend fun CameraCaptureSession.capture(captureRequest: CaptureRequest, enableS
 
         override fun onCaptureStarted(session: CameraCaptureSession, request: CaptureRequest, timestamp: Long, frameNumber: Long) {
           super.onCaptureStarted(session, request, timestamp, frameNumber)
-          shutterSound?.play(MediaActionSound.SHUTTER_CLICK)
+
+          if (enableShutterSound) {
+            shutterSound?.play(MediaActionSound.SHUTTER_CLICK)
+          }
         }
 
         override fun onCaptureFailed(session: CameraCaptureSession, request: CaptureRequest, failure: CaptureFailure) {

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+capture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+capture.kt
@@ -14,6 +14,9 @@ import kotlin.coroutines.suspendCoroutine
 
 suspend fun CameraCaptureSession.capture(captureRequest: CaptureRequest, enableShutterSound: Boolean): TotalCaptureResult =
   suspendCoroutine { continuation ->
+    val shutterSound = if (enableShutterSound) MediaActionSound() else null
+    shutterSound?.load(MediaActionSound.SHUTTER_CLICK)
+
     this.capture(
       captureRequest,
       object : CameraCaptureSession.CaptureCallback() {
@@ -21,15 +24,12 @@ suspend fun CameraCaptureSession.capture(captureRequest: CaptureRequest, enableS
           super.onCaptureCompleted(session, request, result)
 
           continuation.resume(result)
+          shutterSound?.release()
         }
 
         override fun onCaptureStarted(session: CameraCaptureSession, request: CaptureRequest, timestamp: Long, frameNumber: Long) {
           super.onCaptureStarted(session, request, timestamp, frameNumber)
-
-          if (enableShutterSound) {
-            val mediaActionSound = MediaActionSound()
-            mediaActionSound.play(MediaActionSound.SHUTTER_CLICK)
-          }
+          shutterSound?.play(MediaActionSound.SHUTTER_CLICK)
         }
 
         override fun onCaptureFailed(session: CameraCaptureSession, request: CaptureRequest, failure: CaptureFailure) {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Pre-loads and releases the `MediaActionSound` if `enableShutterSound` is true. 

Will make the Shutter sound better timed and release it after being done.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Might fix #2379

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
