### PR TITLE
feat: Add `minFocusDistance` prop to `CameraDevice`

### DIFF
--- a/docs/docs/guides/ERRORS.mdx
+++ b/docs/docs/guides/ERRORS.mdx
@@ -55,7 +55,7 @@ See [the `CameraError.ts` file](https://github.com/mrousavy/react-native-vision-
 
 ### Runtime Errors
 
-The `CameraRuntimeError` represents any kind of error that occured while mounting the Camera view, or an error that occured during the runtime.
+The [`CameraRuntimeError`](/docs/api/classes/CameraRuntimeError) represents any kind of error that occured while mounting the Camera view, or an error that occured during the runtime.
 
 The `<Camera />` UI Component provides an `onError` function that will be invoked every time an unexpected runtime error occured.
 
@@ -71,7 +71,7 @@ function App() {
 
 ### Capture Errors
 
-The `CameraCaptureError` represents any kind of error that occured only while taking a photo or recording a video.
+The [`CameraCaptureError`](/docs/api/classes/CameraCaptureError) represents any kind of error that occured only while taking a photo or recording a video.
 
 ```tsx
 function App() {

--- a/docs/docs/guides/PERFORMANCE.mdx
+++ b/docs/docs/guides/PERFORMANCE.mdx
@@ -83,7 +83,7 @@ By default, the `native` [`PixelFormat`](/docs/api#pixelformat) is used, which i
 
 ### Disable unneeded pipelines
 
-Only enable [`photo`](/docs/api/interfaces/CameraProps#photo) and [`video`](/docs/api/interfaces/CameraProps#video) if needed.
+Only enable [`photo`](/docs/api/interfaces/CameraProps#photo), [`video`](/docs/api/interfaces/CameraProps#video), [`codeScanner`](/docs/api/interfaces/CameraProps#codescanner) or [`frameProcessor`](/docs/api/interfaces/CameraProps#frameprocessor) if needed.
 
 ### Fast Photos
 

--- a/docs/docs/guides/PERFORMANCE.mdx
+++ b/docs/docs/guides/PERFORMANCE.mdx
@@ -62,7 +62,7 @@ Note: By default (when not passing the options object), a simpler device is alre
 
 ### No Video HDR
 
-Video HDR uses 10-bit formats and/or additional processing steps that come with additional computation overhead. Disable Video HDR (don't pass `videoHdr` to the `<Camera>`) for higher efficiency.
+Video HDR uses 10-bit formats and/or additional processing steps that come with additional computation overhead. Disable [`videoHdr`](/docs/api/interfaces/CameraProps#videohdr) for higher efficiency.
 
 ### Buffer Compression
 

--- a/docs/docs/guides/PERFORMANCE.mdx
+++ b/docs/docs/guides/PERFORMANCE.mdx
@@ -85,6 +85,10 @@ By default, the `native` [`PixelFormat`](/docs/api#pixelformat) is used, which i
 
 Only enable [`photo`](/docs/api/interfaces/CameraProps#photo), [`video`](/docs/api/interfaces/CameraProps#video), [`codeScanner`](/docs/api/interfaces/CameraProps#codescanner) or [`frameProcessor`](/docs/api/interfaces/CameraProps#frameprocessor) if needed.
 
+### Using `isActive`
+
+The [`isActive`](/docs/api/interfaces/CameraProps#isactive) prop controls whether the Camera should actively stream frames. Instead of fully unmounting the `<Camera>` component and remounting it again, keep it mounted and just switch `isActive` on or off. This makes the Camera resume much faster as it internally keeps the session warmed up.
+
 ### Fast Photos
 
 If you need to take photos as fast as possible, use a [`qualityPrioritization`](/docs/api/interfaces/TakePhotoOptions#qualityprioritization) of `'speed'` to speed up the photo pipeline:


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds the `minFocusDistance` prop to the `CameraDevice` to expose how close the device can focus to.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Resolves https://github.com/mrousavy/react-native-vision-camera/issues/2246

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
