### PR TITLE
fix: Fix C++ build-error when trying to use `JSITypedArray.h`

### DIFF
--- a/package/ios/Frame Processor/SharedArray.h
+++ b/package/ios/Frame Processor/SharedArray.h
@@ -12,9 +12,12 @@
 #import <Foundation/Foundation.h>
 
 #ifdef __cplusplus
-#import "JSITypedArray.h"
 #import <jsi/jsi.h>
 using namespace facebook;
+
+namespace vision {
+class TypedArrayBase;
+}
 #endif
 
 // Needs to be in sync with JSITypedArray.h as the index is used

--- a/package/ios/Frame Processor/SharedArray.h
+++ b/package/ios/Frame Processor/SharedArray.h
@@ -16,6 +16,7 @@
 using namespace facebook;
 
 namespace vision {
+// forward-declaration since we cannot import C++ headers here yet.
 class TypedArrayBase;
 }
 #endif


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
