### PR TITLE
fix: Make `Frame` properties readonly in Types

### DIFF
--- a/package/src/Frame.ts
+++ b/package/src/Frame.ts
@@ -18,42 +18,42 @@ export interface Frame {
    * Whether the underlying buffer is still valid or not.
    * A Frame is valid as long as your Frame Processor (or a `runAsync(..)` operation) is still running
    */
-  isValid: boolean
+  readonly isValid: boolean
   /**
    * Returns the width of the frame, in pixels.
    */
-  width: number
+  readonly width: number
   /**
    * Returns the height of the frame, in pixels.
    */
-  height: number
+  readonly height: number
   /**
    * Returns the amount of bytes per row.
    */
-  bytesPerRow: number
+  readonly bytesPerRow: number
   /**
    * Returns the number of planes this frame contains.
    */
-  planesCount: number
+  readonly planesCount: number
   /**
    * Returns whether the Frame is mirrored (selfie camera) or not.
    */
-  isMirrored: boolean
+  readonly isMirrored: boolean
   /**
    * Returns the timestamp of the Frame relative to the host sytem's clock.
    */
-  timestamp: number
+  readonly timestamp: number
   /**
    * Represents the orientation of the Frame.
    *
    * Some ML Models are trained for specific orientations, so they need to be taken into
    * consideration when running a frame processor. See also: {@linkcode isMirrored}
    */
-  orientation: Orientation
+  readonly orientation: Orientation
   /**
    * Represents the pixel-format of the Frame.
    */
-  pixelFormat: PixelFormat
+  readonly pixelFormat: PixelFormat
 
   /**
    * Get the underlying data of the Frame as a uint8 array buffer.

--- a/package/src/FrameProcessorPlugins.ts
+++ b/package/src/FrameProcessorPlugins.ts
@@ -17,12 +17,12 @@ interface FrameProcessorPlugin {
    * @param options (optional) Additional options. Options will be converted to a native dictionary
    * @returns (optional) A value returned from the native Frame Processor Plugin (or undefined)
    */
-  call: (frame: Frame, options?: Record<string, ParameterType>) => ParameterType
+  call(frame: Frame, options?: Record<string, ParameterType>): ParameterType
 }
 
 interface TVisionCameraProxy {
-  setFrameProcessor: (viewTag: number, frameProcessor: FrameProcessor) => void
-  removeFrameProcessor: (viewTag: number) => void
+  setFrameProcessor(viewTag: number, frameProcessor: FrameProcessor): void
+  removeFrameProcessor(viewTag: number): void
   /**
    * Creates a new instance of a native Frame Processor Plugin.
    * The Plugin has to be registered on the native side, otherwise this returns `undefined`.
@@ -34,11 +34,11 @@ interface TVisionCameraProxy {
    * if (plugin == null) throw new Error("Failed to load scanFaces plugin!")
    * ```
    */
-  initFrameProcessorPlugin: (name: string, options?: Record<string, ParameterType>) => FrameProcessorPlugin | undefined
+  initFrameProcessorPlugin(name: string, options?: Record<string, ParameterType>): FrameProcessorPlugin | undefined
   /**
    * Throws the given error.
    */
-  throwJSError: (error: unknown) => void
+  throwJSError(error: unknown): void
 }
 
 const errorMessage = 'Frame Processors are not available, react-native-worklets-core is not installed!'


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Just some typescript changes.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
