### PR TITLE
fix: Use property accessors on `Frame`

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -484,7 +484,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (3.7.1):
+  - VisionCamera (3.8.0):
     - React
     - React-callinvoker
     - React-Core
@@ -724,7 +724,7 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: ac444079a315b38ec664cf77ed548c384554f0ca
+  VisionCamera: 8e3454abf4baa43a2b9ad9cfc9723d1cc89d9eb6
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: 27f53791141a3303d814e09b55770336416ff4eb

--- a/package/ios/Frame Processor/Frame.h
+++ b/package/ios/Frame Processor/Frame.h
@@ -18,10 +18,10 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-@property(nonatomic, readonly, nonnull) CMSampleBufferRef _Nonnull buffer;
+@property(nonatomic, readonly) CMSampleBufferRef _Nonnull buffer;
 @property(nonatomic, readonly) UIImageOrientation orientation;
 
-@property(nonatomic, readonly, nonnull) NSString* pixelFormat;
+@property(nonatomic, readonly) NSString* _Nonnull pixelFormat;
 @property(nonatomic, readonly) BOOL isMirrored;
 @property(nonatomic, readonly) BOOL isValid;
 @property(nonatomic, readonly) size_t width;

--- a/package/ios/Frame Processor/Frame.h
+++ b/package/ios/Frame Processor/Frame.h
@@ -14,8 +14,7 @@
 
 @interface Frame : NSObject
 
-- (instancetype _Nonnull)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer
-                            orientation:(UIImageOrientation)orientation;
+- (instancetype _Nonnull)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/package/ios/Frame Processor/Frame.h
+++ b/package/ios/Frame Processor/Frame.h
@@ -14,21 +14,21 @@
 
 @interface Frame : NSObject
 
-- (instancetype _Nonnull)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation;
+- (instancetype _Nonnull)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer
+                            orientation:(UIImageOrientation)orientation;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-@property(nonatomic, readonly) CMSampleBufferRef _Nonnull buffer;
+@property(nonatomic, readonly, nonnull) CMSampleBufferRef _Nonnull buffer;
 @property(nonatomic, readonly) UIImageOrientation orientation;
 
-// Getters
-- (NSString* _Nonnull)pixelFormat;
-- (BOOL)isMirrored;
-- (BOOL)isValid;
-- (size_t)width;
-- (size_t)height;
-- (double)timestamp;
-- (size_t)bytesPerRow;
-- (size_t)planesCount;
+@property(nonatomic, readonly, nonnull) NSString* pixelFormat;
+@property(nonatomic, readonly) BOOL isMirrored;
+@property(nonatomic, readonly) BOOL isValid;
+@property(nonatomic, readonly) size_t width;
+@property(nonatomic, readonly) size_t height;
+@property(nonatomic, readonly) double timestamp;
+@property(nonatomic, readonly) size_t bytesPerRow;
+@property(nonatomic, readonly) size_t planesCount;
 
 @end

--- a/package/ios/Frame Processor/Frame.h
+++ b/package/ios/Frame Processor/Frame.h
@@ -12,16 +12,17 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIImage.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface Frame : NSObject
 
-- (instancetype _Nonnull)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation;
-
+- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation;
 - (instancetype)init NS_UNAVAILABLE;
 
-@property(nonatomic, readonly) CMSampleBufferRef _Nonnull buffer;
+@property(nonatomic, readonly) CMSampleBufferRef buffer;
 @property(nonatomic, readonly) UIImageOrientation orientation;
 
-@property(nonatomic, readonly) NSString* _Nonnull pixelFormat;
+@property(nonatomic, readonly) NSString* pixelFormat;
 @property(nonatomic, readonly) BOOL isMirrored;
 @property(nonatomic, readonly) BOOL isValid;
 @property(nonatomic, readonly) size_t width;
@@ -31,3 +32,5 @@
 @property(nonatomic, readonly) size_t planesCount;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/package/ios/Frame Processor/Frame.m
+++ b/package/ios/Frame Processor/Frame.m
@@ -15,8 +15,7 @@
   UIImageOrientation _orientation;
 }
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer
-                   orientation:(UIImageOrientation)orientation {
+- (instancetype)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation {
   self = [super init];
   if (self) {
     _buffer = buffer;
@@ -30,11 +29,11 @@
   CFRelease(_buffer);
 }
 
-- (CMSampleBufferRef) buffer {
+- (CMSampleBufferRef)buffer {
   return _buffer;
 }
 
-- (UIImageOrientation) orientation {
+- (UIImageOrientation)orientation {
   return _orientation;
 }
 

--- a/package/ios/Frame Processor/Frame.m
+++ b/package/ios/Frame Processor/Frame.m
@@ -11,11 +11,12 @@
 #import <Foundation/Foundation.h>
 
 @implementation Frame {
-  CMSampleBufferRef _Nonnull buffer;
-  UIImageOrientation orientation;
+  CMSampleBufferRef _Nonnull _buffer;
+  UIImageOrientation _orientation;
 }
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation {
+- (instancetype)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer
+                   orientation:(UIImageOrientation)orientation {
   self = [super init];
   if (self) {
     _buffer = buffer;
@@ -29,8 +30,13 @@
   CFRelease(_buffer);
 }
 
-@synthesize buffer = _buffer;
-@synthesize orientation = _orientation;
+- (CMSampleBufferRef) buffer {
+  return _buffer;
+}
+
+- (UIImageOrientation) orientation {
+  return _orientation;
+}
 
 - (NSString*)pixelFormat {
   CMFormatDescriptionRef format = CMSampleBufferGetFormatDescription(_buffer);

--- a/package/ios/Frame Processor/Frame.m
+++ b/package/ios/Frame Processor/Frame.m
@@ -15,7 +15,7 @@
   UIImageOrientation _orientation;
 }
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef _Nonnull)buffer orientation:(UIImageOrientation)orientation {
+- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation {
   self = [super init];
   if (self) {
     _buffer = buffer;

--- a/package/ios/Frame Processor/FrameProcessor.h
+++ b/package/ios/Frame Processor/FrameProcessor.h
@@ -19,6 +19,8 @@
 #import <memory.h>
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface FrameProcessor : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -30,6 +32,8 @@
 - (void)callWithFrameHostObject:(std::shared_ptr<FrameHostObject>)frameHostObject;
 #endif
 
-- (void)call:(Frame* _Nonnull)frame;
+- (void)call:(Frame*)frame;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/package/ios/Frame Processor/FrameProcessorPlugin.h
+++ b/package/ios/Frame Processor/FrameProcessorPlugin.h
@@ -85,4 +85,3 @@ NS_ASSUME_NONNULL_END
   }                                                                                                                                        \
                                                                                                                                            \
   @end
-

--- a/package/ios/Frame Processor/FrameProcessorPlugin.h
+++ b/package/ios/Frame Processor/FrameProcessorPlugin.h
@@ -12,6 +12,8 @@
 #import "VisionCameraProxy.h"
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The base class of a native Frame Processor Plugin.
  *
@@ -32,7 +34,7 @@
  *   - proxy: The VisionCameraProxy instance for using the Frame Processor Context, e.g. to initialize SharedArrays.
  *   - options: An options dictionary passed from the JS side, or `nil` if none.
  */
-- (instancetype _Nonnull)initWithProxy:(VisionCameraProxyHolder* _Nonnull)proxy
+- (instancetype _Nonnull)initWithProxy:(VisionCameraProxyHolder*)proxy
                            withOptions:(NSDictionary* _Nullable)options NS_SWIFT_NAME(init(proxy:options:));
 
 - (instancetype _Nonnull)init NS_UNAVAILABLE;
@@ -44,13 +46,16 @@
  *
  * - Parameters:
  *   - frame: The Frame from the Camera. Don't do any ref-counting on this, as VisionCamera handles that.
+ *   - arguments: An options dictionary passed from the JS side, or `nil` if none.
  * - Returns: You can return any primitive, map or array you want.
  *            See the <a href="https://react-native-vision-camera.com/docs/guides/frame-processors-plugins-overview#types">Types</a>
  *            table for a list of supported types.
  */
-- (id _Nullable)callback:(Frame* _Nonnull)frame withArguments:(NSDictionary* _Nullable)arguments;
+- (id _Nullable)callback:(Frame*)frame withArguments:(NSDictionary* _Nullable)arguments;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #define VISION_CONCAT2(A, B) A##B
 #define VISION_CONCAT(A, B) VISION_CONCAT2(A, B)
@@ -80,3 +85,4 @@
   }                                                                                                                                        \
                                                                                                                                            \
   @end
+

--- a/package/ios/Frame Processor/FrameProcessorPluginRegistry.h
+++ b/package/ios/Frame Processor/FrameProcessorPluginRegistry.h
@@ -17,8 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FrameProcessorPluginRegistry : NSObject
 
-typedef FrameProcessorPlugin* _Nonnull (^PluginInitializerFunction)(VisionCameraProxyHolder* proxy,
-                                                                    NSDictionary* _Nullable options);
+typedef FrameProcessorPlugin* _Nonnull (^PluginInitializerFunction)(VisionCameraProxyHolder* proxy, NSDictionary* _Nullable options);
 
 + (void)addFrameProcessorPlugin:(NSString*)name withInitializer:(PluginInitializerFunction)pluginInitializer;
 

--- a/package/ios/Frame Processor/FrameProcessorPluginRegistry.h
+++ b/package/ios/Frame Processor/FrameProcessorPluginRegistry.h
@@ -13,15 +13,19 @@
 #import "VisionCameraProxy.h"
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface FrameProcessorPluginRegistry : NSObject
 
-typedef FrameProcessorPlugin* _Nonnull (^PluginInitializerFunction)(VisionCameraProxyHolder* _Nonnull proxy,
+typedef FrameProcessorPlugin* _Nonnull (^PluginInitializerFunction)(VisionCameraProxyHolder* proxy,
                                                                     NSDictionary* _Nullable options);
 
-+ (void)addFrameProcessorPlugin:(NSString* _Nonnull)name withInitializer:(PluginInitializerFunction _Nonnull)pluginInitializer;
++ (void)addFrameProcessorPlugin:(NSString*)name withInitializer:(PluginInitializerFunction)pluginInitializer;
 
-+ (FrameProcessorPlugin* _Nullable)getPlugin:(NSString* _Nonnull)name
-                                   withProxy:(VisionCameraProxyHolder* _Nonnull)proxy
++ (FrameProcessorPlugin* _Nullable)getPlugin:(NSString*)name
+                                   withProxy:(VisionCameraProxyHolder*)proxy
                                  withOptions:(NSDictionary* _Nullable)options;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/package/ios/Frame Processor/SharedArray.h
+++ b/package/ios/Frame Processor/SharedArray.h
@@ -34,14 +34,15 @@ typedef NS_ENUM(NSInteger, SharedArrayType) {
   Float64Array,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SharedArray : NSObject
 
-- (instancetype _Nonnull)init NS_UNAVAILABLE;
-
-- (instancetype _Nonnull)initWithProxy:(VisionCameraProxyHolder* _Nonnull)proxy type:(SharedArrayType)type size:(NSInteger)size;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy type:(SharedArrayType)type size:(NSInteger)size;
 
 #ifdef __cplusplus
-- (instancetype _Nonnull)initWithRuntime:(jsi::Runtime&)runtime typedArray:(std::shared_ptr<vision::TypedArrayBase>)typedArray;
+- (instancetype)initWithRuntime:(jsi::Runtime&)runtime typedArray:(std::shared_ptr<vision::TypedArrayBase>)typedArray;
 
 - (std::shared_ptr<vision::TypedArrayBase>)typedArray;
 #endif
@@ -50,3 +51,5 @@ typedef NS_ENUM(NSInteger, SharedArrayType) {
 @property(nonatomic, readonly) NSInteger count;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/package/ios/Frame Processor/VisionCameraProxy.h
+++ b/package/ios/Frame Processor/VisionCameraProxy.h
@@ -42,18 +42,22 @@ private:
 };
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface VisionCameraProxyHolder : NSObject
 
-- (_Nonnull instancetype)initWithProxy:(void* _Nonnull)proxy;
+- (_Nonnull instancetype)initWithProxy:(void*)proxy;
 
 #ifdef __cplusplus
-- (VisionCameraProxy* _Nonnull)proxy;
+- (VisionCameraProxy*)proxy;
 #endif
 
 @end
 
 @interface VisionCameraInstaller : NSObject
 
-+ (BOOL)installToBridge:(RCTBridge* _Nonnull)bridge;
++ (BOOL)installToBridge:(RCTBridge*)bridge;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Uses `@property` accessors instead of get methods for the `Frame` type.

Before:

```swift
frame.isValid()
```

After:

```swift
frame.isValid
```

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
