### PR TITLE
feat: Add `SharedArray.getSize()`

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JSharedArray.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JSharedArray.cpp
@@ -28,6 +28,7 @@ jni::global_ref<jni::JByteBuffer> JSharedArray::wrapInByteBuffer(jsi::Runtime& r
 JSharedArray::JSharedArray(jsi::Runtime& runtime, std::shared_ptr<TypedArrayBase> array) {
   _array = array;
   _byteBuffer = wrapInByteBuffer(runtime, _array);
+  _size = _array.size(runtime);
 }
 
 JSharedArray::JSharedArray(const jni::alias_ref<JSharedArray::jhybridobject>& javaThis,
@@ -43,17 +44,23 @@ JSharedArray::JSharedArray(const jni::alias_ref<JSharedArray::jhybridobject>& ja
   __android_log_print(ANDROID_LOG_INFO, TAG, "Allocating ArrayBuffer with size %i and type %i...", size, dataType);
   _array = std::make_shared<TypedArrayBase>(runtime, size, kind);
   _byteBuffer = wrapInByteBuffer(runtime, _array);
+  _size = size;
 }
 
 void JSharedArray::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", JSharedArray::initHybrid),
       makeNativeMethod("getByteBuffer", JSharedArray::getByteBuffer),
+      makeNativeMethod("getSize", JSharedArray::getSize),
   });
 }
 
 jni::local_ref<jni::JByteBuffer> JSharedArray::getByteBuffer() {
   return jni::make_local(_byteBuffer);
+}
+
+jint JSharedArray::getSize() {
+  return _size;
 }
 
 std::shared_ptr<TypedArrayBase> JSharedArray::getTypedArray() {

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JSharedArray.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JSharedArray.cpp
@@ -28,7 +28,7 @@ jni::global_ref<jni::JByteBuffer> JSharedArray::wrapInByteBuffer(jsi::Runtime& r
 JSharedArray::JSharedArray(jsi::Runtime& runtime, std::shared_ptr<TypedArrayBase> array) {
   _array = array;
   _byteBuffer = wrapInByteBuffer(runtime, _array);
-  _size = _array.size(runtime);
+  _size = _array->size(runtime);
 }
 
 JSharedArray::JSharedArray(const jni::alias_ref<JSharedArray::jhybridobject>& javaThis,

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JSharedArray.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JSharedArray.h
@@ -23,6 +23,7 @@ public:
   static jni::local_ref<JSharedArray::javaobject> create(jsi::Runtime& runtime, TypedArrayBase array);
 
 public:
+  jint getSize();
   jni::local_ref<jni::JByteBuffer> getByteBuffer();
   std::shared_ptr<TypedArrayBase> getTypedArray();
 
@@ -35,6 +36,7 @@ private:
   jni::global_ref<javaobject> _javaPart;
   jni::global_ref<jni::JByteBuffer> _byteBuffer;
   std::shared_ptr<TypedArrayBase> _array;
+  int _size;
 
 private:
   explicit JSharedArray(jsi::Runtime& runtime, std::shared_ptr<TypedArrayBase> array);

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/SharedArray.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/SharedArray.java
@@ -39,6 +39,11 @@ public final class SharedArray {
      */
     public native ByteBuffer getByteBuffer();
 
+    /**
+     * Gets the size of the ByteBuffer.
+     */
+    public native int getSize();
+
     private native HybridData initHybrid(VisionCameraProxy proxy, int dataType, int size);
 
     /**

--- a/package/ios/Frame Processor/SharedArray.h
+++ b/package/ios/Frame Processor/SharedArray.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 @property(nonatomic, readonly, nonnull) uint8_t* data;
-@property(nonatomic, readonly) NSInteger count;
+@property(nonatomic, readonly) NSInteger size;
 
 @end
 

--- a/package/ios/Frame Processor/SharedArray.mm
+++ b/package/ios/Frame Processor/SharedArray.mm
@@ -15,7 +15,7 @@ using namespace facebook;
 
 @implementation SharedArray {
   uint8_t* _data;
-  NSInteger _count;
+  NSInteger _size;
   std::shared_ptr<vision::TypedArrayBase> _array;
 }
 
@@ -29,7 +29,7 @@ vision::TypedArrayKind getTypedArrayKind(int unsafeEnumValue) {
     vision::TypedArrayKind kind = getTypedArrayKind((int)type);
     _array = std::make_shared<vision::TypedArrayBase>(vision::TypedArrayBase(runtime, size, kind));
     _data = _array->getBuffer(runtime).data(runtime);
-    _count = size;
+    _size = size;
   }
   return self;
 }
@@ -38,7 +38,7 @@ vision::TypedArrayKind getTypedArrayKind(int unsafeEnumValue) {
   if (self = [super init]) {
     _array = typedArray;
     _data = _array->getBuffer(runtime).data(runtime);
-    _count = _array->getBuffer(runtime).size(runtime);
+    _size = _array->getBuffer(runtime).size(runtime);
   }
   return self;
 }
@@ -51,8 +51,8 @@ vision::TypedArrayKind getTypedArrayKind(int unsafeEnumValue) {
   return _data;
 }
 
-- (NSInteger)count {
-  return _count;
+- (NSInteger)size {
+  return _size;
 }
 
 @end


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds a getter for the array size for `SharedArray` Android part

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
