### PR TITLE
feat: `SharedArray:wrapData:withSize` init for iOS

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/SharedArray.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/SharedArray.java
@@ -25,7 +25,7 @@ public final class SharedArray {
     }
 
     /**
-     * Allocate a new SharedArray. Use `getByteBuffer` to obtain a reference to the direct ByteBuffer for writing.
+     * Allocate a new SharedArray with the given size. Use `getByteBuffer` to obtain a reference to the direct ByteBuffer for writing.
      * @param proxy The VisionCamera Proxy from the Frame Processor Plugin's initializer.
      * @param size The size of the ArrayBuffer.
      */
@@ -34,7 +34,7 @@ public final class SharedArray {
     }
 
     /**
-     * Wraps the given ByteBuffer in a JSI ArrayBuffer. Using `getByteBuffer` will return the same instance which can be used for writing.
+     * Wraps the given ByteBuffer in a SharedArray without copying. Using `getByteBuffer` will return the same instance which can be used for writing.
      * @param proxy The VisionCamera Proxy from the Frame Processor Plugin's initializer.
      * @param byteBuffer The ByteBuffer to wrap.
      */

--- a/package/cpp/MutableRawBuffer.cpp
+++ b/package/cpp/MutableRawBuffer.cpp
@@ -12,17 +12,19 @@
 
 namespace vision {
 
-MutableRawBuffer::MutableRawBuffer(uint8_t* data, size_t size, std::function<void()> cleanup)
-    : _data(data), _size(size), _cleanup(std::move(cleanup)) {}
+MutableRawBuffer::MutableRawBuffer(uint8_t* data, size_t size, bool freeOnDealloc)
+    : _data(data), _size(size), _freeOnDealloc(freeOnDealloc) {}
 
 MutableRawBuffer::MutableRawBuffer(size_t size) {
   _size = size;
   _data = (uint8_t*)malloc(size * sizeof(uint8_t));
-  _cleanup = [=]() { free(_data); };
+  _freeOnDealloc = true;
 }
 
 MutableRawBuffer::~MutableRawBuffer() {
-  _cleanup();
+  if (_freeOnDealloc) {
+    free(_data);
+  }
 }
 
 size_t MutableRawBuffer::size() const {

--- a/package/cpp/MutableRawBuffer.h
+++ b/package/cpp/MutableRawBuffer.h
@@ -20,7 +20,7 @@ class MutableRawBuffer : public jsi::MutableBuffer {
 
 public:
   explicit MutableRawBuffer(size_t size);
-  explicit MutableRawBuffer(uint8_t* data, size_t size, std::function<void()> cleanup);
+  explicit MutableRawBuffer(uint8_t* data, size_t size, bool freeOnDealloc);
   ~MutableRawBuffer();
 
 public:
@@ -30,7 +30,7 @@ public:
 private:
   uint8_t* _data;
   size_t _size;
-  std::function<void()> _cleanup;
+  bool _freeOnDealloc;
 };
 
 } // namespace vision

--- a/package/example/ios/Frame Processor Plugins/Example Plugin/ExampleFrameProcessorPlugin.m
+++ b/package/example/ios/Frame Processor Plugins/Example Plugin/ExampleFrameProcessorPlugin.m
@@ -25,7 +25,7 @@
                   withOptions:(NSDictionary* _Nullable)options {
   if (self = [super initWithProxy:proxy withOptions:options]) {
     _sharedArray = [[SharedArray alloc] initWithProxy:proxy
-                                                 size:5];
+                                     allocateWithSize:5];
     NSLog(@"ExampleFrameProcessorPlugin initialized with options: %@", options);
   }
   return self;

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -484,7 +484,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (3.8.0):
+  - VisionCamera (3.8.1):
     - React
     - React-callinvoker
     - React-Core
@@ -724,9 +724,9 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 8e3454abf4baa43a2b9ad9cfc9723d1cc89d9eb6
+  VisionCamera: f6ca954813603e753578623fcbb9364d3e08d6ce
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: 27f53791141a3303d814e09b55770336416ff4eb
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.14.3

--- a/package/ios/Frame Processor/JSINSObjectConversion.mm
+++ b/package/ios/Frame Processor/JSINSObjectConversion.mm
@@ -170,7 +170,7 @@ id convertJSIValueToObjCObject(jsi::Runtime& runtime, const jsi::Value& value, s
     } else if (o.isArrayBuffer(runtime)) {
       // ArrayBuffer
       auto arrayBuffer = std::make_shared<jsi::ArrayBuffer>(o.getArrayBuffer(runtime));
-      return [[SharedArray alloc] initWithRuntime:runtime arrayBuffer:arrayBuffer];
+      return [[SharedArray alloc] initWithRuntime:runtime wrapArrayBuffer:arrayBuffer];
     } else {
       // object
       return convertJSIObjectToNSDictionary(runtime, o, jsInvoker);

--- a/package/ios/Frame Processor/SharedArray.h
+++ b/package/ios/Frame Processor/SharedArray.h
@@ -12,7 +12,6 @@
 #import <Foundation/Foundation.h>
 
 #ifdef __cplusplus
-#import "../../cpp/MutableRawBuffer.h"
 #import <jsi/jsi.h>
 using namespace facebook;
 #endif
@@ -22,10 +21,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SharedArray : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy size:(NSInteger)size;
+
+- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
+             allocateWithSize:(NSInteger)size;
+
+- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
+                     wrapData:(uint8_t*)data
+                     withSize:(NSInteger)size
+                freeOnDealloc:(BOOL)freeOnDealloc;
 
 #ifdef __cplusplus
-- (instancetype)initWithRuntime:(jsi::Runtime&)runtime arrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer;
+- (instancetype)initWithRuntime:(jsi::Runtime&)runtime
+                wrapArrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer;
 
 - (std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer;
 #endif

--- a/package/ios/Frame Processor/SharedArray.h
+++ b/package/ios/Frame Processor/SharedArray.h
@@ -18,24 +18,45 @@ using namespace facebook;
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * An ArrayBuffer of type uint8 that can be shared between native and JS without copying.
+ */
 @interface SharedArray : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 
+/**
+ * Allocates a new SharedArray with the given size.
+ * Use `data` to write to the SharedArray.
+ */
 - (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy allocateWithSize:(NSInteger)size;
 
+/**
+ * Wraps the given data in a SharedArray without copying.
+ * Use `data` to write to the SharedArray.
+ */
 - (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
                      wrapData:(uint8_t*)data
                      withSize:(NSInteger)size
                 freeOnDealloc:(BOOL)freeOnDealloc;
 
 #ifdef __cplusplus
+/**
+ * Wraps the given JSI ArrayBuffer in a SharedArray for native access.
+ * Use `data` to write to the SharedArray.
+ */
 - (instancetype)initWithRuntime:(jsi::Runtime&)runtime wrapArrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer;
 
 - (std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer;
 #endif
 
+/**
+ * The underlying contents of the ArrayBuffer which can be used for reading and writing.
+ */
 @property(nonatomic, readonly, nonnull) uint8_t* data;
+/**
+ * The size of the ArrayBuffer.
+ */
 @property(nonatomic, readonly) NSInteger size;
 
 @end

--- a/package/ios/Frame Processor/SharedArray.h
+++ b/package/ios/Frame Processor/SharedArray.h
@@ -22,8 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
-             allocateWithSize:(NSInteger)size;
+- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy allocateWithSize:(NSInteger)size;
 
 - (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
                      wrapData:(uint8_t*)data
@@ -31,8 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
                 freeOnDealloc:(BOOL)freeOnDealloc;
 
 #ifdef __cplusplus
-- (instancetype)initWithRuntime:(jsi::Runtime&)runtime
-                wrapArrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer;
+- (instancetype)initWithRuntime:(jsi::Runtime&)runtime wrapArrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer;
 
 - (std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer;
 #endif

--- a/package/ios/Frame Processor/SharedArray.mm
+++ b/package/ios/Frame Processor/SharedArray.mm
@@ -19,14 +19,13 @@ using namespace facebook;
   std::shared_ptr<jsi::ArrayBuffer> _arrayBuffer;
 }
 
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
-             allocateWithSize:(NSInteger)size {
+- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy allocateWithSize:(NSInteger)size {
   uint8_t* data = (uint8_t*)malloc(size * sizeof(uint8_t));
   return [self initWithProxy:proxy wrapData:data withSize:size freeOnDealloc:YES];
 }
 
-- (instancetype)initWithProxy:(VisionCameraProxyHolder *)proxy
-                     wrapData:(uint8_t *)data
+- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
+                     wrapData:(uint8_t*)data
                      withSize:(NSInteger)size
                 freeOnDealloc:(BOOL)freeOnDealloc {
   if (self = [super init]) {
@@ -40,8 +39,7 @@ using namespace facebook;
   return self;
 }
 
-- (instancetype)initWithRuntime:(jsi::Runtime&)runtime
-                wrapArrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer {
+- (instancetype)initWithRuntime:(jsi::Runtime&)runtime wrapArrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer {
   if (self = [super init]) {
     _arrayBuffer = arrayBuffer;
     _data = _arrayBuffer->data(runtime);

--- a/package/ios/Frame Processor/SharedArray.mm
+++ b/package/ios/Frame Processor/SharedArray.mm
@@ -7,7 +7,7 @@
 //
 
 #import "SharedArray.h"
-#import "../../cpp/MutableRawBuffer.h"
+#import "MutableRawBuffer.h"
 #import <Foundation/Foundation.h>
 #import <jsi/jsi.h>
 
@@ -19,12 +19,20 @@ using namespace facebook;
   std::shared_ptr<jsi::ArrayBuffer> _arrayBuffer;
 }
 
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy size:(NSInteger)size {
+- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
+             allocateWithSize:(NSInteger)size {
+  uint8_t* data = (uint8_t*)malloc(size * sizeof(uint8_t));
+  return [self initWithProxy:proxy wrapData:data withSize:size freeOnDealloc:YES];
+}
+
+- (instancetype)initWithProxy:(VisionCameraProxyHolder *)proxy
+                     wrapData:(uint8_t *)data
+                     withSize:(NSInteger)size
+                freeOnDealloc:(BOOL)freeOnDealloc {
   if (self = [super init]) {
     jsi::Runtime& runtime = proxy.proxy->getWorkletRuntime();
 
-    uint8_t* data = (uint8_t*)malloc(size * sizeof(uint8_t));
-    auto mutableBuffer = std::make_shared<vision::MutableRawBuffer>(data, size, [=]() { free(data); });
+    auto mutableBuffer = std::make_shared<vision::MutableRawBuffer>(data, size, freeOnDealloc);
     _arrayBuffer = std::make_shared<jsi::ArrayBuffer>(runtime, mutableBuffer);
     _data = data;
     _size = size;
@@ -32,7 +40,8 @@ using namespace facebook;
   return self;
 }
 
-- (instancetype)initWithRuntime:(jsi::Runtime&)runtime arrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer {
+- (instancetype)initWithRuntime:(jsi::Runtime&)runtime
+                wrapArrayBuffer:(std::shared_ptr<jsi::ArrayBuffer>)arrayBuffer {
   if (self = [super init]) {
     _arrayBuffer = arrayBuffer;
     _data = _arrayBuffer->data(runtime);


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

- Adds a `wrapData:` constructor to `SharedArray` for iOS
- Fixes a build error that was caused by `MutableRawBuffer.h` not being includeable

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
