### PR TITLE
fix: Throw `not-compatible-with-outputs` error when adding both CodeScannerPipeline and VideoPipeline

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraError.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraError.kt
@@ -119,6 +119,12 @@ class CodeTypeNotSupportedError(codeType: String) :
     "code-type-not-supported",
     "The codeType \"$codeType\" is not supported by the Code Scanner!"
   )
+class CodeScannerTooManyOutputsError :
+  CameraError(
+    "code-scanner",
+    "not-compatible-with-outputs",
+    "CodeScanner can only be enabled when both video and frameProcessor are disabled! Use a Frame Processor Plugin for code scanning instead."
+  )
 
 class ViewNotFoundError(viewId: Int) :
   CameraError("system", "view-not-found", "The given view (ID $viewId) was not found in the view manager.")

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraError.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraError.kt
@@ -123,7 +123,8 @@ class CodeScannerTooManyOutputsError :
   CameraError(
     "code-scanner",
     "not-compatible-with-outputs",
-    "CodeScanner can only be enabled when both video and frameProcessor are disabled! Use a Frame Processor Plugin for code scanning instead."
+    "CodeScanner can only be enabled when both video and frameProcessor are disabled! " +
+      "Use a Frame Processor Plugin for code scanning instead."
   )
 
 class ViewNotFoundError(viewId: Int) :

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -414,6 +414,12 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
     // CodeScanner Output
     val codeScanner = configuration.codeScanner as? CameraConfiguration.Output.Enabled<CameraConfiguration.CodeScanner>
     if (codeScanner != null) {
+      if (video != null) {
+        // CodeScanner and VideoPipeline are two repeating streams - they cannot be both added.
+        // In this case, the user should use a Frame Processor Plugin for code scanning instead.
+        throw CodeScannerTooManyOutputsError()
+      }
+
       val imageFormat = ImageFormat.YUV_420_888
       val sizes = characteristics.getVideoSizes(cameraDevice.id, imageFormat)
       val size = sizes.closestToOrMax(Size(1280, 720))


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

The CodeScanner is a _simplified_ version of a QR/Barcode scanner. It works perfectly when not using Frame Processors, and on iOS might even work with video recording enabled.
But on Android these are two separate repeating requests; `video`/`frameProcessor` is one output stream, and `codeScanner` is another.
That overloads most Cameras, so it is not recomended to do that.
If you need both `video`/`frameProcessor` and `codeScanner`, instead only use `video`/`frameProcessor` and use a QR/Barcode Scanner Frame Processor Plugin as this will then only use one output. Also it might give you more fine-grained control over the code scanning.

So because of this limitation, we throw an error on Android if the user tries to add all outputs, recommending him that he should disable one of those. 

**‼️ HOWEVER ‼️:** It is possible to work around that solution entirely if I just append the `CodeScannerPipeline` AFTER the `VideoPipeline`.
This would work perfectly, but it introduces quite a bit of added complexity to the codebase. I guess if someone really wants this feature and sponsors/funds my efforts to implement that, I can do it. Otherwise this is the workaround for now.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Resolves #2407

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
