### PR TITLE
fix: Catch `insufficient-storage` errors

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+RecordVideo.kt
@@ -5,8 +5,8 @@ import android.annotation.SuppressLint
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 import com.facebook.react.bridge.*
+import com.mrousavy.camera.core.CameraError
 import com.mrousavy.camera.core.MicrophonePermissionError
-import com.mrousavy.camera.core.RecorderError
 import com.mrousavy.camera.core.RecordingSession
 import com.mrousavy.camera.core.code
 import com.mrousavy.camera.types.RecordVideoOptions
@@ -29,7 +29,7 @@ suspend fun CameraView.startRecording(options: RecordVideoOptions, onRecordCallb
     map.putInt("height", video.size.height)
     onRecordCallback(map, null)
   }
-  val onError = { error: RecorderError ->
+  val onError = { error: CameraError ->
     val errorMap = makeErrorMap(error.code, error.message)
     onRecordCallback(null, errorMap)
   }

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -93,7 +93,7 @@ private suspend fun savePhotoToFile(
     when (photo.format) {
       // When the format is JPEG or DEPTH JPEG we can simply save the bytes as-is
       ImageFormat.JPEG, ImageFormat.DEPTH_JPEG -> {
-        val file = createFile(context, ".jpg")
+        val file = FileUtils.createTempFile(context, ".jpg")
         writePhotoToFile(photo, file)
         return@withContext file.absolutePath
       }
@@ -101,7 +101,7 @@ private suspend fun savePhotoToFile(
       // When the format is RAW we use the DngCreator utility library
       ImageFormat.RAW_SENSOR -> {
         val dngCreator = DngCreator(cameraCharacteristics, photo.metadata)
-        val file = createFile(context, ".dng")
+        val file = FileUtils.createTempFile(context, ".dng")
         FileOutputStream(file).use { stream ->
           // TODO: Make sure orientation is loaded properly here?
           dngCreator.writeImage(stream, photo.image)
@@ -113,9 +113,4 @@ private suspend fun savePhotoToFile(
         throw Error("Failed to save Photo to file, image format is not supported! ${photo.format}")
       }
     }
-  }
-
-private fun createFile(context: Context, extension: String): File =
-  File.createTempFile("mrousavy", extension, context.cacheDir).apply {
-    deleteOnExit()
   }

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -12,11 +12,13 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.mrousavy.camera.core.CameraSession
+import com.mrousavy.camera.core.InsufficientStorageError
 import com.mrousavy.camera.types.Flash
 import com.mrousavy.camera.types.QualityPrioritization
 import com.mrousavy.camera.utils.*
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import kotlinx.coroutines.*
 
 private const val TAG = "CameraView.takePhoto"
@@ -49,7 +51,15 @@ suspend fun CameraView.takePhoto(optionsMap: ReadableMap): WritableMap {
 
     val cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId!!)
 
-    val path = savePhotoToFile(context, cameraCharacteristics, photo)
+    val path = try {
+      savePhotoToFile(context, cameraCharacteristics, photo)
+    } catch (e: IOException) {
+      if (e.message?.contains("no space left", true) == true) {
+        throw InsufficientStorageError()
+      } else {
+        throw e
+      }
+    }
 
     Log.i(TAG, "Successfully saved photo to file! $path")
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraError.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraError.kt
@@ -106,6 +106,7 @@ class RecorderError(name: String, extra: Int) :
   CameraError("capture", "recorder-error", "An error occured while recording a video! $name $extra")
 class NoRecordingInProgressError :
   CameraError("capture", "no-recording-in-progress", "There was no active video recording in progress! Did you call stopRecording() twice?")
+class InsufficientStorageError : CameraError("capture", "insufficient-storage", "There is not enough storage space available.")
 class RecordingInProgressError :
   CameraError(
     "capture",

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -623,7 +623,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
     enableAudio: Boolean,
     options: RecordVideoOptions,
     callback: (video: RecordingSession.Video) -> Unit,
-    onError: (error: RecorderError) -> Unit
+    onError: (error: CameraError) -> Unit
   ) {
     mutex.withLock {
       if (recording != null) throw RecordingInProgressError()

--- a/package/android/src/main/java/com/mrousavy/camera/utils/FileUtils.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/utils/FileUtils.kt
@@ -1,0 +1,13 @@
+package com.mrousavy.camera.utils
+
+import android.content.Context
+import java.io.File
+
+class FileUtils {
+  companion object {
+    fun createTempFile(context: Context, extension: String): File =
+      File.createTempFile("mrousavy", extension, context.cacheDir).also {
+        it.deleteOnExit()
+      }
+  }
+}

--- a/package/ios/Core/CameraError.swift
+++ b/package/ios/Core/CameraError.swift
@@ -180,6 +180,7 @@ enum CaptureError {
   case videoNotEnabled
   case photoNotEnabled
   case aborted
+  case insufficientStorage
   case unknown(message: String? = nil)
 
   var code: String {
@@ -198,6 +199,8 @@ enum CaptureError {
       return "video-not-enabled"
     case .photoNotEnabled:
       return "photo-not-enabled"
+    case .insufficientStorage:
+      return "insufficient-storage"
     case .aborted:
       return "aborted"
     case .unknown:
@@ -223,6 +226,8 @@ enum CaptureError {
       return "Photo capture is disabled! Pass `photo={true}` to enable photo capture."
     case .aborted:
       return "The capture has been stopped before any input data arrived."
+    case .insufficientStorage:
+      return "There is not enough storage space available."
     case let .unknown(message: message):
       return message ?? "An unknown error occured while capturing a video/photo."
     }

--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -54,6 +54,8 @@ extension CameraSession {
           // Something went wrong, we have an error
           if error.domain == "capture/aborted" {
             onError(.capture(.aborted))
+          } else if error.code == -11807 {
+            onError(.capture(.insufficientStorage))
           } else {
             onError(.capture(.unknown(message: "An unknown recording error occured! \(error.code) \(error.description)")))
           }

--- a/package/ios/Core/PhotoCaptureDelegate.swift
+++ b/package/ios/Core/PhotoCaptureDelegate.swift
@@ -84,7 +84,11 @@ class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
       delegatesReferences.removeAll(where: { $0 == self })
     }
     if let error = error as NSError? {
-      promise.reject(error: .capture(.unknown(message: error.description)), cause: error)
+      if error.code == -11807 {
+        promise.reject(error: .capture(.insufficientStorage), cause: error)
+      } else {
+        promise.reject(error: .capture(.unknown(message: error.description)), cause: error)
+      }
       return
     }
   }

--- a/package/src/CameraError.ts
+++ b/package/src/CameraError.ts
@@ -36,6 +36,7 @@ export type CaptureError =
   | 'capture/file-io-error'
   | 'capture/create-temp-file-error'
   | 'capture/create-recorder-error'
+  | 'capture/insufficient-storage'
   | 'capture/recorder-error'
   | 'capture/video-not-enabled'
   | 'capture/photo-not-enabled'


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Instead of throwing `capture/unknown`, VisionCamera will now throw `capture/insufficient-storage` errors when there is not enough storage space available to complete the capture.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Resolves https://github.com/mrousavy/react-native-vision-camera/issues/627

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
