### PR TITLE
fix: maxImages when frameprocessor error

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -110,21 +110,22 @@ class VideoPipeline(
         Log.i(TAG, "ImageReader::onImageAvailable!")
         val image = reader.acquireNextImage() ?: return@setOnImageAvailableListener
 
+        // TODO: Get correct orientation and isMirrored
+        val frame = Frame(image, image.timestamp, Orientation.PORTRAIT, isMirrored)
+        frame.incrementRefCount()
+
         try {
-          // TODO: Get correct orientation and isMirrored
-          val frame = Frame(image, image.timestamp, Orientation.PORTRAIT, isMirrored)
-          frame.incrementRefCount()
           frameProcessor?.call(frame)
 
           if (hasOutputs) {
             // If we have outputs (e.g. a RecordingSession), pass the frame along to the OpenGL pipeline
             imageWriter!!.queueInputImage(image)
           }
-
-          frame.decrementRefCount()
         } catch (e: Throwable) {
-          image.close()
-          Log.e(TAG, "Failed to call Frame Processor!", e)
+          Log.e(TAG, "FrameProcessor/ImageReader pipeline threw an error!", e)
+          throw e
+        } finally {
+          frame.decrementRefCount()
         }
       }, CameraQueues.videoQueue.handler)
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -123,6 +123,7 @@ class VideoPipeline(
 
           frame.decrementRefCount()
         } catch (e: Throwable) {
+          image.close()
           Log.e(TAG, "Failed to call Frame Processor!", e)
         }
       }, CameraQueues.videoQueue.handler)


### PR DESCRIPTION
## What

This PR prevent crash and cause `maxImages (3) has already been acquired` when FrameProcessor throws an error.

## Changes
Call `image.close()` when FrameProcessor throws an error.

## Tested on

Motorola Edge 40 Neo.

## Related issues

Maybe releated to: https://github.com/mrousavy/react-native-vision-camera/issues/2288