### PR TITLE
feat: Use `yuv` by default if no `pixelFormat` is set

### DIFF
--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -470,6 +470,7 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
     }
 
     const shouldEnableBufferCompression = props.video === true && frameProcessor == null
+    const pixelFormat = props.pixelFormat ?? (frameProcessor == null ? 'yuv' : 'native')
     const torch = this.state.isRecordingWithFlash ? 'on' : props.torch
 
     return (
@@ -487,6 +488,7 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
         codeScannerOptions={codeScanner}
         enableFrameProcessor={frameProcessor != null}
         enableBufferCompression={props.enableBufferCompression ?? shouldEnableBufferCompression}
+        pixelFormat={pixelFormat}
       />
     )
   }

--- a/package/src/CameraProps.ts
+++ b/package/src/CameraProps.ts
@@ -74,7 +74,9 @@ export interface CameraProps extends ViewProps {
    * - `yuv`: The YUV (Y'CbCr 4:2:0 or NV21, 8-bit) format, either video- or full-range, depending on hardware capabilities. This is the second most efficient format.
    * - `rgb`: The RGB (RGB, RGBA or ABGRA, 8-bit) format. This is least efficient and requires explicit conversion.
    *
-   * @default `native`
+   * @default
+   * - Without a Frame Processor: `native`
+   * - With a Frame Processor: `yuv`
    */
   pixelFormat?: 'native' | 'yuv' | 'rgb'
   //#endregion


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

If no pixelFormat is set and the user is using a Frame Processor, use `yuv` as a default format.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
