### PR TITLE
fix: Fix `SharedArray` JSI constructor allocating a new array instead of wrapping

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JSharedArray.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JSharedArray.cpp
@@ -18,7 +18,7 @@ jni::local_ref<JSharedArray::javaobject> JSharedArray::create(jsi::Runtime& runt
 JSharedArray::JSharedArray(jsi::Runtime& runtime, std::shared_ptr<jsi::ArrayBuffer> arrayBuffer) {
   size_t size = arrayBuffer->size(runtime);
   __android_log_print(ANDROID_LOG_INFO, TAG, "Wrapping JSI ArrayBuffer with size %zu...", size);
-  jni::local_ref<JByteBuffer> byteBuffer = JByteBuffer::allocateDirect(size);
+  jni::local_ref<JByteBuffer> byteBuffer = JByteBuffer::wrapBytes(arrayBuffer->data(runtime), size);
 
   _arrayBuffer = arrayBuffer;
   _byteBuffer = jni::make_global(byteBuffer);


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
