### PR TITLE
fix: Enable `processNestedWorklets` to fix `runAsync` in example

### DIFF
--- a/package/example/babel.config.js
+++ b/package/example/babel.config.js
@@ -5,7 +5,12 @@ const pak = require('../package.json')
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
   plugins: [
-    ['react-native-reanimated/plugin'],
+    [
+      'react-native-reanimated/plugin',
+      {
+        processNestedWorklets: true
+      }
+    ],
     ['react-native-worklets-core/plugin'],
     [
       'module-resolver',


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
