### PR TITLE
fix: Fix `NullPointerException` in `VideoPipeline.removeRecordingSessionOutputSurface`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -144,7 +144,6 @@ class VideoPipeline(
       frameProcessor = null
       recordingSession = null
       surfaceTexture.release()
-      mHybridData.resetNative()
     }
   }
 


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes a possible `NullPointerException` error that happened in `VideoPipeline.removeRecordingSessionOutputSurface` which might have been caused by `mHybridData` being null, hence the native state/instance not existing, hence the null pointer exception.

This fix does not close hybrid data in `close()` so that it remains valid as long as the Java instance is still there - if it still runs some code.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2316

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
