### PR TITLE
fix: Fix `NullPointerException` in `initFrameProcessorPlugin` if plugin is not found

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorPluginRegistry.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessorPluginRegistry.java
@@ -36,7 +36,7 @@ public class FrameProcessorPluginRegistry {
 
     @DoNotStrip
     @Keep
-    public static FrameProcessorPlugin getPlugin(String name, VisionCameraProxy proxy, Map<String, Object> options) {
+    public static @Nullable FrameProcessorPlugin getPlugin(String name, VisionCameraProxy proxy, Map<String, Object> options) {
         Log.i(TAG, "Looking up Frame Processor Plugin \"" + name + "\"...");
         PluginInitializer initializer = Plugins.get(name);
         if (initializer == null) {
@@ -48,6 +48,6 @@ public class FrameProcessorPluginRegistry {
     }
 
     public interface PluginInitializer {
-        FrameProcessorPlugin initializePlugin(@NonNull VisionCameraProxy proxy, @Nullable Map<String, Object> options);
+        @NonNull FrameProcessorPlugin initializePlugin(@NonNull VisionCameraProxy proxy, @Nullable Map<String, Object> options);
     }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraProxy.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraProxy.kt
@@ -71,7 +71,7 @@ class VisionCameraProxy(context: ReactApplicationContext) {
 
   @DoNotStrip
   @Keep
-  fun initFrameProcessorPlugin(name: String, options: Map<String, Any>): FrameProcessorPlugin =
+  fun initFrameProcessorPlugin(name: String, options: Map<String, Any>): FrameProcessorPlugin? =
     FrameProcessorPluginRegistry.getPlugin(name, this, options)
 
   // private C++ funcs


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

If you call the `VisionCameraProxy.initFrameProcessorPlugin('processor');` and the specific  processor were not available, the whole program crash with this error 
```
JNI DETECTED ERROR IN APPLICATION: JNI GetObjectRefType called with pending exception java.lang.NullPointerException: getPlugin(name, this, options) must not be null
```

this fix mark the getPlugin function as nullable

## Changes

mark the getPlugin function as nullable

## Tested on

Android simulator, and real android device