### PR TITLE
fix: Expose auto-focus system for Android and adds it to Format Filter

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -76,6 +76,7 @@ class CameraDeviceDetails(val cameraManager: CameraManager, val cameraId: String
     characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION) ?: IntArray(0)
   val supportsPhotoHdr = extensions.contains(3) // TODO: CameraExtensionCharacteristics.EXTENSION_HDR
   val supportsVideoHdr = getHasVideoHdr()
+  val autoFocusSystem = getAutoFocusSystem()
 
   val videoFormat = ImageFormat.YUV_420_888
 
@@ -130,6 +131,18 @@ class CameraDeviceDetails(val cameraManager: CameraManager, val cameraId: String
       }
     }
     return deviceTypes
+  }
+
+  private fun getAutoFocusSystem(): AutoFocusSystem {
+    val supportedAFModes = characteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES)
+    val supportsAF = supportedAFModes?.contains(CameraCharacteristics.CONTROL_AF_MODE_AUTO) == true
+    if (!supportsAF) return AutoFocusSystem.NONE
+
+    val focusCalibrationSystem = characteristics.get(CameraCharacteristics.LENS_INFO_FOCUS_DISTANCE_CALIBRATION)
+    return when (focusCalibrationSystem) {
+      CameraCharacteristics.LENS_INFO_FOCUS_DISTANCE_CALIBRATION_CALIBRATED -> AutoFocusSystem.PHASE_DETECTION
+      else -> AutoFocusSystem.CONTRAST_DETECTION
+    }
   }
 
   private fun getFieldOfView(focalLength: Float): Double {
@@ -190,7 +203,7 @@ class CameraDeviceDetails(val cameraManager: CameraManager, val cameraId: String
     map.putBoolean("supportsVideoHdr", supportsVideoHdr)
     map.putBoolean("supportsPhotoHdr", supportsPhotoHdr)
     map.putBoolean("supportsDepthCapture", supportsDepthCapture)
-    map.putString("autoFocusSystem", AutoFocusSystem.CONTRAST_DETECTION.unionValue)
+    map.putString("autoFocusSystem", autoFocusSystem.unionValue)
     map.putArray("videoStabilizationModes", createStabilizationModes())
     map.putArray("pixelFormats", createPixelFormats())
     return map

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -76,7 +76,7 @@ class CameraDeviceDetails(val cameraManager: CameraManager, val cameraId: String
     characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION) ?: IntArray(0)
   val supportsPhotoHdr = extensions.contains(3) // TODO: CameraExtensionCharacteristics.EXTENSION_HDR
   val supportsVideoHdr = getHasVideoHdr()
-  val autoFocusSystem = getAutoFocusSystem()
+  val autoFocusSystem = getAutoFocusSystemMode()
 
   val videoFormat = ImageFormat.YUV_420_888
 
@@ -133,7 +133,7 @@ class CameraDeviceDetails(val cameraManager: CameraManager, val cameraId: String
     return deviceTypes
   }
 
-  private fun getAutoFocusSystem(): AutoFocusSystem {
+  private fun getAutoFocusSystemMode(): AutoFocusSystem {
     val supportedAFModes = characteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES)
     val supportsAF = supportedAFModes?.contains(CameraCharacteristics.CONTROL_AF_MODE_AUTO) == true
     if (!supportsAF) return AutoFocusSystem.NONE

--- a/package/android/src/main/java/com/mrousavy/camera/types/AutoFocusSystem.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/types/AutoFocusSystem.kt
@@ -1,6 +1,7 @@
 package com.mrousavy.camera.types
 
 enum class AutoFocusSystem(override val unionValue: String) : JSUnionValue {
+  PHASE_DETECTION("phase-detection"),
   CONTRAST_DETECTION("contrast-detection"),
   NONE("none");
 

--- a/package/src/devices/getCameraFormat.ts
+++ b/package/src/devices/getCameraFormat.ts
@@ -242,8 +242,8 @@ export function getCameraFormat(device: CameraDevice, filters: FormatFilter[]): 
 
     // phase-detection is generally the best AF system
     if (filter.autoFocusSystem != null) {
-      if (bestFormat.autoFocusSystem === filter.autoFocusSystem) leftPoints++
-      if (format.autoFocusSystem === filter.autoFocusSystem) rightPoints++
+      if (bestFormat.autoFocusSystem === filter.autoFocusSystem.target) leftPoints++
+      if (format.autoFocusSystem === filter.autoFocusSystem.target) rightPoints++
     }
 
     if (rightPoints > leftPoints) bestFormat = format

--- a/package/src/devices/getCameraFormat.ts
+++ b/package/src/devices/getCameraFormat.ts
@@ -1,4 +1,4 @@
-import type { CameraDevice, CameraDeviceFormat, VideoStabilizationMode } from '../CameraDevice'
+import type { AutoFocusSystem, CameraDevice, CameraDeviceFormat, VideoStabilizationMode } from '../CameraDevice'
 import { CameraRuntimeError } from '../CameraError'
 import { PixelFormat } from '../PixelFormat'
 
@@ -74,6 +74,12 @@ export interface FormatFilter {
    * Lower ISO values tend to capture photos quicker.
    */
   iso?: number | 'max' | 'min'
+  /**
+   * The target auto-focus system.
+   * While `phase-detection` is generally the best system available,
+   * you might want to choose a different auto-focus system.
+   */
+  autoFocusSystem?: AutoFocusSystem
 }
 
 type FilterWithPriority<T> = {
@@ -232,6 +238,12 @@ export function getCameraFormat(device: CameraDevice, filters: FormatFilter[]): 
     if (filter.videoHdr != null) {
       if (bestFormat.supportsVideoHdr === filter.videoHdr.target) leftPoints++
       if (format.supportsVideoHdr === filter.videoHdr.target) rightPoints++
+    }
+
+    // phase-detection is generally the best AF system
+    if (filter.autoFocusSystem != null) {
+      if (bestFormat.autoFocusSystem === filter.autoFocusSystem) leftPoints++
+      if (format.autoFocusSystem === filter.autoFocusSystem) rightPoints++
     }
 
     if (rightPoints > leftPoints) bestFormat = format


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

You can now use `autoFocusSystem: 'phase-detection'` in format filter

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
