### PR TITLE
fix: Fix `Unable to retrieve jni environment. Is the thread attached?` errors by using `jni::ThreadScope`

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
@@ -21,7 +21,9 @@ void JVisionCameraScheduler::dispatchAsync(const std::function<void()>& job) {
 }
 
 void JVisionCameraScheduler::scheduleTrigger() {
-  // 2. schedule `triggerUI` to be called on the java thread
+  // 2.1 Open a JNI Thread scope because this might be called from a C++ background Thread
+  jni::ThreadScope scope;
+  // 2.2 schedule `triggerUI` to be called on the java thread
   static auto method = _javaPart->getClass()->getMethod<void()>("scheduleTrigger");
   method(_javaPart.get());
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes an issue for a discord user who posted this symbolicated C++ tombstone/stacktrace:

```

01-29 10:03:10.683  5754  5754 F DEBUG   : Abort message: 'terminating with uncaught exception of type std::runtime_error: Unable to retrieve jni environment. Is the thread attached?'
01-29 10:03:10.683  5754  5754 F DEBUG   :     x0  0000000000000000  x1  0000000000007f55  x2  0000000000000006  x3  00000076736bce60
01-29 10:03:10.683  5754  5754 F DEBUG   :     x4  736f646277641f73  x5  736f646277641f73  x6  736f646277641f73  x7  7f7f7f7f7f7f7f7f
01-29 10:03:10.683  5754  5754 F DEBUG   :     x8  00000000000000f0  x9  0000007b33a491e8  x10 0000000000000001  x11 0000007b33a8f230
01-29 10:03:10.683  5754  5754 F DEBUG   :     x12 00000000088060e2  x13 000000037a3e1d10  x14 0013284630951c98  x15 0000000026762762
01-29 10:03:10.683  5754  5754 F DEBUG   :     x16 0000007b33af3d08  x17 0000007b33ad10f0  x18 0000007664e98000  x19 0000000000007db6
01-29 10:03:10.683  5754  5754 F DEBUG   :     x20 0000000000007f55  x21 00000000ffffffff  x22 ffffff80ffffffc8  x23 00000076736bd0b0
01-29 10:03:10.684  5754  5754 F DEBUG   :     x24 00000076736bcf90  x25 00000076736bcfd0  x26 000000727f400000  x27 0000000000000005
01-29 10:03:10.684  5754  5754 F DEBUG   :     x28 000000000002daf8  x29 00000076736bcee0
01-29 10:03:10.684  5754  5754 F DEBUG   :     lr  0000007b33a80b8c  sp  00000076736bce40  pc  0000007b33a80bb8  pst 0000000000001000
01-29 10:03:10.684  5754  5754 F DEBUG   : 31 total frames
01-29 10:03:10.684  5754  5754 F DEBUG   : backtrace:
01-29 10:03:10.684  5754  5754 F DEBUG   :       #00 pc 0000000000059bb8  /apex/com.android.runtime/lib64/bionic/libc.so (abort+164) (BuildId: 2febda0bbcffa4b71545deb95b27767d)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #01 pc 00000000000cece8  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libc++_shared.so (BuildId: fcc246cbb373c5edee634b117c4b4564cc9becf3)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #02 pc 00000000000cee9c  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libc++_shared.so (BuildId: fcc246cbb373c5edee634b117c4b4564cc9becf3)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #03 pc 00000000000e3c5c  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libc++_shared.so (BuildId: fcc246cbb373c5edee634b117c4b4564cc9becf3)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #04 pc 00000000000e3bf4  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libc++_shared.so (std::terminate()+56) (BuildId: fcc246cbb373c5edee634b117c4b4564cc9becf3)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #05 pc 0000000000045a10  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libVisionCamera.so (BuildId: 9a23a728cc295d73a03704aa6c72ca79768ca276)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #06 pc 0000000000049bfc  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libVisionCamera.so (facebook::jni::getHybridDataFromField(facebook::jni::JObject const*, facebook::jni::JField<facebook::jni::detail::JTypeFor<facebook::jni::detail::HybridData, facebook::jni::JObject, void>::_javaobject*> const&)+332) (BuildId: 9a23a728cc295d73a03704aa6c72ca79768ca276)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #07 pc 000000000006117c  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libVisionCamera.so (facebook::jni::HybridClass<vision::JVisionCameraScheduler, facebook::jni::detail::BaseHybridClass>::JavaPart::cthis() const+60) (BuildId: 9a23a728cc295d73a03704aa6c72ca79768ca276)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #08 pc 0000000000060f0c  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libVisionCamera.so (BuildId: 9a23a728cc295d73a03704aa6c72ca79768ca276)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #09 pc 0000000000141f60  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #10 pc 0000000000124430  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (std::__ndk1::function<void (std::__ndk1::function<void ()>&&)>::operator()(std::__ndk1::function<void ()>&&) const+44) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #11 pc 000000000012461c  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (RNWorklet::JsiWorkletContext::invokeOnWorkletThread(std::__ndk1::function<void (RNWorklet::JsiWorkletContext*, facebook::jsi::Runtime&)>&&)+232) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #12 pc 000000000014ae84  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (RNWorklet::WorkletInvoker::~WorkletInvoker()+384) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #13 pc 0000000000147f04  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (std::__ndk1::__shared_ptr_emplace<RNWorklet::WorkletInvoker, std::__ndk1::allocator<RNWorklet::WorkletInvoker> >::__on_zero_shared()+28) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #14 pc 0000000000101648  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #15 pc 00000000001015f8  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #16 pc 00000000001250f8  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (std::__ndk1::shared_ptr<RNWorklet::WorkletInvoker>::~shared_ptr()+40) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #17 pc 000000000019f830  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (RNWorklet::JsiObjectWrapper::setFunctionValue(facebook::jsi::Runtime&, facebook::jsi::Value const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::~()+20) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #18 pc 00000000001a1028  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (std::__ndk1::__compressed_pair_elem<RNWorklet::JsiObjectWrapper::setFunctionValue(facebook::jsi::Runtime&, facebook::jsi::Value const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), 0, false>::~__compressed_pair_elem()+20) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #19 pc 00000000001a10c0  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (std::__ndk1::__compressed_pair<RNWorklet::JsiObjectWrapper::setFunctionValue(facebook::jsi::Runtime&, facebook::jsi::Value const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), std::__ndk1::allocator<RNWorklet::JsiObjectWrapper::setFunctionValue(facebook::jsi::Runtime&, facebook::jsi::Value const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)> >::~__compressed_pair()+20) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #20 pc 00000000001a1d58  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #21 pc 00000000001a0b7c  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/librnworklets.so (std::__ndk1::__function::__func<RNWorklet::JsiObjectWrapper::setFunctionValue(facebook::jsi::Runtime&, facebook::jsi::Value const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), std::__ndk1::allocator<RNWorklet::JsiObjectWrapper::setFunctionValue(facebook::jsi::Runtime&, facebook::jsi::Value const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::destroy()+24) (BuildId: b131f60bb0e73282b75de5efb521328e96af6b7c)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #22 pc 000000000007cec8  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libhermes.so (BuildId: 8444099cfeb4b8425773291ae7eac400c44aadcd)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #23 pc 000000000015b1dc  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libhermes.so (BuildId: 8444099cfeb4b8425773291ae7eac400c44aadcd)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #24 pc 000000000015e868  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libhermes.so (BuildId: 8444099cfeb4b8425773291ae7eac400c44aadcd)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #25 pc 0000000000165184  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libhermes.so (BuildId: 8444099cfeb4b8425773291ae7eac400c44aadcd)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #26 pc 0000000000163868  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libhermes.so (BuildId: 8444099cfeb4b8425773291ae7eac400c44aadcd)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #27 pc 00000000001648d0  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libhermes.so (BuildId: 8444099cfeb4b8425773291ae7eac400c44aadcd)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #28 pc 00000000001646fc  /data/app/~~pdSIeKDbGrPGD4JGDx1JWg==/com.myapp.name-3oKHcyt-XBHPtZDMORbQ5A==/lib/arm64/libhermes.so (BuildId: 8444099cfeb4b8425773291ae7eac400c44aadcd)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #29 pc 00000000000be908  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 2febda0bbcffa4b71545deb95b27767d)
01-29 10:03:10.684  5754  5754 F DEBUG   :       #30 pc 000000000005b3f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 2febda0bbcffa4b71545deb95b27767d)
```

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1791 (or at least some comments in there)

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
