### PR TITLE
perf: Use existing `cameraQueue` instead of yet another Thread

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -22,7 +22,6 @@ import com.mrousavy.camera.types.PixelFormat
 import com.mrousavy.camera.types.ResizeMode
 import com.mrousavy.camera.types.Torch
 import com.mrousavy.camera.types.VideoStabilizationMode
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -38,7 +37,6 @@ import kotlinx.coroutines.launch
 @SuppressLint("ClickableViewAccessibility", "ViewConstructor", "MissingPermission")
 class CameraView(context: Context) :
   FrameLayout(context),
-  CoroutineScope,
   CameraSession.CameraSessionCallback {
   companion object {
     const val TAG = "CameraView"
@@ -101,7 +99,7 @@ class CameraView(context: Context) :
       cameraSession.frameProcessor = frameProcessor
     }
 
-  override val coroutineContext: CoroutineContext = CameraQueues.cameraQueue.coroutineDispatcher
+  private val coroutineScope = CoroutineScope(CameraQueues.cameraQueue.coroutineDispatcher)
 
   init {
     this.installHierarchyFitter()
@@ -134,7 +132,7 @@ class CameraView(context: Context) :
     val now = System.currentTimeMillis()
     currentConfigureCall = now
 
-    launch {
+    coroutineScope.launch {
       cameraSession.configure { config ->
         if (currentConfigureCall != now) {
           // configure waits for a lock, and if a new call to update() happens in the meantime we can drop this one.

--- a/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -10,6 +10,7 @@ import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 import com.facebook.react.uimanager.UIManagerHelper
 import com.mrousavy.camera.core.CameraError
+import com.mrousavy.camera.core.CameraQueues
 import com.mrousavy.camera.core.ViewNotFoundError
 import com.mrousavy.camera.frameprocessor.VisionCameraInstaller
 import com.mrousavy.camera.frameprocessor.VisionCameraProxy
@@ -28,7 +29,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     var sharedRequestCode = 10
   }
 
-  private val coroutineScope = CoroutineScope(Dispatchers.Default) // TODO: or Dispatchers.Main?
+  private val coroutineScope = CoroutineScope(CameraQueues.cameraQueue.coroutineDispatcher)
 
   override fun invalidate() {
     super.invalidate()

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -57,8 +57,7 @@ import kotlinx.coroutines.sync.withLock
 
 class CameraSession(private val context: Context, private val cameraManager: CameraManager, private val callback: CameraSessionCallback) :
   CameraManager.AvailabilityCallback(),
-  Closeable,
-  CoroutineScope {
+  Closeable {
   companion object {
     private const val TAG = "CameraSession"
   }
@@ -94,8 +93,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
       field = value
     }
 
-  override val coroutineContext: CoroutineContext
-    get() = CameraQueues.cameraQueue.coroutineDispatcher
+  private val coroutineScope = CoroutineScope(CameraQueues.cameraQueue.coroutineDispatcher)
 
   // Video Outputs
   private var recording: RecordingSession? = null
@@ -138,7 +136,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
     super.onCameraAvailable(cameraId)
     if (this.configuration?.cameraId == cameraId && cameraDevice == null && configuration?.isActive == true) {
       Log.i(TAG, "Camera #$cameraId is now available again, trying to re-open it now...")
-      launch {
+      coroutineScope.launch {
         configure {
           // re-open CameraDevice if needed
         }
@@ -251,7 +249,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
   private fun createPreviewOutput(surface: Surface) {
     Log.i(TAG, "Setting Preview Output...")
-    launch {
+    coroutineScope.launch {
       configure { config ->
         config.preview = CameraConfiguration.Output.Enabled.create(CameraConfiguration.Preview(surface))
       }

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -49,7 +49,6 @@ import com.mrousavy.camera.utils.ImageFormatUtils
 import java.io.Closeable
 import java.lang.IllegalStateException
 import java.util.concurrent.CancellationException
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
