### PR TITLE
fix: Use `ThreadScope::WithClassLoader` to also load custom JNI Types

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
@@ -22,7 +22,7 @@ void JVisionCameraScheduler::dispatchAsync(const std::function<void()>& job) {
 
 void JVisionCameraScheduler::scheduleTrigger() {
   // 2.1 Open a JNI Thread scope because this might be called from a C++ background Thread
-  jni::ThreadScope::WithClassLoader([&] () {
+  jni::ThreadScope::WithClassLoader([&]() {
     // 2.2 schedule `triggerUI` to be called on the java thread
     static auto method = _javaPart->getClass()->getMethod<void()>("scheduleTrigger");
     method(_javaPart.get());

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
@@ -22,7 +22,7 @@ void JVisionCameraScheduler::dispatchAsync(const std::function<void()>& job) {
 
 void JVisionCameraScheduler::scheduleTrigger() {
   // 2.1 Open a JNI Thread scope because this might be called from a C++ background Thread
-  jni::ThreadScope::WithClassLoader([this] () {
+  jni::ThreadScope::WithClassLoader([&] () {
     // 2.2 schedule `triggerUI` to be called on the java thread
     static auto method = _javaPart->getClass()->getMethod<void()>("scheduleTrigger");
     method(_javaPart.get());

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
@@ -22,10 +22,11 @@ void JVisionCameraScheduler::dispatchAsync(const std::function<void()>& job) {
 
 void JVisionCameraScheduler::scheduleTrigger() {
   // 2.1 Open a JNI Thread scope because this might be called from a C++ background Thread
-  jni::ThreadScope scope;
-  // 2.2 schedule `triggerUI` to be called on the java thread
-  static auto method = _javaPart->getClass()->getMethod<void()>("scheduleTrigger");
-  method(_javaPart.get());
+  jni::ThreadScope::WithClassLoader([this] () {
+    // 2.2 schedule `triggerUI` to be called on the java thread
+    static auto method = _javaPart->getClass()->getMethod<void()>("scheduleTrigger");
+    method(_javaPart.get());
+  });
 }
 
 void JVisionCameraScheduler::trigger() {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
