### PR TITLE
fix: Fix `capture/no-valid-data` thrown when calling `stopRecording()` on some Android devices

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -508,8 +508,8 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
 
       preview = previewBuilder.build()
       Log.i(TAG, "Attaching ${useCases.size} use-cases...")
-      camera = cameraProvider.bindToLifecycle(this, cameraSelector, preview, *useCases.toTypedArray())
       preview!!.setSurfaceProvider(previewView.surfaceProvider)
+      camera = cameraProvider.bindToLifecycle(this, cameraSelector, preview, *useCases.toTypedArray())
 
       minZoom = camera!!.cameraInfo.zoomState.value?.minZoomRatio ?: 1f
       maxZoom = camera!!.cameraInfo.zoomState.value?.maxZoomRatio ?: 1f


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

This PR fixes the crash happening on some Android devices while trying to record a video with the front camera (described in #2428)

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

Call `preview.setSurfaceProvider()` before calling `cameraProvider.bindToLifecycle()` as recommended [here](https://issuetracker.google.com/issues/270656244#comment21)

The bug is known in CameraX and has been fixed in 1.2.x but not backported to 1.1.x
This is the recommended workaround 

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * Xiaomi M2101K9G, Android 11
    * HONOR REA-NX9, Android 13
    * Samsung SM-F711, Android 13
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #2428
-->
