### PR TITLE
fix: Fix crash in `toArrayBuffer()` by properly acquiring a reference on `AHardwareBuffer*`

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
@@ -95,14 +95,12 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
 #if __ANDROID_API__ >= 26
       AHardwareBuffer* hardwareBuffer = this->frame->getHardwareBuffer();
       AHardwareBuffer_acquire(hardwareBuffer);
-      finally([&] () {
-        AHardwareBuffer_release(hardwareBuffer);
-      });
+      finally([&]() { AHardwareBuffer_release(hardwareBuffer); });
 
       AHardwareBuffer_Desc bufferDescription;
       AHardwareBuffer_describe(hardwareBuffer, &bufferDescription);
-      __android_log_print(ANDROID_LOG_INFO, "Frame", "Converting %i x %i @ %i HardwareBuffer...",
-                          bufferDescription.width, bufferDescription.height, bufferDescription.stride);
+      __android_log_print(ANDROID_LOG_INFO, "Frame", "Converting %i x %i @ %i HardwareBuffer...", bufferDescription.width,
+                          bufferDescription.height, bufferDescription.stride);
       size_t size = bufferDescription.height * bufferDescription.stride;
 
       static constexpr auto ARRAYBUFFER_CACHE_PROP_NAME = "__frameArrayBufferCache";
@@ -129,10 +127,10 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
         throw jsi::JSError(runtime, "Failed to lock HardwareBuffer for reading!");
       }
       finally([&]() {
-          int result = AHardwareBuffer_unlock(hardwareBuffer, nullptr);
-          if (result != 0) {
-              throw jsi::JSError(runtime, "Failed to lock HardwareBuffer for reading!");
-          }
+        int result = AHardwareBuffer_unlock(hardwareBuffer, nullptr);
+        if (result != 0) {
+          throw jsi::JSError(runtime, "Failed to lock HardwareBuffer for reading!");
+        }
       });
 
       // directly write to C++ JSI ArrayBuffer

--- a/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessor/FrameHostObject.cpp
@@ -15,6 +15,8 @@
 #include <android/hardware_buffer.h>
 #include <android/hardware_buffer_jni.h>
 
+#include "FinalAction.h"
+
 namespace vision {
 
 using namespace facebook;
@@ -92,11 +94,15 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     jsi::HostFunctionType toArrayBuffer = JSI_FUNC {
 #if __ANDROID_API__ >= 26
       AHardwareBuffer* hardwareBuffer = this->frame->getHardwareBuffer();
+      AHardwareBuffer_acquire(hardwareBuffer);
+      finally([&] () {
+        AHardwareBuffer_release(hardwareBuffer);
+      });
 
       AHardwareBuffer_Desc bufferDescription;
       AHardwareBuffer_describe(hardwareBuffer, &bufferDescription);
-      __android_log_print(ANDROID_LOG_INFO, "Frame", "Buffer %i x %i @ %i", bufferDescription.width, bufferDescription.height,
-                          bufferDescription.stride);
+      __android_log_print(ANDROID_LOG_INFO, "Frame", "Converting %i x %i @ %i HardwareBuffer...",
+                          bufferDescription.width, bufferDescription.height, bufferDescription.stride);
       size_t size = bufferDescription.height * bufferDescription.stride;
 
       static constexpr auto ARRAYBUFFER_CACHE_PROP_NAME = "__frameArrayBufferCache";
@@ -118,15 +124,20 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
 
       // Get CPU access to the HardwareBuffer (&buffer is a virtual temporary address)
       void* buffer;
-      AHardwareBuffer_lock(hardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_MASK, -1, nullptr, &buffer);
+      int result = AHardwareBuffer_lock(hardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_MASK, -1, nullptr, &buffer);
+      if (result != 0) {
+        throw jsi::JSError(runtime, "Failed to lock HardwareBuffer for reading!");
+      }
+      finally([&]() {
+          int result = AHardwareBuffer_unlock(hardwareBuffer, nullptr);
+          if (result != 0) {
+              throw jsi::JSError(runtime, "Failed to lock HardwareBuffer for reading!");
+          }
+      });
 
       // directly write to C++ JSI ArrayBuffer
       auto destinationBuffer = arrayBuffer.data(runtime);
       memcpy(destinationBuffer, buffer, sizeof(uint8_t) * size);
-
-      // Release HardwareBuffer again
-      AHardwareBuffer_unlock(hardwareBuffer, nullptr);
-      AHardwareBuffer_release(hardwareBuffer);
 
       return arrayBuffer;
 #else

--- a/package/cpp/FinalAction.h
+++ b/package/cpp/FinalAction.h
@@ -1,0 +1,31 @@
+//
+//  MutableRawBuffer.h
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 17.01.24.
+//  Copyright © 2024 mrousavy. All rights reserved.
+//
+
+#pragma once
+
+namespace vision {
+
+template <typename F>
+struct FinalAction {
+
+public:
+  FinalAction(F f) : clean_{f} {}
+  ~FinalAction() { if(enabled_) clean_(); }
+  void disable() { enabled_ = false; };
+
+private:
+  F clean_;
+  bool enabled_ = true;
+};
+
+} // namespace vision
+
+template <typename F>
+vision::FinalAction<F> finally(F f) {
+  return vision::FinalAction<F>(std::move(f));
+}

--- a/package/cpp/FinalAction.h
+++ b/package/cpp/FinalAction.h
@@ -10,13 +10,17 @@
 
 namespace vision {
 
-template <typename F>
-struct FinalAction {
+template <typename F> struct FinalAction {
 
 public:
   FinalAction(F f) : clean_{f} {}
-  ~FinalAction() { if(enabled_) clean_(); }
-  void disable() { enabled_ = false; };
+  ~FinalAction() {
+    if (enabled_)
+      clean_();
+  }
+  void disable() {
+    enabled_ = false;
+  };
 
 private:
   F clean_;
@@ -25,7 +29,6 @@ private:
 
 } // namespace vision
 
-template <typename F>
-vision::FinalAction<F> finally(F f) {
+template <typename F> vision::FinalAction<F> finally(F f) {
   return vision::FinalAction<F>(std::move(f));
 }

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -27,9 +27,9 @@ PODS:
   - libwebp/sharpyuv (1.3.2)
   - libwebp/webp (1.3.2):
     - libwebp/sharpyuv
-  - MMKV (1.3.2):
-    - MMKVCore (~> 1.3.2)
-  - MMKVCore (1.3.2)
+  - MMKV (1.3.3):
+    - MMKVCore (~> 1.3.3)
+  - MMKVCore (1.3.3)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -337,7 +337,7 @@ PODS:
   - react-native-mmkv (2.11.0):
     - MMKV (>= 1.2.13)
     - React-Core
-  - react-native-safe-area-context (4.8.0):
+  - react-native-safe-area-context (4.8.2):
     - React-Core
   - react-native-video (5.2.1):
     - React-Core
@@ -675,8 +675,8 @@ SPEC CHECKSUMS:
   hermes-engine: 9180d43df05c1ed658a87cc733dc3044cf90c00a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
-  MMKV: f21593c0af4b3f2a0ceb8f820f28bb639ea22bb7
-  MMKVCore: 31b4cb83f8266467eef20a35b6d78e409a11060d
+  MMKV: f902fb6719da13c2ab0965233d8963a59416f911
+  MMKVCore: d26e4d3edd5cb8588c2569222cbd8be4231374e9
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 83bca1c184feb4d2e51c72c8369b83d641443f95
   RCTTypeSafety: 13c4a87a16d7db6cd66006ce9759f073402ef85b
@@ -695,7 +695,7 @@ SPEC CHECKSUMS:
   react-native-blur: cfdad7b3c01d725ab62a8a729f42ea463998afa2
   react-native-cameraroll: 4701ae7c3dbcd3f5e9e150ca17f250a276154b35
   react-native-mmkv: e97c0c79403fb94577e5d902ab1ebd42b0715b43
-  react-native-safe-area-context: d1c8161a1e9560f7066e8926a7d825eb57c5dab5
+  react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   react-native-video: c26780b224543c62d5e1b2a7244a5cd1b50e8253
   react-native-worklets-core: a894d572639fcf37c6d284cc799882d25d00c93d
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes a crash in `toArrayBuffer()` that happens because of a race condition where the returned `HardwareBuffer` was deleted first.

Now, we acquire a strong reference on the `AHardwareBuffer*` when we operate on it to fix that crash.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
