### PR TITLE
fix: Improve Templates type

### DIFF
--- a/package/src/devices/Templates.ts
+++ b/package/src/devices/Templates.ts
@@ -1,9 +1,17 @@
 import { Dimensions } from 'react-native'
 import { FormatFilter } from './getCameraFormat'
 
-type TTemplates = {
-  [key: string]: FormatFilter[]
-}
+type PredefinedTemplates =
+  | 'Video'
+  | 'Video60Fps'
+  | 'VideoSlowMotion'
+  | 'VideoStabilized'
+  | 'Photo'
+  | 'PhotoPortrait'
+  | 'FrameProcessingYUV'
+  | 'FrameProcessingRGB'
+  | 'Snapchat'
+  | 'Instagram'
 
 const SnapchatResolution = { width: 1920, height: 1080 }
 const InstagramResolution = { width: 3840, height: 2160 }
@@ -16,7 +24,7 @@ const ScreenAspectRatio = Dimensions.get('window').height / Dimensions.get('wind
  * const format = useCameraFormat(device, Templates.Snapchat)
  * ```
  */
-export const Templates: TTemplates = {
+export const Templates: Record<PredefinedTemplates, FormatFilter[]> = {
   /**
    * Highest resolution video recordings (e.g. 4k)
    */


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What


The predefined template has a generic type, so the TypeScript and autocomplete can't get a typo issue. This PR defines a literal type to register all keys and help users when using `Templates`.   


## Changes

This PR changes the `Templates` const type. 

## Tested on

<img width="920" alt="image" src="https://github.com/mrousavy/react-native-vision-camera/assets/12939735/bb30237d-e166-47cf-896e-11a4b1298133">


## Related issues

