### PR TITLE
fix: Fix crash in `HardwareBuffer.isSupported`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -224,8 +224,13 @@ class VideoPipeline(
 
   @RequiresApi(Build.VERSION_CODES.Q)
   private fun supportsHardwareBufferFlags(flags: Long): Boolean {
-    val hardwareBufferFormat = format.toHardwareBufferFormat()
-    return HardwareBuffer.isSupported(width, height, hardwareBufferFormat, 1, flags)
+    try {
+      val hardwareBufferFormat = format.toHardwareBufferFormat()
+      return HardwareBuffer.isSupported(width, height, hardwareBufferFormat, 1, flags)
+    } catch (e: Throwable) {
+      Log.e(TAG, "HardwareBuffer.isSupported($width, $height, $hardwareBufferFormat, 1, $flags) failed!", e)
+      return false
+    }
   }
 
   private external fun getInputTextureId(): Int

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -228,7 +228,7 @@ class VideoPipeline(
       val hardwareBufferFormat = format.toHardwareBufferFormat()
       return HardwareBuffer.isSupported(width, height, hardwareBufferFormat, 1, flags)
     } catch (e: Throwable) {
-      Log.e(TAG, "HardwareBuffer.isSupported($width, $height, $hardwareBufferFormat, 1, $flags) failed!", e)
+      Log.e(TAG, "HardwareBuffer.isSupported($width, $height, $format, 1, $flags) failed!", e)
       return false
     }
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Might fix a crash reported by @bglgwyng

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
