### PR TITLE
Fix photo not saving in Android example app on Android 13+

### DIFF
--- a/package/example/src/MediaPage.tsx
+++ b/package/example/src/MediaPage.tsx
@@ -14,7 +14,8 @@ import { useIsFocused } from '@react-navigation/core'
 import FastImage, { OnLoadEvent } from 'react-native-fast-image'
 
 const requestSavePermission = async (): Promise<boolean> => {
-  if (Platform.OS !== 'android') return true
+  // On Android 13 and above, scoped storage is used instead and no permission is needed
+  if (Platform.OS !== 'android' || Platform.Version >= 33) return true
 
   const permission = PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
   if (permission == null) return false


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes an issue in the example app which prevented the saving of photos on Android 13+. I came across this when testing #2519 and needed to save some example photos.


On Android 13+, requesting the `WRITE_EXTERNAL_STORAGE` permission immediately denies, without asking the user. Instead we need to use scoped storage. The `@react-native-camera-roll/camera-roll` plugin being used already supports using scoped storage for saving images on Android 13+, so all we need to do is skip the permission check in that case.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

* This PR skips the storage permission check in the example app on Android 13+

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

* Pixel 7a, Android 14

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
