### PR TITLE
Revert: #1955 unbinding camera

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -302,10 +302,6 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   }
 
   override fun onDetachedFromWindow() {
-    coroutineScope.launch {
-      val cameraProvider = ProcessCameraProvider.getInstance(reactContext).await()
-      cameraProvider.unbindAll()
-    }
     super.onDetachedFromWindow()
     updateLifecycleState()
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

In this PR:

- https://github.com/mrousavy/react-native-vision-camera/pull/1955/

A regression has been introduced which causes the camera to be unmounted when returning to a screen. Reproduction video:


https://github.com/mrousavy/react-native-vision-camera/assets/16821682/41afbc10-1b24-420f-9ada-afbd60a96d6b



## Changes

Simply reverts unmounting the camera. 

## Tested on

/ 

## Related issues

/
