### PR TITLE
perf: Fix double configuration on device change

### DIFF
--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -144,6 +144,9 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
         // If needed, configure the AVCaptureDevice (format, zoom, low-light-boost, ..)
         if difference.isDeviceConfigurationDirty {
           try device.lockForConfiguration()
+          defer {
+            device.unlockForConfiguration()
+          }
 
           // 4. Configure format
           if difference.formatChanged {
@@ -166,8 +169,6 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
           if difference.exposureChanged {
             self.configureExposure(configuration: config, device: device)
           }
-
-          device.unlockForConfiguration()
         }
 
         if difference.isSessionConfigurationDirty {
@@ -182,8 +183,10 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
         // 10. Enable or disable the Torch if needed (requires session to be running)
         if difference.torchChanged {
           try device.lockForConfiguration()
+          defer {
+            device.unlockForConfiguration()
+          }
           try self.configureTorch(configuration: config, device: device)
-          device.unlockForConfiguration()
         }
 
         // Notify about Camera initialization

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -117,55 +117,61 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
       do {
         // If needed, configure the AVCaptureSession (inputs, outputs)
         if difference.isSessionConfigurationDirty {
-         self.session.beginConfiguration()
-         defer {
-           self.session.commitConfiguration()
-         }
-         try self.withSessionLock {
-            // 1. Update input device
-            if difference.inputChanged {
-              try self.configureDevice(configuration: config)
-            }
-            // 2. Update outputs
-            if difference.outputsChanged {
-              try self.configureOutputs(configuration: config)
-            }
-            // 3. Update Video Stabilization
-            if difference.videoStabilizationChanged {
-              self.configureVideoStabilization(configuration: config)
-            }
-            // 4. Update output orientation
-            if difference.orientationChanged {
-              self.configureOrientation(configuration: config)
-            }
+          self.captureSession.beginConfiguration()
+          
+          // 1. Update input device
+          if difference.inputChanged {
+            try self.configureDevice(configuration: config)
           }
+          // 2. Update outputs
+          if difference.outputsChanged {
+            try self.configureOutputs(configuration: config)
+          }
+          // 3. Update Video Stabilization
+          if difference.videoStabilizationChanged {
+            self.configureVideoStabilization(configuration: config)
+          }
+          // 4. Update output orientation
+          if difference.orientationChanged {
+            self.configureOrientation(configuration: config)
+          }
+        }
+        
+        guard let device = self.videoDeviceInput?.device else {
+          throw CameraError.session(.cameraNotReady)
         }
 
         // If needed, configure the AVCaptureDevice (format, zoom, low-light-boost, ..)
         if difference.isDeviceConfigurationDirty {
-          try self.withDeviceLock { device in
-            // 4. Configure format
-            if difference.formatChanged {
-              try self.configureFormat(configuration: config, device: device)
-            }
-            // 5. After step 2. and 4., we also need to configure the PixelFormat.
-            //    This needs to be done AFTER we updated the `format`, as this controls the supported PixelFormats.
-            if difference.outputsChanged || difference.formatChanged {
-              try self.configurePixelFormat(configuration: config)
-            }
-            // 6. Configure side-props (fps, lowLightBoost)
-            if difference.sidePropsChanged {
-              try self.configureSideProps(configuration: config, device: device)
-            }
-            // 7. Configure zoom
-            if difference.zoomChanged {
-              self.configureZoom(configuration: config, device: device)
-            }
-            // 8. Configure exposure bias
-            if difference.exposureChanged {
-              self.configureExposure(configuration: config, device: device)
-            }
+          try device.lockForConfiguration()
+          
+          // 4. Configure format
+          if difference.formatChanged {
+            try self.configureFormat(configuration: config, device: device)
           }
+          // 5. After step 2. and 4., we also need to configure the PixelFormat.
+          //    This needs to be done AFTER we updated the `format`, as this controls the supported PixelFormats.
+          if difference.outputsChanged || difference.formatChanged {
+            try self.configurePixelFormat(configuration: config)
+          }
+          // 6. Configure side-props (fps, lowLightBoost)
+          if difference.sidePropsChanged {
+            try self.configureSideProps(configuration: config, device: device)
+          }
+          // 7. Configure zoom
+          if difference.zoomChanged {
+            self.configureZoom(configuration: config, device: device)
+          }
+          // 8. Configure exposure bias
+          if difference.exposureChanged {
+            self.configureExposure(configuration: config, device: device)
+          }
+          
+          device.unlockForConfiguration()
+        }
+        
+        if difference.isSessionConfigurationDirty {
+          self.captureSession.commitConfiguration()
         }
 
         // 9. Start or stop the session if needed
@@ -173,9 +179,9 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
 
         // 10. Enable or disable the Torch if needed (requires session to be running)
         if difference.torchChanged {
-          try self.withDeviceLock { device in
-            try self.configureTorch(configuration: config, device: device)
-          }
+          try device.lockForConfiguration()
+          try self.configureTorch(configuration: config, device: device)
+          device.unlockForConfiguration()
         }
 
         // Notify about Camera initialization
@@ -208,41 +214,6 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
         }
       }
     }
-  }
-
-  /**
-   Runs the given [lambda] under an AVCaptureSession configuration lock (`beginConfiguration()`)
-   */
-  private func withSessionLock(_ lambda: () throws -> Void) throws {
-    // Lock Capture Session for configuration
-    ReactLogger.log(level: .info, message: "Beginning CameraSession configuration...")
-    captureSession.beginConfiguration()
-    defer {
-      // Unlock Capture Session again and submit configuration to Hardware
-      self.captureSession.commitConfiguration()
-      ReactLogger.log(level: .info, message: "Committed CameraSession configuration!")
-    }
-
-    // Call lambda
-    try lambda()
-  }
-
-  /**
-   Runs the given [lambda] under an AVCaptureDevice configuration lock (`lockForConfiguration()`)
-   */
-  private func withDeviceLock(_ lambda: (_ device: AVCaptureDevice) throws -> Void) throws {
-    guard let device = videoDeviceInput?.device else {
-      throw CameraError.session(.cameraNotReady)
-    }
-    ReactLogger.log(level: .info, message: "Beginning CaptureDevice configuration...")
-    try device.lockForConfiguration()
-    defer {
-      device.unlockForConfiguration()
-      ReactLogger.log(level: .info, message: "Committed CaptureDevice configuration!")
-    }
-
-    // Call lambda with Device
-    try lambda(device)
   }
 
   /**

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -138,7 +138,7 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
         }
 
         guard let device = self.videoDeviceInput?.device else {
-          throw CameraError.session(.cameraNotReady)
+          throw CameraError.device(.noDevice)
         }
 
         // If needed, configure the AVCaptureDevice (format, zoom, low-light-boost, ..)

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -117,7 +117,11 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
       do {
         // If needed, configure the AVCaptureSession (inputs, outputs)
         if difference.isSessionConfigurationDirty {
-          try self.withSessionLock {
+         self.session.beginConfiguration()
+         defer {
+           self.session.commitConfiguration()
+         }
+         try self.withSessionLock {
             // 1. Update input device
             if difference.inputChanged {
               try self.configureDevice(configuration: config)

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -118,7 +118,7 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
         // If needed, configure the AVCaptureSession (inputs, outputs)
         if difference.isSessionConfigurationDirty {
           self.captureSession.beginConfiguration()
-          
+
           // 1. Update input device
           if difference.inputChanged {
             try self.configureDevice(configuration: config)
@@ -136,7 +136,7 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
             self.configureOrientation(configuration: config)
           }
         }
-        
+
         guard let device = self.videoDeviceInput?.device else {
           throw CameraError.session(.cameraNotReady)
         }
@@ -144,7 +144,7 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
         // If needed, configure the AVCaptureDevice (format, zoom, low-light-boost, ..)
         if difference.isDeviceConfigurationDirty {
           try device.lockForConfiguration()
-          
+
           // 4. Configure format
           if difference.formatChanged {
             try self.configureFormat(configuration: config, device: device)
@@ -166,10 +166,10 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
           if difference.exposureChanged {
             self.configureExposure(configuration: config, device: device)
           }
-          
+
           device.unlockForConfiguration()
         }
-        
+
         if difference.isSessionConfigurationDirty {
           self.captureSession.commitConfiguration()
         }

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -171,6 +171,8 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
         }
 
         if difference.isSessionConfigurationDirty {
+          // We commit the session config updates AFTER the device config,
+          // that way we can also batch those changes into one update instead of doing two updates.
           self.captureSession.commitConfiguration()
         }
 


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the visual Camera zoom glitch that happened everytime you switch the Camera device, as well as on the initial mount of the camera.

The reason for this bug was that the device was configured **after** the session, meaning we had a double configuration instead of one single batch, causing an additonal delay/flicker of the preview.

This now also means the session starts faster! 🔥 🚀 

Before:


https://github.com/mrousavy/react-native-vision-camera/assets/15199031/26f3fbea-0c79-46c8-a3d0-e25ee634dece

After:

https://github.com/mrousavy/react-native-vision-camera/assets/15199031/277ebcc1-c67b-4f7e-85ed-ff736f23521c




<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2525

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
