### PR TITLE
fix: Close capture session before reconfiguring outputs

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -237,13 +237,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
     // Destroy previous outputs
     Log.i(TAG, "Destroying previous outputs...")
-    photoOutput?.close()
-    photoOutput = null
-    videoOutput?.close()
-    videoOutput = null
-    codeScannerOutput?.close()
-    codeScannerOutput = null
-    isRunning = false
+    destroy()
 
     val characteristics = cameraManager.getCameraCharacteristics(cameraId)
     val format = configuration.format


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Not closing capture session before reconfiguring outputs triggers `TOO_MANY_OPEN_CAMERAS` error on Android when navigating from a screen to another one with different cameras.

This PR is an attempt to fix this. (And closes previous attempt #2157)

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

This PR makes a call to `captureSession.close` during `CameraSession.configureOutputs`

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

This issue is an Android only one, tested on Pixel 5, Android 14. Using this repro repo: https://github.com/xseignard/black-screen


## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

* Fixes #2378
* Fixes #2240
* Fixes #1958
* Closes #2157
