### PR TITLE
feat: Add `context` to `VisionCameraProxy`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraProxy.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/VisionCameraProxy.kt
@@ -14,7 +14,7 @@ import com.mrousavy.camera.core.ViewNotFoundError
 import java.lang.ref.WeakReference
 
 @Suppress("KotlinJniMissingFunction") // we use fbjni.
-class VisionCameraProxy(context: ReactApplicationContext) {
+class VisionCameraProxy(private val reactContext: ReactApplicationContext) {
   companion object {
     const val TAG = "VisionCameraProxy"
   }
@@ -24,6 +24,8 @@ class VisionCameraProxy(context: ReactApplicationContext) {
   private var mHybridData: HybridData
   private var mContext: WeakReference<ReactApplicationContext>
   private var mScheduler: VisionCameraScheduler
+  val context: ReactApplicationContext
+    get() = reactContext
 
   init {
     val jsCallInvokerHolder = context.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds the current `ReactApplicationContext` (extends Android's [`Context`](https://developer.android.com/reference/android/content/Context)) to `VisionCameraProxy` so you can access that in Frame Processor Plugins.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
