### PR TITLE
fix: Fix `java.lang.NoSuchMethodError` in `FrameProcessor` initializer

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessor.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/FrameProcessor.java
@@ -21,6 +21,8 @@ public final class FrameProcessor {
     @Keep
     private final HybridData mHybridData;
 
+    @DoNotStrip
+    @Keep
     public FrameProcessor(HybridData hybridData) {
         mHybridData = hybridData;
     }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the `FrameProcessor(..)` constructor being stripped by ProGuard in release builds, which previously caused this error:

```
java.lang.NoSuchMethodError: no non-static method "Lcom/mrousavy/camera/frameprocessor/FrameProcessor;.<init>(Lcom/facebook/jni/HybridData;)V"
```

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2544

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
