### PR TITLE
fix: Fix "Invalid pixel format 35" HardwareBuffer crash

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -228,7 +228,11 @@ class VideoPipeline(
   @RequiresApi(Build.VERSION_CODES.Q)
   private fun supportsHardwareBufferFlags(flags: Long): Boolean {
     val hardwareBufferFormat = format.toHardwareBufferFormat()
-    return HardwareBuffer.isSupported(width, height, hardwareBufferFormat, 1, flags)
+    try {
+      return HardwareBuffer.isSupported(width, height, hardwareBufferFormat, 1, flags)
+    } catch (_: Throwable) {
+      return false
+    }
   }
 
   private external fun getInputTextureId(): Int


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

The HardwareBuffer Format YCBCR420 is apparently only supported on API 30 or something, and if you try to use it on API 29 or lower it will crash because `HardwareBuffer.isSupported(YCBCR420, ...)` will throw an IllegalArgumentError:

```
java.lang.IllegalArgumentException: Invalid pixel format 35
```

This PR just fixes that by catching this error and returning `false` instead of crashing the app (which is what this method should always do instead in my opinion)

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2540

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
