### PR TITLE
fix: Fix crashing when setting torch to null

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -86,8 +86,12 @@ class CameraViewManager : ViewGroupManager<CameraView>() {
 
   @ReactProp(name = "videoStabilizationMode")
   fun setVideoStabilizationMode(view: CameraView, videoStabilizationMode: String?) {
-    val newMode = VideoStabilizationMode.fromUnionValue(videoStabilizationMode)
-    view.videoStabilizationMode = newMode
+    if (videoStabilizationMode != null) {
+      val newMode = VideoStabilizationMode.fromUnionValue(videoStabilizationMode)
+      view.videoStabilizationMode = newMode
+    } else {
+      view.videoStabilizationMode = null
+    }
   }
 
   @ReactProp(name = "enableHighQualityPhotos")

--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -44,7 +44,7 @@ public final class CameraView: UIView, CameraSessionDelegate {
   @objc var orientation: NSString?
   // other props
   @objc var isActive = false
-  @objc var torch = "off"
+  @objc var torch: NSString?
   @objc var zoom: NSNumber = 1.0 // in "factor"
   @objc var exposure: NSNumber = 1.0
   @objc var enableFpsGraph = false
@@ -142,8 +142,16 @@ public final class CameraView: UIView, CameraSessionDelegate {
 
   func getTorch() -> Torch {
     // TODO: Use ObjC RCT enum parser for this
-    if let torch = try? Torch(jsValue: torch) {
-      return torch
+    if let torch = torch as? String {
+      do {
+        return try Torch(jsValue: pixelFormat)
+      } catch {
+        if let error = error as? CameraError {
+          onError(error)
+        } else {
+          onError(.unknown(message: error.localizedDescription, cause: error as NSError))
+        }
+      }
     }
     return .off
   }
@@ -227,7 +235,7 @@ public final class CameraView: UIView, CameraSessionDelegate {
       // Side-Props
       config.fps = fps?.int32Value
       config.enableLowLightBoost = lowLightBoost
-      config.torch = try Torch(jsValue: torch)
+      config.torch = getTorch()
 
       // Zoom
       config.zoom = zoom.doubleValue


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fix crash when setting `torch` back to `null` again after it has already been set.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2533

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
