### PR TITLE
perf: Allow skipping pre-capture sequence if already focused

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -172,7 +172,7 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
 
       // 1. Run precapture sequence
       val precaptureRequest = repeatingRequest.createCaptureRequest(device, deviceDetails, repeatingOutputs)
-      val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE, PrecaptureTrigger.AWB), flash, emptyList())
+      val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE, PrecaptureTrigger.AWB), flash, emptyList(), true)
       val result = session.precapture(precaptureRequest, deviceDetails, options)
 
       try {
@@ -208,7 +208,7 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
 
       // 1. Run a precapture sequence for AF, AE and AWB.
       val request = repeatingRequest.createCaptureRequest(device, deviceDetails, outputs)
-      val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE), Flash.OFF, listOf(point))
+      val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE), Flash.OFF, listOf(point), false)
       session.precapture(request, deviceDetails, options)
 
       // 2. Wait 3 seconds

--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -172,7 +172,8 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
 
       // 1. Run precapture sequence
       val precaptureRequest = repeatingRequest.createCaptureRequest(device, deviceDetails, repeatingOutputs)
-      val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE, PrecaptureTrigger.AWB), flash, emptyList(), true)
+      val skipIfPassivelyFocused = flash == Flash.OFF
+      val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE, PrecaptureTrigger.AWB), flash, emptyList(), skipIfPassivelyFocused)
       val result = session.precapture(precaptureRequest, deviceDetails, options)
 
       try {

--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -173,7 +173,13 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
       // 1. Run precapture sequence
       val precaptureRequest = repeatingRequest.createCaptureRequest(device, deviceDetails, repeatingOutputs)
       val skipIfPassivelyFocused = flash == Flash.OFF
-      val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE, PrecaptureTrigger.AWB), flash, emptyList(), skipIfPassivelyFocused)
+      val options =
+        PrecaptureOptions(
+          listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE, PrecaptureTrigger.AWB),
+          flash,
+          emptyList(),
+          skipIfPassivelyFocused
+        )
       val result = session.precapture(precaptureRequest, deviceDetails, options)
 
       try {

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
@@ -11,7 +11,12 @@ import com.mrousavy.camera.core.CameraDeviceDetails
 import com.mrousavy.camera.types.Flash
 import com.mrousavy.camera.types.HardwareLevel
 
-data class PrecaptureOptions(val modes: List<PrecaptureTrigger>, val flash: Flash = Flash.OFF, val pointsOfInterest: List<Point>, val skipIfPassivelyFocused: Boolean)
+data class PrecaptureOptions(
+  val modes: List<PrecaptureTrigger>,
+  val flash: Flash = Flash.OFF,
+  val pointsOfInterest: List<Point>,
+  val skipIfPassivelyFocused: Boolean
+)
 
 data class PrecaptureResult(val needsFlash: Boolean)
 

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
@@ -11,7 +11,7 @@ import com.mrousavy.camera.core.CameraDeviceDetails
 import com.mrousavy.camera.types.Flash
 import com.mrousavy.camera.types.HardwareLevel
 
-data class PrecaptureOptions(val modes: List<PrecaptureTrigger>, val flash: Flash = Flash.OFF, val pointsOfInterest: List<Point>)
+data class PrecaptureOptions(val modes: List<PrecaptureTrigger>, val flash: Flash = Flash.OFF, val pointsOfInterest: List<Point>, val skipIfPassivelyFocused: Boolean)
 
 data class PrecaptureResult(val needsFlash: Boolean)
 
@@ -33,15 +33,22 @@ suspend fun CameraCaptureSession.precapture(
   request.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO)
 
   var enableFlash = options.flash == Flash.ON
+  var afState = FocusState.Inactive
+  var aeState = ExposureState.Inactive
+  var awbState = WhiteBalanceState.Inactive
 
   // 1. Cancel any ongoing precapture sequences
   request.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL)
   request.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_CANCEL)
-  if (options.flash == Flash.AUTO) {
-    // we want Auto-Flash, so check the current lighting conditions if we need it.
+  if (options.flash == Flash.AUTO || options.skipIfPassivelyFocused) {
+    // We want to read the current AE/AF/AWB values to determine if we need flash or can skip AF/AE/AWB precapture
     val result = this.capture(request.build(), false)
-    val aeState = result.get(CaptureResult.CONTROL_AE_STATE)
-    if (aeState == CaptureResult.CONTROL_AE_STATE_FLASH_REQUIRED) {
+
+    afState = FocusState.fromAFState(result.get(CaptureResult.CONTROL_AF_STATE) ?: CaptureResult.CONTROL_AF_STATE_INACTIVE)
+    aeState = ExposureState.fromAEState(result.get(CaptureResult.CONTROL_AE_STATE) ?: CaptureResult.CONTROL_AE_STATE_INACTIVE)
+    awbState = WhiteBalanceState.fromAWBState(result.get(CaptureResult.CONTROL_AWB_STATE) ?: CaptureResult.CONTROL_AWB_STATE_INACTIVE)
+
+    if (aeState == ExposureState.FlashRequired) {
       Log.i(TAG, "Auto-Flash: Flash is required for photo capture, enabling flash...")
       enableFlash = true
     } else {
@@ -57,11 +64,18 @@ suspend fun CameraCaptureSession.precapture(
     MeteringRectangle(point, DEFAULT_METERING_SIZE, meteringWeight)
   }.toTypedArray()
 
+  val skipAF = options.skipIfPassivelyFocused && afState.isPassivelyFocused
+  val skipAE = options.skipIfPassivelyFocused && aeState.isPassivelyFocused
+  val skipAWB = options.skipIfPassivelyFocused && awbState.isPassivelyFocused
+  if (skipAF || skipAE || skipAWB) {
+    Log.i(TAG, "Skipping AF: $skipAF, Skipping AE: $skipAE, Skipping AWB: $skipAWB")
+  }
+
   // 2. Submit a precapture start sequence
   if (enableFlash && deviceDetails.hasFlash) {
     request.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH)
   }
-  if (options.modes.contains(PrecaptureTrigger.AF)) {
+  if (options.modes.contains(PrecaptureTrigger.AF) && !skipAF) {
     // AF Precapture
     if (deviceDetails.afModes.contains(CaptureRequest.CONTROL_AF_MODE_AUTO)) {
       request.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO)
@@ -71,14 +85,14 @@ suspend fun CameraCaptureSession.precapture(
     }
     request.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START)
   }
-  if (options.modes.contains(PrecaptureTrigger.AE) && deviceDetails.hardwareLevel.isAtLeast(HardwareLevel.LIMITED)) {
+  if (options.modes.contains(PrecaptureTrigger.AE) && deviceDetails.hardwareLevel.isAtLeast(HardwareLevel.LIMITED) && !skipAE) {
     // AE Precapture
     if (meteringRectangles.isNotEmpty() && deviceDetails.supportsExposureRegions) {
       request.set(CaptureRequest.CONTROL_AE_REGIONS, meteringRectangles)
     }
     request.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START)
   }
-  if (options.modes.contains(PrecaptureTrigger.AWB)) {
+  if (options.modes.contains(PrecaptureTrigger.AWB) && !skipAWB) {
     // AWB Precapture
     if (meteringRectangles.isNotEmpty() && deviceDetails.supportsWhiteBalanceRegions) {
       request.set(CaptureRequest.CONTROL_AWB_REGIONS, meteringRectangles)

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
@@ -35,6 +35,8 @@ enum class FocusState {
 
   val isCompleted: Boolean
     get() = this == Focused || this == Unfocused
+  val isPassivelyFocused: Boolean
+    get() = this == PassiveFocused
 
   companion object {
     fun fromAFState(afState: Int): FocusState =
@@ -60,6 +62,8 @@ enum class ExposureState {
 
   val isCompleted: Boolean
     get() = this == Converged || this == FlashRequired
+  val isPassivelyFocused: Boolean
+    get() = this == Converged
 
   companion object {
     fun fromAEState(aeState: Int): ExposureState =
@@ -82,6 +86,8 @@ enum class WhiteBalanceState {
   Converged;
 
   val isCompleted: Boolean
+    get() = this == Converged
+  val isPassivelyFocused: Boolean
     get() = this == Converged
 
   companion object {

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
@@ -24,7 +24,12 @@ enum class PrecaptureTrigger {
   AWB
 }
 
-enum class FocusState {
+interface AutoState {
+  val isCompleted: Boolean
+  val isPassivelyFocused: Boolean
+}
+
+enum class FocusState : AutoState {
   Inactive,
   Scanning,
   Focused,
@@ -33,9 +38,9 @@ enum class FocusState {
   PassiveFocused,
   PassiveUnfocused;
 
-  val isCompleted: Boolean
+  override val isCompleted: Boolean
     get() = this == Focused || this == Unfocused
-  val isPassivelyFocused: Boolean
+  override val isPassivelyFocused: Boolean
     get() = this == PassiveFocused
 
   companion object {
@@ -52,7 +57,7 @@ enum class FocusState {
       }
   }
 }
-enum class ExposureState {
+enum class ExposureState : AutoState {
   Locked,
   Inactive,
   Precapture,
@@ -60,9 +65,9 @@ enum class ExposureState {
   Converged,
   FlashRequired;
 
-  val isCompleted: Boolean
+  override val isCompleted: Boolean
     get() = this == Converged || this == FlashRequired
-  val isPassivelyFocused: Boolean
+  override val isPassivelyFocused: Boolean
     get() = this == Converged
 
   companion object {
@@ -79,15 +84,15 @@ enum class ExposureState {
   }
 }
 
-enum class WhiteBalanceState {
+enum class WhiteBalanceState : AutoState {
   Inactive,
   Locked,
   Searching,
   Converged;
 
-  val isCompleted: Boolean
+  override val isCompleted: Boolean
     get() = this == Converged
-  val isPassivelyFocused: Boolean
+  override val isPassivelyFocused: Boolean
     get() = this == Converged
 
   companion object {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR speeds up photo capture on Android by skipping pre-capture sequences on modes that are already focused (either AF, AE or AWB)

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
