### PR TITLE
Add UPC-A support

### DIFF
--- a/docs/docs/guides/CODE_SCANNING.mdx
+++ b/docs/docs/guides/CODE_SCANNING.mdx
@@ -131,3 +131,22 @@ The Code Scanner will call your [`onCodeScanned`](/docs/api/interfaces/CodeScann
 <br />
 
 #### 🚀 Next section: [Frame Processors](frame-processors)
+
+## Special Case (UPC-A)
+
+UPC-A is a special case to handle if you need to cater for it. Android's SDK officially supports UPC-A but iOS does not, instead they handle the code as EAN-13. Since EAN-13 is a superset of UPC-A, with an extra 0 digit at the front.
+
+This means the following code gives you the wrong type.
+
+```jsx
+const codeScanner = useCodeScanner({
+  codeTypes: ['upc-a'], // <-- ✅ I configure 'upc-a'
+  onCodeScanned: (codes) => {
+    for (const code of codes) {
+      console.log(code.type); // <-- ❌ I receive 'ean-13' on iOS
+    }
+  }
+})
+```
+
+You will need to keep this in mind and do the conversion from EAN-13 to UPC-A yourself. This can be done by removing the front `0` digit from the code to get a UPC-A code.

--- a/docs/docs/guides/CODE_SCANNING.mdx
+++ b/docs/docs/guides/CODE_SCANNING.mdx
@@ -130,23 +130,23 @@ The Code Scanner will call your [`onCodeScanned`](/docs/api/interfaces/CodeScann
 
 <br />
 
-#### 🚀 Next section: [Frame Processors](frame-processors)
-
-## Special Case (UPC-A)
+## UPC-A vs EAN-13 codes
 
 UPC-A is a special case to handle if you need to cater for it. Android's SDK officially supports UPC-A but iOS does not, instead they handle the code as EAN-13. Since EAN-13 is a superset of UPC-A, with an extra 0 digit at the front.
 
-This means the following code gives you the wrong type.
+This means, the `upc-a` types are reported under the `ean-13` umbrella type on iOS:
 
 ```jsx
 const codeScanner = useCodeScanner({
-  codeTypes: ['upc-a'], // <-- ✅ I configure 'upc-a'
+  codeTypes: ['upc-a'], // <-- ✅ We configure for 'upc-a' types
   onCodeScanned: (codes) => {
     for (const code of codes) {
-      console.log(code.type); // <-- ❌ I receive 'ean-13' on iOS
+      console.log(code.type); // <-- ❌ On iOS, we receive 'ean-13'
     }
   }
 })
 ```
 
 You will need to keep this in mind and do the conversion from EAN-13 to UPC-A yourself. This can be done by removing the front `0` digit from the code to get a UPC-A code.
+
+#### 🚀 Next section: [Frame Processors](frame-processors)

--- a/package/android/src/main/java/com/mrousavy/camera/types/CodeType.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/types/CodeType.kt
@@ -13,6 +13,7 @@ enum class CodeType(override val unionValue: String) : JSUnionValue {
   EAN_8("ean-8"),
   ITF("itf"),
   UPC_E("upc-e"),
+  UPC_A("upc-a"),
   QR("qr"),
   PDF_417("pdf-417"),
   AZTEC("aztec"),
@@ -29,6 +30,7 @@ enum class CodeType(override val unionValue: String) : JSUnionValue {
       EAN_8 -> Barcode.FORMAT_EAN_8
       ITF -> Barcode.FORMAT_ITF
       UPC_E -> Barcode.FORMAT_UPC_E
+      UPC_A -> Barcode.FORMAT_UPC_A
       QR -> Barcode.FORMAT_QR_CODE
       PDF_417 -> Barcode.FORMAT_PDF417
       AZTEC -> Barcode.FORMAT_AZTEC
@@ -47,6 +49,7 @@ enum class CodeType(override val unionValue: String) : JSUnionValue {
         Barcode.FORMAT_EAN_8 -> EAN_8
         Barcode.FORMAT_ITF -> ITF
         Barcode.FORMAT_UPC_E -> UPC_E
+        Barcode.FORMAT_UPC_A -> UPC_A
         Barcode.FORMAT_QR_CODE -> QR
         Barcode.FORMAT_PDF417 -> PDF_417
         Barcode.FORMAT_AZTEC -> AZTEC
@@ -64,6 +67,7 @@ enum class CodeType(override val unionValue: String) : JSUnionValue {
         "ean-8" -> EAN_8
         "itf" -> ITF
         "upc-e" -> UPC_E
+        "upc-a" -> UPC_A
         "qr" -> QR
         "pdf-417" -> PDF_417
         "aztec" -> AZTEC

--- a/package/ios/Parsers/AVMetadataObject.ObjectType+descriptor.swift
+++ b/package/ios/Parsers/AVMetadataObject.ObjectType+descriptor.swift
@@ -40,6 +40,9 @@ extension AVMetadataObject.ObjectType {
     case "upc-e":
       self = .upce
       return
+    case "upc-a":
+      self = .ean13
+      return
     case "qr":
       self = .qr
       return

--- a/package/src/CodeScanner.ts
+++ b/package/src/CodeScanner.ts
@@ -12,6 +12,7 @@ export type CodeType =
   | 'ean-8'
   | 'itf'
   | 'upc-e'
+  | 'upc-a'
   | 'qr'
   | 'pdf-417'
   | 'aztec'


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR adds support for UPC-A barcode format.

## Changes

This PR adds the UPC-A type format to React Native, CodeType to Android and iOS, but points to EAN13 in iOS as Apple states it supports UPC-A through EAN13 [here](https://developer.apple.com/library/archive/technotes/tn2325/_index.html#//apple_ref/doc/uid/DTS40013824-CH1-IS_UPC_A_SUPPORTED_).

## Tested on

Samsung S22
iPhone X

## Related issues

Fixes #2118 
