### PR TITLE
feat: Allow focus calls to be cancelable

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraError.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraError.kt
@@ -104,6 +104,7 @@ class PhotoNotEnabledError :
   CameraError("capture", "photo-not-enabled", "Photo capture is disabled! Pass `photo={true}` to enable photo capture.")
 class CaptureAbortedError(wasImageCaptured: Boolean) :
   CameraError("capture", "aborted", "The image capture was aborted! Was Image captured: $wasImageCaptured")
+class FocusCanceledError : CameraError("capture", "focus-canceled", "The focus operation was canceled.")
 class CaptureTimedOutError : CameraError("capture", "timed-out", "The image capture was aborted because it timed out.")
 class UnknownCaptureError(wasImageCaptured: Boolean) :
   CameraError("capture", "unknown", "An unknown error occurred while trying to capture an Image! Was Image captured: $wasImageCaptured")

--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -25,16 +25,12 @@ import com.mrousavy.camera.types.QualityPrioritization
 import java.io.Closeable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
-import kotlin.coroutines.coroutineContext
 
 /**
  * A [CameraCaptureSession] wrapper that safely handles interruptions and remains open whenever available.
@@ -81,7 +77,7 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
     // Cancel any ongoing focus jobs
     focusJob?.cancel()
     focusJob = null
-    
+
     mutex.withLock {
       block()
       configure()

--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -26,11 +26,15 @@ import java.io.Closeable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
 
 /**
  * A [CameraCaptureSession] wrapper that safely handles interruptions and remains open whenever available.
@@ -56,7 +60,7 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
 
   private val mutex = Mutex()
   private var didDestroyFromOutside = false
-  private var focusResetJob: Job? = null
+  private var focusJob: Job? = null
   private val coroutineScope = CoroutineScope(CameraQueues.cameraQueue.coroutineDispatcher)
 
   val isRunning: Boolean
@@ -74,6 +78,10 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
   }
 
   suspend fun withConfiguration(block: suspend () -> Unit) {
+    // Cancel any ongoing focus jobs
+    focusJob?.cancel()
+    focusJob = null
+    
     mutex.withLock {
       block()
       configure()
@@ -141,6 +149,10 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
     orientation: Orientation,
     enableShutterSound: Boolean
   ): TotalCaptureResult {
+    // Cancel any ongoing focus jobs
+    focusJob?.cancel()
+    focusJob = null
+
     mutex.withLock {
       Log.i(TAG, "Capturing photo...")
       val session = session ?: throw CameraNotReadyError()
@@ -198,6 +210,10 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
   }
 
   suspend fun focus(point: Point) {
+    // Cancel any previous focus jobs
+    focusJob?.cancel()
+    focusJob = null
+
     mutex.withLock {
       Log.i(TAG, "Focusing to $point...")
       val session = session ?: throw CameraNotReadyError()
@@ -209,17 +225,16 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
       }
       val outputs = outputs.filter { it.isRepeating }
 
-      // 0. Cancel the 3 second focus reset task
-      focusResetJob?.cancelAndJoin()
-      focusResetJob = null
-
       // 1. Run a precapture sequence for AF, AE and AWB.
-      val request = repeatingRequest.createCaptureRequest(device, deviceDetails, outputs)
-      val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE), Flash.OFF, listOf(point), false)
-      session.precapture(request, deviceDetails, options)
+      focusJob = coroutineScope.launch {
+        val request = repeatingRequest.createCaptureRequest(device, deviceDetails, outputs)
+        val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE), Flash.OFF, listOf(point), false)
+        session.precapture(request, deviceDetails, options)
+      }
+      focusJob?.join()
 
-      // 2. Wait 3 seconds
-      focusResetJob = coroutineScope.launch {
+      // 2. Reset AF/AE/AWB again after 3 seconds timeout
+      focusJob = coroutineScope.launch {
         delay(FOCUS_RESET_TIMEOUT)
         if (!this.isActive) {
           // this job got canceled from the outside
@@ -230,7 +245,6 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
           return@launch
         }
         Log.i(TAG, "Resetting focus to auto-focus...")
-        // 3. Reset AF/AE/AWB to continuous auto-focus again, which is the default here.
         repeatingRequest.createCaptureRequest(device, deviceDetails, outputs).also { request ->
           session.setRepeatingRequest(request.build(), null, null)
         }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
@@ -11,8 +11,8 @@ import com.mrousavy.camera.core.CameraDeviceDetails
 import com.mrousavy.camera.core.FocusCanceledError
 import com.mrousavy.camera.types.Flash
 import com.mrousavy.camera.types.HardwareLevel
-import kotlinx.coroutines.isActive
 import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.isActive
 
 data class PrecaptureOptions(
   val modes: List<PrecaptureTrigger>,

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
@@ -8,8 +8,11 @@ import android.hardware.camera2.params.MeteringRectangle
 import android.util.Log
 import android.util.Size
 import com.mrousavy.camera.core.CameraDeviceDetails
+import com.mrousavy.camera.core.FocusCanceledError
 import com.mrousavy.camera.types.Flash
 import com.mrousavy.camera.types.HardwareLevel
+import kotlinx.coroutines.isActive
+import kotlin.coroutines.coroutineContext
 
 data class PrecaptureOptions(
   val modes: List<PrecaptureTrigger>,
@@ -65,6 +68,8 @@ suspend fun CameraCaptureSession.precapture(
     this.capture(request.build(), null, null)
   }
 
+  if (!coroutineContext.isActive) throw FocusCanceledError()
+
   val meteringWeight = MeteringRectangle.METERING_WEIGHT_MAX - 1
   val meteringRectangles = options.pointsOfInterest.map { point ->
     MeteringRectangle(point, DEFAULT_METERING_SIZE, meteringWeight)
@@ -115,13 +120,16 @@ suspend fun CameraCaptureSession.precapture(
   }
   this.capture(request.build(), null, null)
 
+  if (!coroutineContext.isActive) throw FocusCanceledError()
+
   // 3. Start a repeating request without the trigger and wait until AF/AE/AWB locks
   request.set(CaptureRequest.CONTROL_AF_TRIGGER, null)
   request.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, null)
   val result = this.setRepeatingRequestAndWaitForPrecapture(request.build(), *precaptureModes.toTypedArray())
 
+  if (!coroutineContext.isActive) throw FocusCanceledError()
+
   Log.i(TAG, "AF/AE/AWB successfully locked!")
-  // TODO: Set to idle again?
 
   val needsFlash = result.exposureState == ExposureState.FlashRequired
   return PrecaptureResult(needsFlash)

--- a/package/src/CameraError.ts
+++ b/package/src/CameraError.ts
@@ -43,6 +43,7 @@ export type CaptureError =
   | 'capture/photo-not-enabled'
   | 'capture/frame-invalid'
   | 'capture/aborted'
+  | 'capture/focus-canceled'
   | 'capture/timed-out'
   | 'capture/unknown'
 export type SystemError =


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Camera `focus({...})` calls can now be canceled by either flipping the Camera or taking a photo.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
