### PR TITLE
Migrate from deprecated RCTEventEmitter

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/types/Events.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/types/Events.kt
@@ -1,0 +1,36 @@
+package com.mrousavy.camera.types
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class CameraInitializedEvent(surfaceId: Int, viewId: Int) : Event<CameraInitializedEvent>(surfaceId, viewId) {
+  override fun getEventName() = "cameraInitialized"
+  override fun getEventData(): WritableMap = Arguments.createMap()
+}
+
+class CameraStartedEvent(surfaceId: Int, viewId: Int) : Event<CameraStartedEvent>(surfaceId, viewId) {
+  override fun getEventName() = "cameraStarted"
+  override fun getEventData(): WritableMap = Arguments.createMap()
+}
+
+class CameraStoppedEvent(surfaceId: Int, viewId: Int) : Event<CameraStoppedEvent>(surfaceId, viewId) {
+  override fun getEventName() = "cameraStopped"
+  override fun getEventData(): WritableMap = Arguments.createMap()
+}
+
+class CameraErrorEvent(surfaceId: Int, viewId: Int, private val data: WritableMap) : Event<CameraErrorEvent>(surfaceId, viewId) {
+  override fun getEventName() = "cameraError"
+  override fun getEventData() = data
+}
+
+class CameraViewReadyEvent(surfaceId: Int, viewId: Int) : Event<CameraViewReadyEvent>(surfaceId, viewId) {
+  override fun getEventName() = "cameraViewReady"
+  override fun getEventData(): WritableMap = Arguments.createMap()
+}
+
+class CameraCodeScannedEvent(surfaceId: Int, viewId: Int, private val data: WritableMap) :
+  Event<CameraCodeScannedEvent>(surfaceId, viewId) {
+  override fun getEventName() = "cameraCodeScanned"
+  override fun getEventData() = data
+}


### PR DESCRIPTION
## What

- RCTEventEmitter was deprecated 3 years ago
- This doesn't allow the module to be used with the New Renderer Interop Layer

## Changes

- replace `getJSModule(RCTEventEmitter::class.java)` with `UIManagerHelper.getEventDispatcherForReactTag()`
- create event with correct surfaceId
- event classes

## Tested on

- Android 14
- RN 0.72.10
- New Arch and New Renderer Interop Layer enabled for `CameraView`

## Related issues

* Fixes #2526 