### PR TITLE
fix: Fix `Precapture timed out after 5 seconds` error

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -188,15 +188,15 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
           skipIfPassivelyFocused,
           PRECAPTURE_LOCK_TIMEOUT
         )
-      var needsFlash = flash != Flash.OFF
+      var needsFlash: Boolean
       try {
         val result = session.precapture(precaptureRequest, deviceDetails, options)
         needsFlash = result.needsFlash
-      } catch (e: FocusCanceledError) {
-        throw CaptureAbortedError(false)
       } catch (e: CaptureTimedOutError) {
         // the precapture just timed out after 5 seconds, take picture anyways without focus.
         needsFlash = false
+      } catch (e: FocusCanceledError) {
+        throw CaptureAbortedError(false)
       }
 
       try {

--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -234,7 +234,8 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
       // 1. Run a precapture sequence for AF, AE and AWB.
       focusJob = coroutineScope.launch {
         val request = repeatingRequest.createCaptureRequest(device, deviceDetails, outputs)
-        val options = PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE), Flash.OFF, listOf(point), false, FOCUS_RESET_TIMEOUT)
+        val options =
+          PrecaptureOptions(listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE), Flash.OFF, listOf(point), false, FOCUS_RESET_TIMEOUT)
         session.precapture(request, deviceDetails, options)
       }
       focusJob?.join()

--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -178,18 +178,17 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
       Log.i(TAG, "Locking AF/AE/AWB...")
 
       // 1. Run precapture sequence
-      val precaptureRequest = repeatingRequest.createCaptureRequest(device, deviceDetails, repeatingOutputs)
-      val skipIfPassivelyFocused = flash == Flash.OFF
-      val options =
-        PrecaptureOptions(
+      var needsFlash: Boolean
+      try {
+        val precaptureRequest = repeatingRequest.createCaptureRequest(device, deviceDetails, repeatingOutputs)
+        val skipIfPassivelyFocused = flash == Flash.OFF
+        val options = PrecaptureOptions(
           listOf(PrecaptureTrigger.AF, PrecaptureTrigger.AE, PrecaptureTrigger.AWB),
           flash,
           emptyList(),
           skipIfPassivelyFocused,
           PRECAPTURE_LOCK_TIMEOUT
         )
-      var needsFlash: Boolean
-      try {
         val result = session.precapture(precaptureRequest, deviceDetails, options)
         needsFlash = result.needsFlash
       } catch (e: CaptureTimedOutError) {

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
@@ -58,12 +58,8 @@ suspend fun CameraCaptureSession.precapture(
     aeState = ExposureState.fromAEState(result.get(CaptureResult.CONTROL_AE_STATE) ?: CaptureResult.CONTROL_AE_STATE_INACTIVE)
     awbState = WhiteBalanceState.fromAWBState(result.get(CaptureResult.CONTROL_AWB_STATE) ?: CaptureResult.CONTROL_AWB_STATE_INACTIVE)
 
-    if (aeState == ExposureState.FlashRequired) {
-      Log.i(TAG, "Auto-Flash: Flash is required for photo capture, enabling flash...")
-      enableFlash = true && options.flash == Flash.AUTO
-    } else {
-      Log.i(TAG, "Auto-Flash: Flash is not required for photo capture.")
-    }
+    Log.i(TAG, "Precapture current states: AF: $afState, AE: $aeState, AWB: $awbState")
+    enableFlash = aeState == ExposureState.FlashRequired && options.flash == Flash.AUTO
   } else {
     // we either want Flash ON or OFF, so we don't care about lighting conditions - do a fast capture.
     this.capture(request.build(), null, null)

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
@@ -100,23 +100,41 @@ suspend fun CameraCaptureSession.precapture(
     // AF Precapture
     if (deviceDetails.afModes.contains(CaptureRequest.CONTROL_AF_MODE_AUTO)) {
       request.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO)
+      request.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START)
+      if (meteringRectangles.isNotEmpty() && deviceDetails.supportsFocusRegions) {
+        request.set(CaptureRequest.CONTROL_AF_REGIONS, meteringRectangles)
+      }
+    } else {
+      // AF is not supported on this device.
+      precaptureModes.remove(PrecaptureTrigger.AF)
     }
-    if (meteringRectangles.isNotEmpty() && deviceDetails.supportsFocusRegions) {
-      request.set(CaptureRequest.CONTROL_AF_REGIONS, meteringRectangles)
-    }
-    request.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START)
   }
-  if (precaptureModes.contains(PrecaptureTrigger.AE) && deviceDetails.hardwareLevel.isAtLeast(HardwareLevel.LIMITED)) {
+  if (precaptureModes.contains(PrecaptureTrigger.AE)) {
     // AE Precapture
-    if (meteringRectangles.isNotEmpty() && deviceDetails.supportsExposureRegions) {
-      request.set(CaptureRequest.CONTROL_AE_REGIONS, meteringRectangles)
+    if (deviceDetails.aeModes.contains(CaptureRequest.CONTROL_AE_MODE_ON) && deviceDetails.hardwareLevel.isAtLeast(HardwareLevel.LIMITED)) {
+      request.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
+      request.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START)
+      if (meteringRectangles.isNotEmpty() &&
+        deviceDetails.supportsExposureRegions &&
+        deviceDetails.hardwareLevel.isAtLeast(HardwareLevel.LIMITED)
+      ) {
+        request.set(CaptureRequest.CONTROL_AE_REGIONS, meteringRectangles)
+      }
+    } else {
+      // AE is not supported on this device.
+      precaptureModes.remove(PrecaptureTrigger.AE)
     }
-    request.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START)
   }
   if (precaptureModes.contains(PrecaptureTrigger.AWB)) {
     // AWB Precapture
-    if (meteringRectangles.isNotEmpty() && deviceDetails.supportsWhiteBalanceRegions) {
-      request.set(CaptureRequest.CONTROL_AWB_REGIONS, meteringRectangles)
+    if (deviceDetails.awbModes.contains(CaptureRequest.CONTROL_AWB_MODE_AUTO)) {
+      request.set(CaptureRequest.CONTROL_AWB_MODE, CaptureRequest.CONTROL_AWB_MODE_AUTO)
+      if (meteringRectangles.isNotEmpty() && deviceDetails.supportsWhiteBalanceRegions) {
+        request.set(CaptureRequest.CONTROL_AWB_REGIONS, meteringRectangles)
+      }
+    } else {
+      // AWB is not supported on this device.
+      precaptureModes.remove(PrecaptureTrigger.AWB)
     }
   }
   this.capture(request.build(), null, null)

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
@@ -60,7 +60,7 @@ suspend fun CameraCaptureSession.precapture(
 
     if (aeState == ExposureState.FlashRequired) {
       Log.i(TAG, "Auto-Flash: Flash is required for photo capture, enabling flash...")
-      enableFlash = true
+      enableFlash = true && options.flash == Flash.AUTO
     } else {
       Log.i(TAG, "Auto-Flash: Flash is not required for photo capture.")
     }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+precapture.kt
@@ -18,7 +18,8 @@ data class PrecaptureOptions(
   val modes: List<PrecaptureTrigger>,
   val flash: Flash = Flash.OFF,
   val pointsOfInterest: List<Point>,
-  val skipIfPassivelyFocused: Boolean
+  val skipIfPassivelyFocused: Boolean,
+  val timeoutMs: Long
 )
 
 data class PrecaptureResult(val needsFlash: Boolean)
@@ -125,7 +126,7 @@ suspend fun CameraCaptureSession.precapture(
   // 3. Start a repeating request without the trigger and wait until AF/AE/AWB locks
   request.set(CaptureRequest.CONTROL_AF_TRIGGER, null)
   request.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, null)
-  val result = this.setRepeatingRequestAndWaitForPrecapture(request.build(), *precaptureModes.toTypedArray())
+  val result = this.setRepeatingRequestAndWaitForPrecapture(request.build(), options.timeoutMs, *precaptureModes.toTypedArray())
 
   if (!coroutineContext.isActive) throw FocusCanceledError()
 

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
@@ -143,23 +143,23 @@ suspend fun CameraCaptureSession.setRepeatingRequestAndWaitForPrecapture(
           if (continuation.isActive) {
             // AF Precapture
             val afState = FocusState.fromAFState(result.get(CaptureResult.CONTROL_AF_STATE) ?: CaptureResult.CONTROL_AF_STATE_INACTIVE)
-            val aeState = ExposureState.fromAEState(result.get(CaptureResult.CONTROL_AE_STATE) ?: CaptureResult.CONTROL_AE_STATE_INACTIVE)
+            val aeState = ExposureState.fromAEState(
+              result.get(CaptureResult.CONTROL_AE_STATE) ?: CaptureResult.CONTROL_AE_STATE_INACTIVE
+            )
             val awbState = WhiteBalanceState.fromAWBState(
               result.get(CaptureResult.CONTROL_AWB_STATE) ?: CaptureResult.CONTROL_AWB_STATE_INACTIVE
             )
+            Log.i(TAG, "Precapture state: AF: $afState, AE: $aeState, AWB: $awbState")
 
             if (precaptureTriggers.contains(PrecaptureTrigger.AF)) {
-              Log.i(TAG, "AF State: $afState (isCompleted: ${afState.isCompleted})")
               completed[PrecaptureTrigger.AF] = afState.isCompleted
             }
             // AE Precapture
             if (precaptureTriggers.contains(PrecaptureTrigger.AE)) {
-              Log.i(TAG, "AE State: $aeState (isCompleted: ${aeState.isCompleted})")
               completed[PrecaptureTrigger.AE] = aeState.isCompleted
             }
             // AWB Precapture
             if (precaptureTriggers.contains(PrecaptureTrigger.AWB)) {
-              Log.i(TAG, "AWB State: $awbState (isCompleted: ${awbState.isCompleted})")
               completed[PrecaptureTrigger.AWB] = awbState.isCompleted
             }
 

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
@@ -114,6 +114,7 @@ data class ResultState(val focusState: FocusState, val exposureState: ExposureSt
  */
 suspend fun CameraCaptureSession.setRepeatingRequestAndWaitForPrecapture(
   request: CaptureRequest,
+  timeoutMs: Long,
   vararg precaptureTriggers: PrecaptureTrigger
 ): ResultState =
   suspendCancellableCoroutine { continuation ->
@@ -121,9 +122,9 @@ suspend fun CameraCaptureSession.setRepeatingRequestAndWaitForPrecapture(
     val completed = precaptureTriggers.associateWith { false }.toMutableMap()
 
     CoroutineScope(Dispatchers.Default).launch {
-      delay(5000) // after 5s, cancel capture
+      delay(timeoutMs) // after timeout, cancel capture
       if (continuation.isActive) {
-        Log.e(TAG, "Precapture timed out after 5 seconds!")
+        Log.e(TAG, "Precapture timed out after ${timeoutMs / 1000} seconds!")
         continuation.resumeWithException(CaptureTimedOutError())
         try {
           setRepeatingRequest(request, null, null)

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
@@ -142,7 +142,6 @@ suspend fun CameraCaptureSession.setRepeatingRequestAndWaitForPrecapture(
           super.onCaptureCompleted(session, request, result)
 
           if (continuation.isActive) {
-            // AF Precapture
             val afState = FocusState.fromAFState(result.get(CaptureResult.CONTROL_AF_STATE) ?: CaptureResult.CONTROL_AF_STATE_INACTIVE)
             val aeState = ExposureState.fromAEState(
               result.get(CaptureResult.CONTROL_AE_STATE) ?: CaptureResult.CONTROL_AE_STATE_INACTIVE
@@ -152,6 +151,7 @@ suspend fun CameraCaptureSession.setRepeatingRequestAndWaitForPrecapture(
             )
             Log.i(TAG, "Precapture state: AF: $afState, AE: $aeState, AWB: $awbState")
 
+            // AF Precapture
             if (precaptureTriggers.contains(PrecaptureTrigger.AF)) {
               completed[PrecaptureTrigger.AF] = afState.isCompleted
             }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the "Precapture timed out after 5 seconds" error by changing two things:

1. If AE, AF, or AWB is not supported on the device, remove the unsupported value from the precapture trigger.
2. If the precapture timed out after 5 seconds, we still take a picture. Might be unfocused, but who cares. (not sure if this is a good idea tbh)

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2577

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
