### PR TITLE
fix: Trigger `measure` and `layout` manually to fix Preview stretching

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -103,6 +103,10 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) :
   private fun getSize(contentSize: Size, containerSize: Size, resizeMode: ResizeMode): Size {
     val contentAspectRatio = contentSize.width.toDouble() / contentSize.height
     val containerAspectRatio = containerSize.width.toDouble() / containerSize.height
+    if (!(contentAspectRatio > 0 && containerAspectRatio > 0)) {
+      // One of the aspect ratios is 0 or NaN, maybe the view hasn't been laid out yet.
+      return contentSize
+    }
 
     val widthOverHeight = when (resizeMode) {
       ResizeMode.COVER -> contentAspectRatio > containerAspectRatio

--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -90,6 +90,16 @@ class PreviewView(context: Context, callback: SurfaceHolder.Callback) :
     }
   }
 
+  override fun requestLayout() {
+    super.requestLayout()
+    // Manually trigger measure & layout, as RN on Android skips those.
+    // See this issue: https://github.com/facebook/react-native/issues/17968#issuecomment-721958427
+    post {
+      measure(MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY), MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY))
+      layout(left, top, right, bottom)
+    }
+  }
+
   private fun getSize(contentSize: Size, containerSize: Size, resizeMode: ResizeMode): Size {
     val contentAspectRatio = contentSize.width.toDouble() / contentSize.height
     val containerAspectRatio = containerSize.width.toDouble() / containerSize.height


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

While the aspect ratio calculations for the Preview View are now seemingly correct (I think), there were some issues reported by users that the Preview View was still stretched.

According to this comment: https://github.com/mrousavy/react-native-vision-camera/issues/2583#issuecomment-1952418003 the `onMeasure` function was not called after updating the Surface size. I believe this is related to this bug in react-native: https://github.com/facebook/react-native/issues/17968 - which means `requestLayout` does not call `onMeasure`.

So in this PR I fix this by manually calling `measure` for this component, so it calls `onMeasure` as expected - causing the PreviewView to update it's aspect ratio accordingly.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
