### PR TITLE
fix: Fix Frame Processor SIGSEV crash in `VisionCameraScheduler::trigger` by locking mutex in `dispatchAsync`

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraScheduler.cpp
@@ -15,6 +15,7 @@ TSelf JVisionCameraScheduler::initHybrid(jni::alias_ref<jhybridobject> jThis) {
 }
 
 void JVisionCameraScheduler::dispatchAsync(const std::function<void()>& job) {
+  std::unique_lock<std::mutex> lock(_mutex);
   // 1. add job to queue
   _jobs.push(job);
   scheduleTrigger();


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fix for the crash on frame processor updates in `VisionCameraScheduler` by making sure the `trigger` and `schedule` functions are properly locked with a Mutex.
<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

Add a missing lock.
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

Galaxy S21
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2153
- Fixes #2178
- 
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
