### PR TITLE
fix: Fix "Unknown AF/AE/AWB State" error

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+setRepeatingRequestAndWaitForPrecapture.kt
@@ -30,6 +30,7 @@ interface AutoState {
 }
 
 enum class FocusState : AutoState {
+  Unknown,
   Inactive,
   Scanning,
   Focused,
@@ -53,11 +54,12 @@ enum class FocusState : AutoState {
         CaptureResult.CONTROL_AF_STATE_PASSIVE_SCAN -> PassiveScanning
         CaptureResult.CONTROL_AF_STATE_PASSIVE_FOCUSED -> PassiveFocused
         CaptureResult.CONTROL_AF_STATE_PASSIVE_UNFOCUSED -> PassiveUnfocused
-        else -> throw Error("Invalid CONTROL_AF_STATE! $afState")
+        else -> Unknown
       }
   }
 }
 enum class ExposureState : AutoState {
+  Unknown,
   Locked,
   Inactive,
   Precapture,
@@ -79,12 +81,13 @@ enum class ExposureState : AutoState {
         CaptureResult.CONTROL_AE_STATE_CONVERGED -> Converged
         CaptureResult.CONTROL_AE_STATE_FLASH_REQUIRED -> FlashRequired
         CaptureResult.CONTROL_AE_STATE_LOCKED -> Locked
-        else -> throw Error("Invalid CONTROL_AE_STATE! $aeState")
+        else -> Unknown
       }
   }
 }
 
 enum class WhiteBalanceState : AutoState {
+  Unknown,
   Inactive,
   Locked,
   Searching,
@@ -102,7 +105,7 @@ enum class WhiteBalanceState : AutoState {
         CaptureResult.CONTROL_AWB_STATE_SEARCHING -> Searching
         CaptureResult.CONTROL_AWB_STATE_CONVERGED -> Converged
         CaptureResult.CONTROL_AWB_STATE_LOCKED -> Locked
-        else -> throw Error("Invalid CONTROL_AWB_STATE! $awbState")
+        else -> Unknown
       }
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

In Camera2, there's `CaptureResult.CONTROL_AF_STATE` (or the respective value for AE and AWB).
These are the supported values: https://developer.android.com/reference/android/hardware/camera2/CaptureResult#CONTROL_AF_STATE

- INACTIVE
- PASSIVE_SCAN
- PASSIVE_FOCUSED
- ACTIVE_SCAN
- FOCUSED_LOCKED
- NOT_FOCUSED_LOCKED
- PASSIVE_UNFOCUSED

For some reason, on a Samsung SM-S901B there is a situation where this value is `101` which is none of those enums. WTF?

So maybe Samsung has a proprietrary intermediate state which is not exposed to Android. In that case, we just use "UNKNOWN" instead to avoid this error being thrown.,

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
