### PR TITLE
docs: Fix `toArrayBuffer` example in Frame Processor Guide

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSORS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSORS.mdx
@@ -89,7 +89,8 @@ Additionally, you can also directly access the Frame's pixel data using [`toArra
 const frameProcessor = useFrameProcessor((frame) => {
   'worklet'
   if (frame.pixelFormat === 'rgb') {
-    const data = frame.toArrayBuffer()
+    const buffer = frame.toArrayBuffer()
+    const data = new Uint8Array(buffer)
     console.log(`Pixel at 0,0: RGB(${data[0]}, ${data[1]}, ${data[2]})`)
   }
 }, [])


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR fixes an issue on the Frame Processor page in the guide which shows an `ArrayBuffer` being indexed directly without first creating a view into the buffer with a `Uint8Array`.

Before:
![image](https://github.com/mrousavy/react-native-vision-camera/assets/79512656/8cbe7595-97f8-4978-a4c6-caf81b64739a)

After:
![image](https://github.com/mrousavy/react-native-vision-camera/assets/79512656/43cf2b0e-52c3-477c-a8b0-a6715559070e)


## Changes
Updates the `toArrayBuffer` example on the Frame Processor guide page to match the correct example on the function's API documentation page
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on
Firefox
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
N/A
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
