### PR TITLE
fix: Use `0x0` as a fallback Size if `SENSOR_INFO_PHYSICAL_SIZE` is null (e.g. on USB cameras)

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.util.Log
 import android.util.Range
 import android.util.Size
+import android.util.SizeF
 import android.view.SurfaceHolder
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
@@ -68,7 +69,7 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, val cameraId
     // 35mm is the film standard sensor size
     characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS) ?: floatArrayOf(35f)
   }
-  val sensorSize by lazy { characteristics.get(CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE)!! }
+  val sensorSize by lazy { characteristics.get(CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE) ?: SizeF(0f, 0f) }
   val activeSize
     get() = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)!!
   val sensorOrientation by lazy {
@@ -230,6 +231,9 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, val cameraId
   }
 
   private fun getFieldOfView(focalLength: Float): Double {
+    if ((sensorSize.width == 0f) || (sensorSize.height == 0f)) {
+      return 0.0
+    }
     val sensorDiagonal = sqrt((sensorSize.width * sensorSize.width + sensorSize.height * sensorSize.height).toDouble())
     val fovRadians = 2.0 * atan2(sensorDiagonal, (2.0 * focalLength))
     return Math.toDegrees(fovRadians)


### PR DESCRIPTION
…cs cannot get the SENSOR_INFO_PHYSICAL_SIZE value of the camera device

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
