### PR TITLE
fix: 'react/bridging/CallbackWrapper.h' file not found

### DIFF
--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -69,6 +69,7 @@ Pod::Spec.new do |s|
   s.dependency "React"
   s.dependency "React-Core"
   s.dependency "React-callinvoker"
+  s.dependency "ReactCommon"
 
   if hasWorklets
     s.dependency "react-native-worklets-core"


### PR DESCRIPTION
This PR fixes build error: 'react/bridging/CallbackWrapper.h' file not found

## Changes
This PR adds `s.dependency "ReactCommon"` to `VisionCamera.podspec`

## Tested on
    * iPhone 15, iOS 17.3.1

## Related issues
    * Fixes #2603 
