### PR TITLE
fix: Disable precapture sequence by default

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -32,6 +32,7 @@ suspend fun CameraView.takePhoto(optionsMap: ReadableMap): WritableMap {
   val flash = options["flash"] as? String ?: "off"
   val enableAutoStabilization = options["enableAutoStabilization"] == true
   val enableShutterSound = options["enableShutterSound"] as? Boolean ?: true
+  val enablePrecapture = options["enablePrecapture"] as? Boolean ?: false
 
   // TODO: Implement Red Eye Reduction
   options["enableAutoRedEyeReduction"]
@@ -44,6 +45,7 @@ suspend fun CameraView.takePhoto(optionsMap: ReadableMap): WritableMap {
     flashMode,
     enableShutterSound,
     enableAutoStabilization,
+    enablePrecapture,
     orientation
   )
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -369,6 +369,7 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
     flash: Flash,
     enableShutterSound: Boolean,
     enableAutoStabilization: Boolean,
+    enablePrecapture: Boolean,
     outputOrientation: Orientation
   ): CapturedPhoto {
     val photoOutput = photoOutput ?: throw PhotoNotEnabledError()
@@ -380,7 +381,8 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
       enableAutoStabilization,
       photoOutput.enableHdr,
       outputOrientation,
-      enableShutterSound
+      enableShutterSound,
+      enablePrecapture
     )
 
     try {

--- a/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PersistentCameraCaptureSession.kt
@@ -145,7 +145,8 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
     enableAutoStabilization: Boolean,
     enablePhotoHdr: Boolean,
     orientation: Orientation,
-    enableShutterSound: Boolean
+    enableShutterSound: Boolean,
+    enablePrecapture: Boolean
   ): TotalCaptureResult {
     // Cancel any ongoing focus jobs
     focusJob?.cancel()
@@ -169,7 +170,8 @@ class PersistentCameraCaptureSession(private val cameraManager: CameraManager, p
       val outputs = outputs
       val repeatingOutputs = outputs.filter { it.isRepeating }
 
-      if (qualityPrioritization == QualityPrioritization.SPEED && flash == Flash.OFF) {
+      val skipPrecapture = !enablePrecapture || qualityPrioritization == QualityPrioritization.SPEED
+      if (skipPrecapture && flash == Flash.OFF) {
         // 0. We want to take a picture as fast as possible, so skip any precapture sequence and just capture one Frame.
         Log.i(TAG, "Using fast capture path without pre-capture sequence...")
         val singleRequest = photoRequest.createCaptureRequest(device, deviceDetails, outputs)

--- a/package/src/PhotoFile.ts
+++ b/package/src/PhotoFile.ts
@@ -44,6 +44,14 @@ export interface TakePhotoOptions {
    * @default true
    */
   enableShutterSound?: boolean
+  /**
+   * Whether to run the pre-capture sequence to properly lock AF, AE and AWB values.
+   * Enabling this results in greater photos, but might not work on some devices.
+   *
+   * @platform Android
+   * @default false
+   */
+  enablePrecapture?: boolean
 }
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Disables the precapture pipeline by default, and allows the user to enable it again using the `enablePrecapture` parameter in `takePhoto`.

The precapture sequence is used for properly locking AE, AF and AWB values to a good state before shooting the photo, but apparently it broke on some Samsung devices, and I have no idea why.



<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- "Fixes" https://github.com/mrousavy/react-native-vision-camera/issues/2577

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
