### PR TITLE
fix: Properly set `maxPhotoDimensions` on PhotoOutput

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -344,7 +344,7 @@ PODS:
     - react-native-video/Video (= 5.2.1)
   - react-native-video/Video (5.2.1):
     - React-Core
-  - react-native-worklets-core (0.3.0):
+  - react-native-worklets-core (0.4.0):
     - React
     - React-callinvoker
     - React-Core
@@ -484,7 +484,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (4.0.0-beta.6):
+  - VisionCamera (4.0.0-beta.7):
     - React
     - React-callinvoker
     - React-Core
@@ -697,7 +697,7 @@ SPEC CHECKSUMS:
   react-native-mmkv: e97c0c79403fb94577e5d902ab1ebd42b0715b43
   react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   react-native-video: c26780b224543c62d5e1b2a7244a5cd1b50e8253
-  react-native-worklets-core: a894d572639fcf37c6d284cc799882d25d00c93d
+  react-native-worklets-core: 2efe80a3ee87fe5e6fefa814e0e20c2708d3ad25
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a
   React-RCTActionSheet: 392090a3abc8992eb269ef0eaa561750588fc39d
@@ -724,7 +724,7 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 7a9e59cc5e65d458d9809a9ac23700265df0f14e
+  VisionCamera: e0f80a131dbfa1361fdfc0231cb02e3312903acf
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: 27f53791141a3303d814e09b55770336416ff4eb

--- a/package/example/package.json
+++ b/package/example/package.json
@@ -29,7 +29,7 @@
     "react-native-static-safe-area-insets": "^2.2.0",
     "react-native-vector-icons": "^10.0.0",
     "react-native-video": "^5.2.1",
-    "react-native-worklets-core": "0.3.0"
+    "react-native-worklets-core": "0.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.10",

--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -212,6 +212,7 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
                 video={true}
                 audio={hasMicrophonePermission}
                 frameProcessor={frameProcessor}
+                enableHighQualityPhotos={true}
               />
             </TapGestureHandler>
           </Reanimated.View>

--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -212,7 +212,6 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
                 video={true}
                 audio={hasMicrophonePermission}
                 frameProcessor={frameProcessor}
-                enableHighQualityPhotos={true}
               />
             </TapGestureHandler>
           </Reanimated.View>

--- a/package/example/yarn.lock
+++ b/package/example/yarn.lock
@@ -5178,10 +5178,10 @@ react-native-video@^5.2.1:
     prop-types "^15.7.2"
     shaka-player "^2.5.9"
 
-react-native-worklets-core@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-0.3.0.tgz#4d6c4c4999d3bf2f8c67fa46fdd70d8b5bc7ba0e"
-  integrity sha512-bOoo6xbl+f+mz0Q65bLkUP3FxgYt7f/Bzi0c5Yj8Ix4vQCKMtgHwafrqCNRhW32N7TpTv3+zOoyQMJwQVr/frQ==
+react-native-worklets-core@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-0.4.0.tgz#708f204d89327d88e155cccb5fc23421ca764b6f"
+  integrity sha512-0rYCwxnG6L85mih+3xe1r2RhhwKqjgVN9jikVh0iMPKDf9L4OZMJnl6Kh4zjXiW9rkyI5lBghfM4XIcLMfeU6w==
   dependencies:
     string-hash-64 "^1.0.3"
 

--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -25,6 +25,7 @@ public final class CameraView: UIView, CameraSessionDelegate {
   // props that require reconfiguring
   @objc var cameraId: NSString?
   @objc var enableDepthData = false
+  @objc var enableHighQualityPhotos = false
   @objc var enablePortraitEffectsMatteDelivery = false
   @objc var enableBufferCompression = false
   // use cases
@@ -178,9 +179,10 @@ public final class CameraView: UIView, CameraSessionDelegate {
 
       // Photo
       if photo {
-        config.photo = .enabled(config: CameraConfiguration.Photo(qualityBalance: getPhotoQualityBalance(),
+        config.photo = .enabled(config: CameraConfiguration.Photo(enableHighQualityPhotos: enableHighQualityPhotos,
                                                                   enableDepthData: enableDepthData,
-                                                                  enablePortraitEffectsMatte: enablePortraitEffectsMatteDelivery))
+                                                                  enablePortraitEffectsMatte: enablePortraitEffectsMatteDelivery,
+                                                                  qualityBalance: getPhotoQualityBalance()))
       } else {
         config.photo = .disabled
       }

--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -25,7 +25,6 @@ public final class CameraView: UIView, CameraSessionDelegate {
   // props that require reconfiguring
   @objc var cameraId: NSString?
   @objc var enableDepthData = false
-  @objc var enableHighQualityPhotos = false
   @objc var enablePortraitEffectsMatteDelivery = false
   @objc var enableBufferCompression = false
   // use cases
@@ -179,10 +178,9 @@ public final class CameraView: UIView, CameraSessionDelegate {
 
       // Photo
       if photo {
-        config.photo = .enabled(config: CameraConfiguration.Photo(enableHighQualityPhotos: enableHighQualityPhotos,
+        config.photo = .enabled(config: CameraConfiguration.Photo(qualityBalance: getPhotoQualityBalance(),
                                                                   enableDepthData: enableDepthData,
-                                                                  enablePortraitEffectsMatte: enablePortraitEffectsMatteDelivery,
-                                                                  qualityBalance: getPhotoQualityBalance()))
+                                                                  enablePortraitEffectsMatte: enablePortraitEffectsMatteDelivery))
       } else {
         config.photo = .disabled
       }

--- a/package/ios/CameraViewManager.m
+++ b/package/ios/CameraViewManager.m
@@ -25,7 +25,6 @@ RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(installFrameProcessorBindings);
 RCT_EXPORT_VIEW_PROPERTY(isActive, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(cameraId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enableDepthData, BOOL);
-RCT_EXPORT_VIEW_PROPERTY(enableHighQualityPhotos, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(enablePortraitEffectsMatteDelivery, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(enableBufferCompression, BOOL);
 // use cases

--- a/package/ios/CameraViewManager.m
+++ b/package/ios/CameraViewManager.m
@@ -25,6 +25,7 @@ RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(installFrameProcessorBindings);
 RCT_EXPORT_VIEW_PROPERTY(isActive, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(cameraId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enableDepthData, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(enableHighQualityPhotos, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(enablePortraitEffectsMatteDelivery, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(enableBufferCompression, BOOL);
 // use cases

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -147,10 +147,9 @@ class CameraConfiguration {
    A Photo Output configuration
    */
   struct Photo: Equatable {
-    var enableHighQualityPhotos = false
+    var qualityBalance = QualityBalance.balanced
     var enableDepthData = false
     var enablePortraitEffectsMatte = false
-    var qualityBalance = QualityBalance.balanced
   }
 
   /**

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -147,9 +147,10 @@ class CameraConfiguration {
    A Photo Output configuration
    */
   struct Photo: Equatable {
-    var qualityBalance = QualityBalance.balanced
+    var enableHighQualityPhotos = false
     var enableDepthData = false
     var enablePortraitEffectsMatte = false
+    var qualityBalance = QualityBalance.balanced
   }
 
   /**

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -215,6 +215,29 @@ extension CameraSession {
     ReactLogger.log(level: .info, message: "Successfully configured Format!")
   }
 
+  func configurePhotoOutputResolution(configuration: CameraConfiguration) {
+    guard case let .enabled(photo) = configuration.photo,
+          let photoOutput, let videoDeviceInput else {
+      // Video is not enabled
+      return
+    }
+
+    // Configure the PhotoOutput to use the maximum available resolution.
+    // We need to do this after device.activeFormat has been set.
+    if #available(iOS 16.0, *) {
+      let format = videoDeviceInput.device.activeFormat
+      let maxPhotoResolution = format.supportedMaxPhotoDimensions.max(by: { left, right in
+        (left.width * left.height) < (right.width * right.height)
+      })
+      guard let maxPhotoResolution else {
+        return
+      }
+      photoOutput.maxPhotoDimensions = maxPhotoResolution
+    } else {
+      photoOutput.isHighResolutionCaptureEnabled = true
+    }
+  }
+
   func configurePixelFormat(configuration: CameraConfiguration) throws {
     guard case let .enabled(video) = configuration.video,
           let videoOutput else {

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -80,11 +80,6 @@ extension CameraSession {
         let qualityPrioritization = AVCapturePhotoOutput.QualityPrioritization(fromQualityBalance: photo.qualityBalance)
         photoOutput.maxPhotoQualityPrioritization = qualityPrioritization
       }
-      if photo.enableHighQualityPhotos {
-        // This is deprecated in favor of `maxPhotoDimensions`, but maxPhotoDimensions is by default
-        // already set to the highest resolution possible (i think?), so we don't need to set that again.
-        photoOutput.isHighResolutionCaptureEnabled = true
-      }
       // TODO: Enable isResponsiveCaptureEnabled? (iOS 17+)
       // TODO: Enable isFastCapturePrioritizationEnabled? (iOS 17+)
       if photo.enableDepthData {

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -80,6 +80,11 @@ extension CameraSession {
         let qualityPrioritization = AVCapturePhotoOutput.QualityPrioritization(fromQualityBalance: photo.qualityBalance)
         photoOutput.maxPhotoQualityPrioritization = qualityPrioritization
       }
+      if photo.enableHighQualityPhotos {
+        // This is deprecated in favor of `maxPhotoDimensions`, but maxPhotoDimensions is by default
+        // already set to the highest resolution possible (i think?), so we don't need to set that again.
+        photoOutput.isHighResolutionCaptureEnabled = true
+      }
       // TODO: Enable isResponsiveCaptureEnabled? (iOS 17+)
       // TODO: Enable isFastCapturePrioritizationEnabled? (iOS 17+)
       if photo.enableDepthData {

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -213,7 +213,7 @@ extension CameraSession {
     ]
   }
 
-  func configurePhotoOutputFormat(configuration: CameraConfiguration) throws {
+  func configurePhotoOutputFormat(configuration _: CameraConfiguration) throws {
     guard let videoDeviceInput, let photoOutput else {
       // Photo is not enabled
       return

--- a/package/ios/Core/CameraSession+Photo.swift
+++ b/package/ios/Core/CameraSession+Photo.swift
@@ -44,11 +44,7 @@ extension CameraSession {
       // high resolution capture
       if photo.enableHighQualityPhotos {
         // TODO: On iOS 16+ this will be removed in favor of maxPhotoDimensions.
-        if #available(iOS 16.0, *) {
-          photoSettings.maxPhotoDimensions = photoOutput.maxPhotoDimensions
-        } else {
-          photoSettings.isHighResolutionPhotoEnabled = true
-        }
+        photoSettings.isHighResolutionPhotoEnabled = photoOutput.isHighResolutionCaptureEnabled
       }
 
       // depth data

--- a/package/ios/Core/CameraSession+Photo.swift
+++ b/package/ios/Core/CameraSession+Photo.swift
@@ -41,12 +41,6 @@ extension CameraSession {
       // Create photo settings
       let photoSettings = AVCapturePhotoSettings()
 
-      // high resolution capture
-      if photo.enableHighQualityPhotos {
-        // TODO: On iOS 16+ this will be removed in favor of maxPhotoDimensions.
-        photoSettings.isHighResolutionPhotoEnabled = photoOutput.isHighResolutionCaptureEnabled
-      }
-
       // depth data
       photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
       if #available(iOS 12.0, *) {

--- a/package/ios/Core/CameraSession+Photo.swift
+++ b/package/ios/Core/CameraSession+Photo.swift
@@ -41,6 +41,12 @@ extension CameraSession {
       // Create photo settings
       let photoSettings = AVCapturePhotoSettings()
 
+      // high resolution capture
+      if photo.enableHighQualityPhotos {
+        // TODO: On iOS 16+ this will be removed in favor of maxPhotoDimensions.
+        photoSettings.isHighResolutionPhotoEnabled = photoOutput.isHighResolutionCaptureEnabled
+      }
+
       // depth data
       photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
       if #available(iOS 12.0, *) {

--- a/package/ios/Core/CameraSession+Photo.swift
+++ b/package/ios/Core/CameraSession+Photo.swift
@@ -41,9 +41,10 @@ extension CameraSession {
       // Create photo settings
       let photoSettings = AVCapturePhotoSettings()
 
-      // high resolution capture
-      if photo.enableHighQualityPhotos {
-        // TODO: On iOS 16+ this will be removed in favor of maxPhotoDimensions.
+      // set photo resolution
+      if #available(iOS 16.0, *) {
+        photoSettings.maxPhotoDimensions = photoOutput.maxPhotoDimensions
+      } else {
         photoSettings.isHighResolutionPhotoEnabled = photoOutput.isHighResolutionCaptureEnabled
       }
 

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -159,15 +159,19 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
           if difference.outputsChanged || difference.formatChanged {
             try self.configurePixelFormat(configuration: config)
           }
-          // 6. Configure side-props (fps, lowLightBoost)
+          // 6. After step 2. and 4. we also need to configure the photo output resolution
+          if difference.outputsChanged || difference.formatChanged {
+            self.configurePhotoOutputResolution(configuration: config)
+          }
+          // 7. Configure side-props (fps, lowLightBoost)
           if difference.sidePropsChanged {
             try self.configureSideProps(configuration: config, device: device)
           }
-          // 7. Configure zoom
+          // 8. Configure zoom
           if difference.zoomChanged {
             self.configureZoom(configuration: config, device: device)
           }
-          // 8. Configure exposure bias
+          // 9. Configure exposure bias
           if difference.exposureChanged {
             self.configureExposure(configuration: config, device: device)
           }
@@ -179,10 +183,10 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
           self.captureSession.commitConfiguration()
         }
 
-        // 9. Start or stop the session if needed
+        // 10. Start or stop the session if needed
         self.checkIsActive(configuration: config)
 
-        // 10. Enable or disable the Torch if needed (requires session to be running)
+        // 11. Enable or disable the Torch if needed (requires session to be running)
         if difference.torchChanged {
           try device.lockForConfiguration()
           defer {

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -159,19 +159,15 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
           if difference.outputsChanged || difference.formatChanged {
             try self.configurePixelFormat(configuration: config)
           }
-          // 6. After step 2. and 4. we also need to configure the photo output resolution
-          if difference.outputsChanged || difference.formatChanged {
-            self.configurePhotoOutputResolution(configuration: config)
-          }
-          // 7. Configure side-props (fps, lowLightBoost)
+          // 6. Configure side-props (fps, lowLightBoost)
           if difference.sidePropsChanged {
             try self.configureSideProps(configuration: config, device: device)
           }
-          // 8. Configure zoom
+          // 7. Configure zoom
           if difference.zoomChanged {
             self.configureZoom(configuration: config, device: device)
           }
-          // 9. Configure exposure bias
+          // 8. Configure exposure bias
           if difference.exposureChanged {
             self.configureExposure(configuration: config, device: device)
           }
@@ -183,10 +179,10 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
           self.captureSession.commitConfiguration()
         }
 
-        // 10. Start or stop the session if needed
+        // 9. Start or stop the session if needed
         self.checkIsActive(configuration: config)
 
-        // 11. Enable or disable the Torch if needed (requires session to be running)
+        // 10. Enable or disable the Torch if needed (requires session to be running)
         if difference.torchChanged {
           try device.lockForConfiguration()
           defer {

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -154,10 +154,11 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
           if difference.formatChanged {
             try self.configureFormat(configuration: config, device: device)
           }
-          // 5. After step 2. and 4., we also need to configure the PixelFormat.
-          //    This needs to be done AFTER we updated the `format`, as this controls the supported PixelFormats.
+          // 5. After step 2. and 4., we also need to configure some output properties that depend on format.
+          //    This needs to be done AFTER we updated the `format`, as this controls the supported properties.
           if difference.outputsChanged || difference.formatChanged {
-            try self.configurePixelFormat(configuration: config)
+            try self.configureVideoOutputFormat(configuration: config)
+            try self.configurePhotoOutputFormat(configuration: config)
           }
           // 6. Configure side-props (fps, lowLightBoost)
           if difference.sidePropsChanged {

--- a/package/package.json
+++ b/package/package.json
@@ -98,7 +98,7 @@
     "react": "^18.2.0",
     "react-native": "^0.72.3",
     "react-native-builder-bob": "^0.21.3",
-    "react-native-worklets-core": "^0.3.0",
+    "react-native-worklets-core": "^0.4.0",
     "release-it": "^16.1.3",
     "typescript": "^5.1.6"
   },

--- a/package/src/CameraProps.ts
+++ b/package/src/CameraProps.ts
@@ -266,18 +266,6 @@ export interface CameraProps extends ViewProps {
    */
   enablePortraitEffectsMatteDelivery?: boolean
   /**
-   * Indicates whether the Camera should prepare the photo pipeline to provide maximum quality photos.
-   *
-   * This enables:
-   * * High Resolution Capture ([`isHighResolutionCaptureEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/1648721-ishighresolutioncaptureenabled))
-   * * Virtual Device fusion for greater detail ([`isVirtualDeviceConstituentPhotoDeliveryEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/3192189-isvirtualdeviceconstituentphotod))
-   * * Dual Device fusion for greater detail ([`isDualCameraDualPhotoDeliveryEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotosettings/2873917-isdualcameradualphotodeliveryena))
-   *
-   * @platform iOS
-   * @default false
-   */
-  enableHighQualityPhotos?: boolean
-  /**
    * If `true`, show a debug view to display the FPS of the Video Pipeline (Frame Processor).
    * This is useful for debugging your Frame Processor's speed.
    *

--- a/package/src/CameraProps.ts
+++ b/package/src/CameraProps.ts
@@ -266,6 +266,18 @@ export interface CameraProps extends ViewProps {
    */
   enablePortraitEffectsMatteDelivery?: boolean
   /**
+   * Indicates whether the Camera should prepare the photo pipeline to provide maximum quality photos.
+   *
+   * This enables:
+   * * High Resolution Capture ([`isHighResolutionCaptureEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/1648721-ishighresolutioncaptureenabled))
+   * * Virtual Device fusion for greater detail ([`isVirtualDeviceConstituentPhotoDeliveryEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/3192189-isvirtualdeviceconstituentphotod))
+   * * Dual Device fusion for greater detail ([`isDualCameraDualPhotoDeliveryEnabled`](https://developer.apple.com/documentation/avfoundation/avcapturephotosettings/2873917-isdualcameradualphotodeliveryena))
+   *
+   * @platform iOS
+   * @default false
+   */
+  enableHighQualityPhotos?: boolean
+  /**
    * If `true`, show a debug view to display the FPS of the Video Pipeline (Frame Processor).
    * This is useful for debugging your Frame Processor's speed.
    *

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -6599,10 +6599,10 @@ react-native-builder-bob@^0.21.3:
   optionalDependencies:
     jetifier "^2.0.0"
 
-react-native-worklets-core@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-0.3.0.tgz#4d6c4c4999d3bf2f8c67fa46fdd70d8b5bc7ba0e"
-  integrity sha512-bOoo6xbl+f+mz0Q65bLkUP3FxgYt7f/Bzi0c5Yj8Ix4vQCKMtgHwafrqCNRhW32N7TpTv3+zOoyQMJwQVr/frQ==
+react-native-worklets-core@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-0.4.0.tgz#708f204d89327d88e155cccb5fc23421ca764b6f"
+  integrity sha512-0rYCwxnG6L85mih+3xe1r2RhhwKqjgVN9jikVh0iMPKDf9L4OZMJnl6Kh4zjXiW9rkyI5lBghfM4XIcLMfeU6w==
   dependencies:
     string-hash-64 "^1.0.3"
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes an inconsistency when the format's video resolution is lower than the photo resolution.

For example, this format:

```json
{
  "photoWidth": 4032,
  "photoHeight": 3024,
  "videoWidth": 192,
  "videoHeight": 144,
  // ...
}
```

...previously caused the resulting photo to be 192x144, even though it could shoot photos in 4032x3024.

The reason for that is that AVFoundation configures the video pipeline to take photos at max at the video resolution (as an optimization strategy), and if you want to change that behaviour you need to set the [`maxPhotoDimensions` property](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/3950867-maxphotodimensions) to 4032x3024 in this case.

> Note: This API is only available since iOS 16, so the legacy approach was to just set the [`isHighResolutionCaptureEnabled` property](https://developer.apple.com/documentation/avfoundation/avcapturephotooutput/1648721-ishighresolutioncaptureenabled) to `true`

With this PR, the `enableHighQualityPhotos` property will be removed (since it can just be implied if format photo size is larger than video size), and photos have their proper maximum resolution. 👍 

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- fixes https://github.com/mrousavy/react-native-vision-camera/issues/2649

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
