### PR TITLE
fix: Changes relative import paths in `usePreferredCameraDevice.ts`

### DIFF
--- a/package/example/src/hooks/usePreferredCameraDevice.ts
+++ b/package/example/src/hooks/usePreferredCameraDevice.ts
@@ -1,7 +1,6 @@
 import { useMMKVString } from 'react-native-mmkv'
-import { CameraDevice } from '../../../src/CameraDevice'
 import { useCallback, useMemo } from 'react'
-import { useCameraDevices } from '../../../src/hooks/useCameraDevices'
+import { CameraDevice, useCameraDevices } from 'react-native-vision-camera'
 
 export function usePreferredCameraDevice(): [CameraDevice | undefined, (device: CameraDevice) => void] {
   const [preferredDeviceId, setPreferredDeviceId] = useMMKVString('camera.preferredDeviceId')


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR fixes to reference 'react-native-vision-camera' instead of referencing a relative path.
<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes
This PR changes import paths in `usePreferredCameraDevice.ts`.

Updated import paths for `CameraDevice` and `useCameraDevices`. 
It now correctly references 'react-native-vision-camera' instead of a relative path. 

Before
```typescript
import { CameraDevice } from '../../../src/CameraDevice'
import { useCameraDevices } from '../../../src/hooks/useCameraDevices'
```
After
```typescript
import { CameraDevice, useCameraDevices } from 'react-native-vision-camera'
```
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on
iPhone SE (3rd generation) 17.3.1
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
