### PR TITLE
fix: focus on Android (v4)

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+Focus.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+Focus.kt
@@ -1,6 +1,7 @@
 package com.mrousavy.camera
 
 import com.facebook.react.bridge.ReadableMap
+import com.mrousavy.camera.extensions.px
 import com.mrousavy.camera.utils.runOnUiThreadAndWait
 
 suspend fun CameraView.focus(pointMap: ReadableMap) {
@@ -8,7 +9,7 @@ suspend fun CameraView.focus(pointMap: ReadableMap) {
   val y = pointMap.getDouble("y")
 
   val point = runOnUiThreadAndWait {
-    previewView.meteringPointFactory.createPoint(x.toFloat(), y.toFloat())
+    previewView.meteringPointFactory.createPoint(x.toFloat().px, y.toFloat().px)
   }
   cameraSession.focus(point)
 }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/Float.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/Float.kt
@@ -1,0 +1,6 @@
+package com.mrousavy.camera.extensions
+
+import android.content.res.Resources
+
+val Float.px: Float
+    get() = this * Resources.getSystem().displayMetrics.density

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/Float.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/Float.kt
@@ -3,4 +3,4 @@ package com.mrousavy.camera.extensions
 import android.content.res.Resources
 
 val Float.px: Float
-    get() = this * Resources.getSystem().displayMetrics.density
+  get() = this * Resources.getSystem().displayMetrics.density


### PR DESCRIPTION
## What

This PR fixes a problem of incorrect focus on Android (when position of the focus is driven by `gesture-handler`).

## Changes

* This PR passes `px` value to `meteringPointFactory.createPoint` method;
* This PR adds `px` for `Float` extension.

## Tested on

Pixel 7 Pro (Android 14).

## Related issues

We discussed it internally in Discord channel.

## Screenshots

|Before|After|
|-------|-----|
|<video src="https://github.com/mrousavy/react-native-vision-camera/assets/22820318/1f2fe807-ed8f-46ce-8bfe-cf61e012c31a">|<video src="https://github.com/mrousavy/react-native-vision-camera/assets/22820318/a5f0f153-afbb-42fa-8c2b-386b2227ddc4">|

