### PR TITLE
Use correct UIManager in `findCameraView` depending on the architecture

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt
@@ -9,6 +9,7 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.common.UIManagerType
 import com.mrousavy.camera.core.CameraError
 import com.mrousavy.camera.core.CameraQueues
 import com.mrousavy.camera.core.ViewNotFoundError
@@ -55,10 +56,11 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     suspendCoroutine { continuation ->
       UiThreadUtil.runOnUiThread {
         Log.d(TAG, "Finding view $viewId...")
+        val uiManagerType = if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) UIManagerType.FABRIC else UIManagerType.DEFAULT
         val view = if (reactApplicationContext != null) {
           UIManagerHelper.getUIManager(
             reactApplicationContext,
-            viewId
+            uiManagerType
           )?.resolveView(viewId) as CameraView?
         } else {
           null


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

`UIManagerHelper.getUIManager` has following signature:
```
UIManager getUIManager(ReactContext context, @UIManagerType int uiManagerType)
```
(Here's the source: https://github.com/facebook/react-native/blob/3f8882116782da609664f311427d7a6523ad06cf/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java#L51)

But in `findCameraView` it's used like this: https://github.com/mrousavy/react-native-vision-camera/blob/83168044a66f18a5b36dc996a389ded7bb840a1c/package/android/src/main/java/com/mrousavy/camera/CameraViewModule.kt#L59-L62

where the view tag is passed instead of the UI manager type. This effectively makes it behave as if `DEFAULT` was passed and `UIManagerModule` was returned on the new arch instead of `FabricUIManager`.

## Changes

- Updates finding the camera view to use correct UIManager depending on the architecture

## Tested on

I've only tried on Android emulator

## Related issues

Potentially fixes https://github.com/mrousavy/react-native-vision-camera/issues/2613
