### PR TITLE
always supply NSLocationWhenInUseUsageDescription string in expo

### DIFF
--- a/package/src/expo-plugin/withVisionCamera.ts
+++ b/package/src/expo-plugin/withVisionCamera.ts
@@ -21,11 +21,9 @@ const withCamera: ConfigPlugin<ConfigProps> = (config, props = {}) => {
     config.ios.infoPlist.NSMicrophoneUsageDescription =
       props.microphonePermissionText ?? (config.ios.infoPlist.NSMicrophoneUsageDescription as string | undefined) ?? MICROPHONE_USAGE
   }
-  if (props.enableLocationPermission) {
-    // Location permission
-    config.ios.infoPlist.NSLocationWhenInUseUsageDescription =
-      props.locationPermissionText ?? (config.ios.infoPlist.NSLocationWhenInUseUsageDescription as string | undefined) ?? LOCATION_USAGE
-  }
+  // Location permission
+  config.ios.infoPlist.NSLocationWhenInUseUsageDescription =
+    props.locationPermissionText ?? (config.ios.infoPlist.NSLocationWhenInUseUsageDescription as string | undefined) ?? LOCATION_USAGE
   const androidPermissions = ['android.permission.CAMERA']
   if (props.enableMicrophonePermission) androidPermissions.push('android.permission.RECORD_AUDIO')
   if (props.enableLocationPermission) androidPermissions.push('android.permission.ACCESS_FINE_LOCATION')


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

After upgrading to react-native-vision-camera 4.0.0-beta.12 and uploading a build to the app store connect I received the following warning:

> ITMS-90683: Missing purpose string in Info.plist - Your app’s code references one or more APIs that access sensitive user data, or the app has one or more entitlements that permit such access. The Info.plist file for the “*.app” bundle should contain a NSLocationWhenInUseUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. If you’re using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. For details, visit: https://developer.apple.com/documentation/uikit/protecting_the_user_s_privacy/requesting_access_to_protected_resources.

But I don't use the location at all

## Changes

This PR removes the need of the user to explicitly mention they use location to supply a default NSLocationWhenInUseUsageDescription string

## Tested on

## Related issues
