### PR TITLE
fix: Make dependencies (`ModuleProxy`) actually optional

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -467,7 +467,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - SocketRocket (0.6.1)
-  - VisionCamera (4.0.0-beta.14):
+  - VisionCamera (4.0.0-beta.15):
     - React
     - React-callinvoker
     - React-Core
@@ -701,7 +701,7 @@ SPEC CHECKSUMS:
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNVectorIcons: 23b6e11af4aaf104d169b1b0afa7e5cf96c676ce
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 4d01ac25d09288d3aa670b1e0eb092c47e7d4211
+  VisionCamera: 6f2f2b7e9df333899e640e3617bc02cac86f4774
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: 299b350392623e1b01615935e236438d90fd2cff

--- a/package/src/dependencies/ModuleProxy.ts
+++ b/package/src/dependencies/ModuleProxy.ts
@@ -4,20 +4,24 @@ type ImportType = ReturnType<typeof require>
  * Create a lazily-imported module proxy.
  * This is useful for lazily requiring optional dependencies.
  */
-export const createModuleProxy = <TModule>(name: string, getModule: () => ImportType): TModule => {
+export const createModuleProxy = <TModule>(getModule: () => ImportType): TModule => {
   const holder: { module: TModule | undefined } = { module: undefined }
 
   const proxy = new Proxy(holder, {
     get: (target, property) => {
       if (target.module == null) {
-        try {
-          target.module = getModule() as TModule
-        } catch (e) {
-          throw new Error(`${name} is not installed!`)
-        }
+        // lazy initialize module via require()
+        // caller needs to make sure the require() call is wrapped in a try/catch
+        target.module = getModule() as TModule
       }
       return target.module[property as keyof typeof holder.module]
     },
   })
   return proxy as unknown as TModule
+}
+
+export class OptionalDependencyNotInstalledError extends Error {
+  constructor(name: string) {
+    super(`${name} is not installed!`)
+  }
 }

--- a/package/src/dependencies/ReanimatedProxy.ts
+++ b/package/src/dependencies/ReanimatedProxy.ts
@@ -1,5 +1,6 @@
 import type * as Reanimated from 'react-native-reanimated'
-import { createModuleProxy } from './ModuleProxy'
+import { createModuleProxy, OptionalDependencyNotInstalledError } from './ModuleProxy'
+
 type TReanimated = typeof Reanimated
 
 /**
@@ -9,4 +10,10 @@ type TReanimated = typeof Reanimated
  * If react-native-reanimated is not installed, accessing anything on
  * {@linkcode ReanimatedProxy} will throw.
  */
-export const ReanimatedProxy = createModuleProxy<TReanimated>('react-native-reanimated', () => require('react-native-reanimated'))
+export const ReanimatedProxy = createModuleProxy<TReanimated>(() => {
+  try {
+    return require('react-native-reanimated')
+  } catch (e) {
+    throw new OptionalDependencyNotInstalledError('react-native-reanimated')
+  }
+})

--- a/package/src/dependencies/SkiaProxy.ts
+++ b/package/src/dependencies/SkiaProxy.ts
@@ -1,5 +1,6 @@
 import type * as Skia from '@shopify/react-native-skia'
-import { createModuleProxy } from './ModuleProxy'
+import { createModuleProxy, OptionalDependencyNotInstalledError } from './ModuleProxy'
+
 type TSkia = typeof Skia
 
 /**
@@ -9,4 +10,10 @@ type TSkia = typeof Skia
  * If @shopify/react-native-skia is not installed, accessing anything on
  * {@linkcode SkiaProxy} will throw.
  */
-export const SkiaProxy = createModuleProxy<TSkia>('@shopify/react-native-skia', () => require('@shopify/react-native-skia'))
+export const SkiaProxy = createModuleProxy<TSkia>(() => {
+  try {
+    return require('@shopify/react-native-skia')
+  } catch (e) {
+    throw new OptionalDependencyNotInstalledError('@shopify/react-native-skia')
+  }
+})

--- a/package/src/dependencies/WorkletsProxy.ts
+++ b/package/src/dependencies/WorkletsProxy.ts
@@ -1,5 +1,6 @@
 import type * as Worklets from 'react-native-worklets-core'
-import { createModuleProxy } from './ModuleProxy'
+import { createModuleProxy, OptionalDependencyNotInstalledError } from './ModuleProxy'
+
 type TWorklets = typeof Worklets
 
 /**
@@ -9,4 +10,10 @@ type TWorklets = typeof Worklets
  * If react-native-worklets-core is not installed, accessing anything on
  * {@linkcode WorkletsProxy} will throw.
  */
-export const WorkletsProxy = createModuleProxy<TWorklets>('react-native-worklets-core', () => require('react-native-worklets-core'))
+export const WorkletsProxy = createModuleProxy<TWorklets>(() => {
+  try {
+    return require('react-native-worklets-core')
+  } catch (e) {
+    throw new OptionalDependencyNotInstalledError('react-native-worklets-core')
+  }
+})


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

I created the `createModuleProxy` function to generate lazy-, optional-dependencies for us.

This was used for react-native-worklets-core (Frame Processors) and Skia + Ranimated (Skia Frame Processors), but unfortunately it crashed when the dependency was not installed in JS.

This was because we were using try/catch in `createModuleProxy`, and apparently the JS parser is not smart enough to catch require errors thrown in a function passed in.
So we need to try/catch at the actual `require` call to fix this.

Maybe this is a bug in Hermes or Metro or something?


This breaks: 

```ts
const getModule = () => require('bla') // <-- error thrown here already

let module = null
try {
  module = getModule()
} catch (e) {
  console.log('module not available.')
}
```

This works:

```ts
const getModule = () => {
  try {
    return require('bla')
  } catch (e) {
    console.log('module not available.')
    return null
  }
}

let module = getModule()
```

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
