### PR TITLE
fix: Clean up Skia resources on Worklet context to avoid race condition

### DIFF
--- a/package/android/src/main/cpp/frameprocessor/VisionCameraProxy.cpp
+++ b/package/android/src/main/cpp/frameprocessor/VisionCameraProxy.cpp
@@ -42,6 +42,7 @@ std::vector<jsi::PropNameID> VisionCameraProxy::getPropertyNames(jsi::Runtime& r
   result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("setFrameProcessor")));
   result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("removeFrameProcessor")));
   result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("initFrameProcessorPlugin")));
+  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("workletContext")));
   return result;
 }
 
@@ -75,8 +76,7 @@ jsi::Value VisionCameraProxy::get(jsi::Runtime& runtime, const jsi::PropNameID& 
           this->setFrameProcessor(static_cast<int>(viewTag), runtime, sharedFunction);
           return jsi::Value::undefined();
         });
-  }
-  if (name == "removeFrameProcessor") {
+  } else if (name == "removeFrameProcessor") {
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forUtf8(runtime, "removeFrameProcessor"), 1,
         [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
@@ -84,8 +84,7 @@ jsi::Value VisionCameraProxy::get(jsi::Runtime& runtime, const jsi::PropNameID& 
           this->removeFrameProcessor(static_cast<int>(viewTag));
           return jsi::Value::undefined();
         });
-  }
-  if (name == "initFrameProcessorPlugin") {
+  } else if (name == "initFrameProcessorPlugin") {
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forUtf8(runtime, "initFrameProcessorPlugin"), 1,
         [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
@@ -97,6 +96,9 @@ jsi::Value VisionCameraProxy::get(jsi::Runtime& runtime, const jsi::PropNameID& 
 
           return this->initFrameProcessorPlugin(runtime, pluginName, options);
         });
+  } else if (name == "workletContext") {
+    std::shared_ptr<RNWorklet::JsiWorkletContext> context = _javaProxy->cthis()->getWorkletContext();
+    return jsi::Object::createFromHostObject(runtime, context);
   }
 
   return jsi::Value::undefined();

--- a/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraProxy.h
+++ b/package/android/src/main/cpp/frameprocessor/java-bindings/JVisionCameraProxy.h
@@ -41,6 +41,10 @@ public:
   jsi::Runtime& getWorkletRuntime() {
     return _workletContext->getWorkletRuntime();
   }
+
+  std::shared_ptr<RNWorklet::JsiWorkletContext> getWorkletContext() {
+    return _workletContext;
+  }
 #endif
 
 private:

--- a/package/ios/Frame Processor/VisionCameraProxy.mm
+++ b/package/ios/Frame Processor/VisionCameraProxy.mm
@@ -62,6 +62,7 @@ std::vector<jsi::PropNameID> VisionCameraProxy::getPropertyNames(jsi::Runtime& r
   result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("setFrameProcessor")));
   result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("removeFrameProcessor")));
   result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("initFrameProcessorPlugin")));
+  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("workletContext")));
   return result;
 }
 
@@ -119,8 +120,7 @@ jsi::Value VisionCameraProxy::get(jsi::Runtime& runtime, const jsi::PropNameID& 
           this->setFrameProcessor(runtime, static_cast<int>(viewTag), sharedFunction);
           return jsi::Value::undefined();
         });
-  }
-  if (name == "removeFrameProcessor") {
+  } else if (name == "removeFrameProcessor") {
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forUtf8(runtime, "removeFrameProcessor"), 1,
         [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
@@ -128,8 +128,7 @@ jsi::Value VisionCameraProxy::get(jsi::Runtime& runtime, const jsi::PropNameID& 
           this->removeFrameProcessor(runtime, static_cast<int>(viewTag));
           return jsi::Value::undefined();
         });
-  }
-  if (name == "initFrameProcessorPlugin") {
+  } else if (name == "initFrameProcessorPlugin") {
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forUtf8(runtime, "initFrameProcessorPlugin"), 1,
         [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
@@ -141,6 +140,8 @@ jsi::Value VisionCameraProxy::get(jsi::Runtime& runtime, const jsi::PropNameID& 
 
           return this->initFrameProcessorPlugin(runtime, pluginName, options);
         });
+  } else if (name == "workletContext") {
+    return jsi::Object::createFromHostObject(runtime, _workletContext);
   }
 
   return jsi::Value::undefined();

--- a/package/src/FrameProcessorPlugins.ts
+++ b/package/src/FrameProcessorPlugins.ts
@@ -60,6 +60,10 @@ interface TVisionCameraProxy {
   throwJSError(error: unknown): void
   /**
    * Get the Frame Processor Runtime Worklet Context.
+   *
+   * This is the serial [DispatchQueue](https://developer.apple.com/documentation/dispatch/dispatchqueue)
+   * / [Executor](https://developer.android.com/reference/java/util/concurrent/Executor) the
+   * video/frame processor pipeline is running on.
    */
   workletContext: IWorkletContext | undefined
 }

--- a/package/src/FrameProcessorPlugins.ts
+++ b/package/src/FrameProcessorPlugins.ts
@@ -3,6 +3,7 @@ import { CameraRuntimeError } from './CameraError'
 import { CameraModule } from './NativeCameraModule'
 import { assertJSIAvailable } from './JSIHelper'
 import { WorkletsProxy } from './dependencies/WorkletsProxy'
+import type { IWorkletContext } from 'react-native-worklets-core'
 
 declare global {
   // eslint-disable-next-line no-var
@@ -57,6 +58,10 @@ interface TVisionCameraProxy {
    * Throws the given error.
    */
   throwJSError(error: unknown): void
+  /**
+   * Get the Frame Processor Runtime Worklet Context.
+   */
+  workletContext: IWorkletContext | undefined
 }
 
 const errorMessage = 'Frame Processors are not available, react-native-worklets-core is not installed!'
@@ -134,6 +139,7 @@ let proxy: TVisionCameraProxy = {
     throw new CameraRuntimeError('system/frame-processors-unavailable', errorMessage)
   },
   throwJSError: throwJSError,
+  workletContext: undefined,
 }
 if (hasWorklets) {
   // Install native Frame Processor Runtime Manager
@@ -157,6 +163,7 @@ export const VisionCameraProxy: TVisionCameraProxy = {
   removeFrameProcessor: proxy.removeFrameProcessor,
   setFrameProcessor: proxy.setFrameProcessor,
   throwJSError: throwJSError,
+  workletContext: undefined,
 }
 
 function getLastFrameProcessorCall(frameProcessorFuncId: string): number {

--- a/package/src/skia/useSkiaFrameProcessor.ts
+++ b/package/src/skia/useSkiaFrameProcessor.ts
@@ -262,7 +262,8 @@ export function useSkiaFrameProcessor(
   useEffect(() => {
     return () => {
       // on unmount, we clean up the resources on the Worklet Context.
-      // this causes it to definitely run after the Frame Processor has finished executing
+      // this causes it to run _after_ the Frame Processor has finished executing,
+      // if it is currently executing - so we avoid race conditions here.
       VisionCameraProxy.workletContext?.runAsync(() => {
         'worklet'
         const surfaces = Object.values(surface.value).map((v) => v.surface)

--- a/package/src/skia/useSkiaFrameProcessor.ts
+++ b/package/src/skia/useSkiaFrameProcessor.ts
@@ -2,13 +2,12 @@ import type { Frame, FrameInternal } from '../Frame'
 import type { DependencyList } from 'react'
 import { useEffect, useMemo } from 'react'
 import type { Orientation } from '../Orientation'
-import { wrapFrameProcessorWithRefCounting } from '../FrameProcessorPlugins'
+import { VisionCameraProxy, wrapFrameProcessorWithRefCounting } from '../FrameProcessorPlugins'
 import type { DrawableFrameProcessor } from '../CameraProps'
 import type { ISharedValue, IWorkletNativeApi } from 'react-native-worklets-core'
 import { WorkletsProxy } from '../dependencies/WorkletsProxy'
 import type { SkCanvas, SkPaint, SkImage, SkSurface } from '@shopify/react-native-skia'
 import { SkiaProxy } from '../dependencies/SkiaProxy'
-import { InteractionManager } from 'react-native'
 
 /**
  * Represents a Camera Frame that can be directly drawn to using Skia.
@@ -262,8 +261,10 @@ export function useSkiaFrameProcessor(
 
   useEffect(() => {
     return () => {
-      InteractionManager.runAfterInteractions(() => {
-        // on unmount, clean everything
+      // on unmount, we clean up the resources on the Worklet Context.
+      // this causes it to definitely run after the Frame Processor has finished executing
+      VisionCameraProxy.workletContext?.runAsync(() => {
+        'worklet'
         const surfaces = Object.values(surface.value).map((v) => v.surface)
         surface.value = {}
         surfaces.forEach((s) => s.dispose())


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Cleans up Skia context resources (all the `SkSurface`s, and all the `SkImage`s (textures)) on the VisionCamera Frame Processor Worklet Context, instead of the default React JS Context.

Before, we cleaned it up on the JS context, which could introduce a race condition as the Frame Processor might still be executing. This can then lead to a hard-crash when trying to access some things, as the memory has been deleted elsewhere.

So instead, we now "schedule" that cleanup to run on the Worklet Context, which will make sure that it always runs after the Frame Processor.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2753

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
