### PR TITLE
fix: Fix `minFps` being larger in `Range` than `maxFps`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -120,8 +120,11 @@ class CameraDeviceDetails(private val cameraInfo: CameraInfo, extensionsManager:
       val maxFps = fpsRanges.maxOf { it.upper }
 
       videoSizes.forEach { videoSize ->
+        // not every size supports the maximum FPS range
         val maxFpsForSize = CamcorderProfileUtils.getMaximumFps(cameraId, videoSize) ?: maxFps
-        val fpsRange = Range(minFps, maxFpsForSize)
+        // if the FPS range for this size is even smaller than min FPS, we need to clamp that as well.
+        val minFpsForSize = min(minFps, maxFpsForSize)
+        val fpsRange = Range(minFpsForSize, maxFpsForSize)
 
         photoSizes.forEach { photoSize ->
           val map = buildFormatMap(photoSize, videoSize, fpsRange)

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -30,6 +30,7 @@ import com.mrousavy.camera.types.Position
 import com.mrousavy.camera.types.VideoStabilizationMode
 import com.mrousavy.camera.utils.CamcorderProfileUtils
 import kotlin.math.atan2
+import kotlin.math.min
 import kotlin.math.sqrt
 
 @SuppressLint("RestrictedApi")


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

We clamp the `maxFps` to the value that is supported by the given size.
If the max fps for the given size is even smaller than the minimum supported size, we also need to clamp the minFps.



<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2740
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
