### PR TITLE
fix: Fix `already bound to a different lifecycle` error when flipping camera

### DIFF
--- a/package/android/src/main/cpp/.clang-format
+++ b/package/android/src/main/cpp/.clang-format
@@ -1,1 +1,0 @@
-../../../../cpp/.clang-format

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -424,7 +424,7 @@ class CameraSession(private val context: Context, private val callback: Callback
 
     // Unbind all currently bound use-cases before rebinding
     if (currentUseCases.isNotEmpty()) {
-      Log.i(TAG, "Unbinding ${useCases.size} use-cases for Camera #${camera?.cameraInfo?.id}...")
+      Log.i(TAG, "Unbinding ${currentUseCases.size} use-cases for Camera #${camera?.cameraInfo?.id}...")
       provider.unbind(*currentUseCases.toTypedArray())
     }
 
@@ -432,6 +432,7 @@ class CameraSession(private val context: Context, private val callback: Callback
     Log.i(TAG, "Binding ${useCases.size} use-cases...")
     camera = provider.bindToLifecycle(this, cameraSelector, *useCases.toTypedArray())
 
+    // Update currentUseCases for next unbind
     currentUseCases = useCases
 
     // Listen to Camera events

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -84,8 +84,7 @@ class CameraSession(private val context: Context, private val callback: Callback
   private var videoOutput: VideoCapture<Recorder>? = null
   private var frameProcessorOutput: ImageAnalysis? = null
   private var codeScannerOutput: ImageAnalysis? = null
-  private val useCases: List<UseCase>
-    get() = listOfNotNull(previewOutput, photoOutput, videoOutput, frameProcessorOutput, codeScannerOutput)
+  private var currentUseCases: List<UseCase> = emptyList()
 
   // Camera Outputs State
   private val metadataProvider = MetadataProvider(context)
@@ -162,7 +161,6 @@ class CameraSession(private val context: Context, private val callback: Callback
         // Build up session or update any props
         if (diff.outputsChanged) {
           // 1. outputs changed, re-create them
-          closeCurrentOutputs(provider)
           configureOutputs(config)
         }
         if (diff.deviceChanged || diff.outputsChanged) {
@@ -383,20 +381,13 @@ class CameraSession(private val context: Context, private val callback: Callback
     Log.i(TAG, "Successfully created new Outputs for Camera #${configuration.cameraId}!")
   }
 
-  private fun closeCurrentOutputs(provider: ProcessCameraProvider) {
-    if (useCases.isEmpty()) {
-      return
-    }
-    Log.i(TAG, "Unbinding ${useCases.size} use-cases for Camera #${camera?.cameraInfo?.id}...")
-    provider.unbind(*useCases.toTypedArray())
-  }
-
   @SuppressLint("RestrictedApi")
   private suspend fun configureCamera(provider: ProcessCameraProvider, configuration: CameraConfiguration) {
     Log.i(TAG, "Binding Camera #${configuration.cameraId}...")
     checkCameraPermission()
 
     // Outputs
+    val useCases = listOfNotNull(previewOutput, photoOutput, videoOutput, frameProcessorOutput, codeScannerOutput)
     if (useCases.isEmpty()) {
       throw NoOutputsError()
     }
@@ -431,9 +422,17 @@ class CameraSession(private val context: Context, private val callback: Callback
       cameraSelector = cameraSelector.withExtension(context, provider, needsImageAnalysis, ExtensionMode.NIGHT, "NIGHT")
     }
 
+    // Unbind all currently bound use-cases before rebinding
+    if (currentUseCases.isNotEmpty()) {
+      Log.i(TAG, "Unbinding ${useCases.size} use-cases for Camera #${camera?.cameraInfo?.id}...")
+      provider.unbind(*currentUseCases.toTypedArray())
+    }
+
     // Bind it all together (must be on UI Thread)
     Log.i(TAG, "Binding ${useCases.size} use-cases...")
     camera = provider.bindToLifecycle(this, cameraSelector, *useCases.toTypedArray())
+
+    currentUseCases = useCases
 
     // Listen to Camera events
     var lastState = CameraState.Type.OPENING
@@ -513,9 +512,8 @@ class CameraSession(private val context: Context, private val callback: Callback
     BitmapFactory.decodeFile(photoFile.uri.path, bitmapOptions)
     val width = bitmapOptions.outWidth
     val height = bitmapOptions.outHeight
-    val orientation = outputOrientation
 
-    return Photo(photoFile.uri.path, width, height, orientation, isMirrored)
+    return Photo(photoFile.uri.path, width, height, outputOrientation, isMirrored)
   }
 
   private fun getEnableShutterSoundActual(enable: Boolean): Boolean {


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes this error:

```
Failed to configure CameraSession! Error: Use case Preview:androidx.camera.core.Preview-de4f3173-e76f-49cf-b589-73fab23b84b1 already bound to a different lifecycle., Config-Diff: Difference(deviceChanged=true, outputsChanged=false, sidePropsChanged=false, isActiveChanged=false, locationChanged=false)
java.lang.IllegalStateException: Use case Preview:androidx.camera.core.Preview-de4f3173-e76f-49cf-b589-73fab23b84b1 already bound to a different lifecycle.
	at androidx.camera.lifecycle.ProcessCameraProvider.bindToLifecycle(ProcessCameraProvider.java:587)
	at androidx.camera.lifecycle.ProcessCameraProvider.bindToLifecycle(ProcessCameraProvider.java:386)
	at com.mrousavy.camera.core.CameraSession.configureCamera(CameraSession.kt:417)
	at com.mrousavy.camera.core.CameraSession.configure(CameraSession.kt:165)
	at com.mrousavy.camera.CameraView$update$1.invokeSuspend(CameraView.kt:156)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.app.ActivityThread.main(ActivityThread.java:8669)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```

..which occured because the `closeCurrentOutputs` branch was never hit when only the device ID changed, but not the output specs.

This only happened in very rare situations where the front and back cameras have exactly the same specifications and formats (video resolution, photo resolution, fps, hdr etc settings).

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2721
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2748

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
