### PR TITLE
fix: Fix `ImageAnalysis is not supported when Extension is enabled` error

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -398,7 +398,7 @@ class CameraSession(private val context: Context, private val callback: Callback
 
     // Wrap input with a vendor extension if needed (see https://developer.android.com/media/camera/camera-extensions)
     val isStreamingHDR = useCases.any { !it.currentConfig.dynamicRange.isSDR }
-    val needsImageAnalysis = codeScannerOutput != null
+    val needsImageAnalysis = codeScannerOutput != null || frameProcessorOutput != null
     val photoOptions = configuration.photo as? CameraConfiguration.Output.Enabled<CameraConfiguration.Photo>
     val enableHdrExtension = photoOptions != null && photoOptions.config.enableHdr
     if (enableHdrExtension) {


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the `ImageAnalysis is not supported when Extension is enabled` error when using FP or CodeScanner **and** Photo HDR or Night Mode vendor extensions.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2715

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
