### PR TITLE
fix: Fix `RCTBlockGuard` not found error

### DIFF
--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -101,6 +101,7 @@ Pod::Spec.new do |s|
       }
 
       fp.dependency "React"
+      fp.dependency "ReactCommon"
       fp.dependency "React-callinvoker"
       fp.dependency "react-native-worklets-core"
     end

--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -101,7 +101,6 @@ Pod::Spec.new do |s|
       }
 
       fp.dependency "React"
-      fp.dependency "ReactCommon"
       fp.dependency "React-callinvoker"
       fp.dependency "react-native-worklets-core"
     end

--- a/package/android/src/main/cpp/frameprocessors/JSIJNIConversion.cpp
+++ b/package/android/src/main/cpp/frameprocessors/JSIJNIConversion.cpp
@@ -180,7 +180,7 @@ jsi::Value JSIJNIConversion::convertJNIObjectToJSIValue(jsi::Runtime& runtime, c
   }
 
   auto type = object->getClass()->toString();
-  auto message = "Received unknown JNI type \"" + type + "\"! Cannot convert to jsi::Value.";
+  auto message = "Cannot convert Java type \"" + type + "\" to jsi::Value!";
   __android_log_write(ANDROID_LOG_ERROR, "VisionCamera", message.c_str());
   throw std::runtime_error(message);
 }

--- a/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
+++ b/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
@@ -44,7 +44,7 @@ jsi::Value FrameProcessorPluginHostObject::get(jsi::Runtime& runtime, const jsi:
           NSDictionary* options = nil;
           if (count > 1) {
             auto optionsObject = arguments[1].asObject(runtime);
-            options = JSINSObjectConversion::convertJSIObjectToNSDictionary(runtime, optionsObject, _callInvoker);
+            options = (NSDictionary*)JSINSObjectConversion::convertJSIValueToObjCObject(runtime, optionsObject);
           }
 
           @try {

--- a/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
+++ b/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
@@ -44,7 +44,7 @@ jsi::Value FrameProcessorPluginHostObject::get(jsi::Runtime& runtime, const jsi:
           NSDictionary* options = nil;
           if (count > 1) {
             auto optionsObject = arguments[1].asObject(runtime);
-            options = (NSDictionary*)JSINSObjectConversion::convertJSIValueToObjCObject(runtime, optionsObject);
+            options = JSINSObjectConversion::convertJSIObjectToObjCDictionary(runtime, optionsObject);
           }
 
           @try {

--- a/package/ios/FrameProcessors/JSINSObjectConversion.h
+++ b/package/ios/FrameProcessors/JSINSObjectConversion.h
@@ -18,9 +18,9 @@ using namespace facebook;
 using namespace facebook::react;
 
 // id -> any
-jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value, std::shared_ptr<CallInvoker> jsInvoker);
+jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value);
 
 // any -> id
-id convertJSIValueToObjCObject(jsi::Runtime& runtime, const jsi::Value& value, std::shared_ptr<CallInvoker> jsInvoker);
+id convertJSIValueToObjCObject(jsi::Runtime& runtime, const jsi::Value& value);
 
 } // namespace JSINSObjectConversion

--- a/package/ios/FrameProcessors/JSINSObjectConversion.h
+++ b/package/ios/FrameProcessors/JSINSObjectConversion.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #import "SharedArray.h"
-#import <React/RCTBridgeModule.h>
 #import <ReactCommon/CallInvoker.h>
 #import <jsi/jsi.h>
 
@@ -18,48 +17,10 @@ namespace JSINSObjectConversion {
 using namespace facebook;
 using namespace facebook::react;
 
-// NSNumber -> boolean
-jsi::Value convertNSNumberToJSIBoolean(jsi::Runtime& runtime, NSNumber* value);
-
-// NSNumber -> number
-jsi::Value convertNSNumberToJSINumber(jsi::Runtime& runtime, NSNumber* value);
-
-// NSNumber -> string
-jsi::String convertNSStringToJSIString(jsi::Runtime& runtime, NSString* value);
-
-// NSDictionary -> {}
-jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime& runtime, NSDictionary* value);
-
-// NSArray -> []
-jsi::Array convertNSArrayToJSIArray(jsi::Runtime& runtime, NSArray* value);
-
-// SharedArray -> ArrayBuffer
-jsi::Object convertSharedArrayToJSIArrayBuffer(jsi::Runtime& runtime, SharedArray* sharedArray);
-
-// id -> ???
-jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value);
-
-// string -> NSString
-NSString* convertJSIStringToNSString(jsi::Runtime& runtime, const jsi::String& value);
-
-// any... -> NSArray
-NSArray* convertJSICStyleArrayToNSArray(jsi::Runtime& runtime, const jsi::Value* array, size_t length,
-                                        std::shared_ptr<CallInvoker> jsInvoker);
-
-// NSArray -> any...
-jsi::Value* convertNSArrayToJSICStyleArray(jsi::Runtime& runtime, NSArray* array);
-
-// [] -> NSArray
-NSArray* convertJSIArrayToNSArray(jsi::Runtime& runtime, const jsi::Array& value, std::shared_ptr<CallInvoker> jsInvoker);
-
-// {} -> NSDictionary
-NSDictionary* convertJSIObjectToNSDictionary(jsi::Runtime& runtime, const jsi::Object& value, std::shared_ptr<CallInvoker> jsInvoker);
+// id -> any
+jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value, std::shared_ptr<CallInvoker> jsInvoker);
 
 // any -> id
 id convertJSIValueToObjCObject(jsi::Runtime& runtime, const jsi::Value& value, std::shared_ptr<CallInvoker> jsInvoker);
-
-// (any...) => any -> (void)(id, id)
-RCTResponseSenderBlock convertJSIFunctionToCallback(jsi::Runtime& runtime, const jsi::Function& value,
-                                                    std::shared_ptr<CallInvoker> jsInvoker);
 
 } // namespace JSINSObjectConversion

--- a/package/ios/FrameProcessors/JSINSObjectConversion.h
+++ b/package/ios/FrameProcessors/JSINSObjectConversion.h
@@ -23,4 +23,7 @@ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value);
 // any -> id
 id convertJSIValueToObjCObject(jsi::Runtime& runtime, const jsi::Value& value);
 
+// object -> NSDictionary*
+NSDictionary* convertJSIObjectToObjCDictionary(jsi::Runtime& runtime, const jsi::Object& object);
+
 } // namespace JSINSObjectConversion

--- a/package/ios/FrameProcessors/JSINSObjectConversion.mm
+++ b/package/ios/FrameProcessors/JSINSObjectConversion.mm
@@ -22,7 +22,6 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridge.h>
 #import <ReactCommon/CallInvoker.h>
-#import <ReactCommon/TurboModuleUtils.h>
 #import <jsi/jsi.h>
 
 using namespace facebook;

--- a/package/ios/FrameProcessors/JSINSObjectConversion.mm
+++ b/package/ios/FrameProcessors/JSINSObjectConversion.mm
@@ -20,7 +20,6 @@
 #import "FrameHostObject.h"
 #import "SharedArray.h"
 #import <Foundation/Foundation.h>
-#import <React/RCTBridge.h>
 #import <ReactCommon/CallInvoker.h>
 #import <jsi/jsi.h>
 
@@ -29,187 +28,119 @@ using namespace facebook::react;
 
 namespace JSINSObjectConversion {
 
-jsi::Value convertNSNumberToJSIBoolean(jsi::Runtime& runtime, NSNumber* value) {
-  return jsi::Value((bool)[value boolValue]);
-}
-
-jsi::Value convertNSNumberToJSINumber(jsi::Runtime& runtime, NSNumber* value) {
-  return jsi::Value([value doubleValue]);
-}
-
-jsi::String convertNSStringToJSIString(jsi::Runtime& runtime, NSString* value) {
-  return jsi::String::createFromUtf8(runtime, [value UTF8String] ?: "");
-}
-
-jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime& runtime, NSDictionary* value) {
-  jsi::Object result = jsi::Object(runtime);
-  for (NSString* k in value) {
-    result.setProperty(runtime, [k UTF8String], convertObjCObjectToJSIValue(runtime, value[k]));
-  }
-  return result;
-}
-
-jsi::Array convertNSArrayToJSIArray(jsi::Runtime& runtime, NSArray* value) {
-  jsi::Array result = jsi::Array(runtime, value.count);
-  for (size_t i = 0; i < value.count; i++) {
-    result.setValueAtIndex(runtime, i, convertObjCObjectToJSIValue(runtime, value[i]));
-  }
-  return result;
-}
-
-jsi::Object convertSharedArrayToJSIArrayBuffer(jsi::Runtime& runtime, SharedArray* sharedArray) {
-  return sharedArray.arrayBuffer->getArrayBuffer(runtime);
-}
-
 jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value) {
-  if (value == nil) {
+  if (value == nil || value == (id)kCFNull) {
+    // null
+
     return jsi::Value::undefined();
-  } else if ([value isKindOfClass:[NSString class]]) {
-    return convertNSStringToJSIString(runtime, (NSString*)value);
   } else if ([value isKindOfClass:[NSNumber class]]) {
+    NSNumber* number = (NSNumber*)value;
     if ([value isKindOfClass:[@YES class]]) {
-      return convertNSNumberToJSIBoolean(runtime, (NSNumber*)value);
+      // Boolean
+
+      return jsi::Value(static_cast<bool>(number.boolValue));
     }
-    return convertNSNumberToJSINumber(runtime, (NSNumber*)value);
+
+    // Double
+
+    return jsi::Value(number.doubleValue);
+  } else if ([value isKindOfClass:[NSString class]]) {
+    // String
+
+    NSString* string = (NSString*)value;
+    return jsi::String::createFromUtf8(runtime, string.UTF8String);
   } else if ([value isKindOfClass:[NSDictionary class]]) {
-    return convertNSDictionaryToJSIObject(runtime, (NSDictionary*)value);
+    // Object
+
+    NSDictionary* dictionary = (NSDictionary*)value;
+    jsi::Object result(runtime);
+    for (NSString* key in dictionary) {
+      result.setProperty(runtime, key.UTF8String, convertObjCObjectToJSIValue(runtime, dictionary[key]));
+    }
+    return result;
   } else if ([value isKindOfClass:[NSArray class]]) {
-    return convertNSArrayToJSIArray(runtime, (NSArray*)value);
-  } else if (value == (id)kCFNull) {
-    return jsi::Value::null();
+    // Array
+
+    NSArray* array = (NSArray*)value;
+    jsi::Array result(runtime, array.count);
+    for (size_t i = 0; i < array.count; i++) {
+      result.setValueAtIndex(runtime, i, convertObjCObjectToJSIValue(runtime, value[i]));
+    }
+    return result;
   } else if ([value isKindOfClass:[Frame class]]) {
-    auto frameHostObject = std::make_shared<FrameHostObject>((Frame*)value);
+    // Frame
+
+    Frame* frame = (Frame*)value;
+    auto frameHostObject = std::make_shared<FrameHostObject>(frame);
     return jsi::Object::createFromHostObject(runtime, frameHostObject);
   } else if ([value isKindOfClass:[SharedArray class]]) {
-    return convertSharedArrayToJSIArrayBuffer(runtime, (SharedArray*)value);
+    // SharedArray
+
+    SharedArray* sharedArray = (SharedArray*)value;
+    return sharedArray.arrayBuffer->getArrayBuffer(runtime);
   }
-  return jsi::Value::undefined();
+
+  NSString* className = NSStringFromClass([value class]);
+  std::string classNameString = std::string(className.UTF8String);
+  throw std::runtime_error("Cannot convert Objective-C type \"" + classNameString + "\" to jsi::Value!");
 }
 
-NSString* convertJSIStringToNSString(jsi::Runtime& runtime, const jsi::String& value) {
-  return [NSString stringWithUTF8String:value.utf8(runtime).c_str()];
-}
-
-NSArray* convertJSICStyleArrayToNSArray(jsi::Runtime& runtime, const jsi::Value* array, size_t length,
-                                        std::shared_ptr<CallInvoker> jsInvoker) {
-  if (length < 1)
-    return @[];
-  NSMutableArray* result = [NSMutableArray new];
-  for (size_t i = 0; i < length; i++) {
-    // Insert kCFNull when it's `undefined` value to preserve the indices.
-    [result addObject:convertJSIValueToObjCObject(runtime, array[i], jsInvoker) ?: (id)kCFNull];
-  }
-  return [result copy];
-}
-
-jsi::Value* convertNSArrayToJSICStyleArray(jsi::Runtime& runtime, NSArray* array) {
-  auto result = new jsi::Value[array.count];
-  for (size_t i = 0; i < array.count; i++) {
-    result[i] = convertObjCObjectToJSIValue(runtime, array[i]);
-  }
-  return result;
-}
-
-NSArray* convertJSIArrayToNSArray(jsi::Runtime& runtime, const jsi::Array& value, std::shared_ptr<CallInvoker> jsInvoker) {
-  size_t size = value.size(runtime);
-  NSMutableArray* result = [NSMutableArray new];
-  for (size_t i = 0; i < size; i++) {
-    // Insert kCFNull when it's `undefined` value to preserve the indices.
-    [result addObject:convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i), jsInvoker) ?: (id)kCFNull];
-  }
-  return [result copy];
-}
-
-NSDictionary* convertJSIObjectToNSDictionary(jsi::Runtime& runtime, const jsi::Object& value, std::shared_ptr<CallInvoker> jsInvoker) {
-  jsi::Array propertyNames = value.getPropertyNames(runtime);
-  size_t size = propertyNames.size(runtime);
-  NSMutableDictionary* result = [NSMutableDictionary new];
-  for (size_t i = 0; i < size; i++) {
-    jsi::String name = propertyNames.getValueAtIndex(runtime, i).getString(runtime);
-    NSString* k = convertJSIStringToNSString(runtime, name);
-    id v = convertJSIValueToObjCObject(runtime, value.getProperty(runtime, name), jsInvoker);
-    if (v) {
-      result[k] = v;
-    }
-  }
-  return [result copy];
-}
-
-id convertJSIValueToObjCObject(jsi::Runtime& runtime, const jsi::Value& value, std::shared_ptr<CallInvoker> jsInvoker) {
+id convertJSIValueToObjCObject(jsi::Runtime& runtime, const jsi::Value& value) {
   if (value.isUndefined() || value.isNull()) {
     // undefined/null
     return nil;
   } else if (value.isBool()) {
     // bool
-    return @(value.getBool());
+    return [NSNumber numberWithBool:value.getBool()];
   } else if (value.isNumber()) {
     // number
-    return @(value.getNumber());
+    return [NSNumber numberWithDouble:value.getNumber()];
   } else if (value.isString()) {
     // string
-    return convertJSIStringToNSString(runtime, value.getString(runtime));
+    std::string string = value.getString(runtime).utf8(runtime);
+    return [NSString stringWithUTF8String:string.c_str()];
   } else if (value.isObject()) {
     // object
-    jsi::Object o = value.getObject(runtime);
-    if (o.isArray(runtime)) {
+    jsi::Object object = value.getObject(runtime);
+    if (object.isArray(runtime)) {
       // array[]
-      return convertJSIArrayToNSArray(runtime, o.getArray(runtime), jsInvoker);
-    } else if (o.isFunction(runtime)) {
-      // function () => {}
-      return convertJSIFunctionToCallback(runtime, std::move(o.getFunction(runtime)), jsInvoker);
-    } else if (o.isHostObject(runtime)) {
-      if (o.isHostObject<FrameHostObject>(runtime)) {
+      jsi::Array array = object.getArray(runtime);
+      size_t size = array.size(runtime);
+      NSMutableArray* result = [NSMutableArray new];
+      for (size_t i = 0; i < size; i++) {
+        jsi::Value value = array.getValueAtIndex(runtime, i);
+        [result addObject:convertJSIValueToObjCObject(runtime, value)];
+      }
+      return [result copy];
+    } else if (object.isHostObject(runtime)) {
+      if (object.isHostObject<FrameHostObject>(runtime)) {
         // Frame
-        auto hostObject = o.getHostObject<FrameHostObject>(runtime);
+        auto hostObject = object.getHostObject<FrameHostObject>(runtime);
         return hostObject->frame;
       } else {
         throw std::runtime_error("The given HostObject is not supported by a Frame Processor Plugin!");
       }
-    } else if (o.isArrayBuffer(runtime)) {
+    } else if (object.isArrayBuffer(runtime)) {
       // ArrayBuffer
-      auto arrayBuffer = std::make_shared<jsi::ArrayBuffer>(o.getArrayBuffer(runtime));
+      auto arrayBuffer = std::make_shared<jsi::ArrayBuffer>(object.getArrayBuffer(runtime));
       return [[SharedArray alloc] initWithRuntime:runtime wrapArrayBuffer:arrayBuffer];
     } else {
       // object
-      return convertJSIObjectToNSDictionary(runtime, o, jsInvoker);
+      jsi::Array propertyNames = object.getPropertyNames(runtime);
+      size_t size = propertyNames.size(runtime);
+      NSMutableDictionary* result = [NSMutableDictionary new];
+      for (size_t i = 0; i < size; i++) {
+        jsi::String name = propertyNames.getValueAtIndex(runtime, i).getString(runtime);
+        jsi::Value value = object.getProperty(runtime, name);
+        NSString* key = [NSString stringWithUTF8String:name.utf8(runtime).c_str()];
+        result[key] = convertJSIValueToObjCObject(runtime, value);
+      }
+      return [result copy];
     }
   }
 
   auto stringRepresentation = value.toString(runtime).utf8(runtime);
   throw std::runtime_error("Failed to convert jsi::Value to JNI value - unsupported type! " + stringRepresentation);
-}
-
-RCTResponseSenderBlock convertJSIFunctionToCallback(jsi::Runtime& runtime, const jsi::Function& value,
-                                                    std::shared_ptr<CallInvoker> jsInvoker) {
-  auto weakWrapper = CallbackWrapper::createWeak(value.getFunction(runtime), runtime, jsInvoker);
-
-  BOOL __block wrapperWasCalled = NO;
-  RCTResponseSenderBlock callback = ^(NSArray* responses) {
-    if (wrapperWasCalled) {
-      throw std::runtime_error("callback arg cannot be called more than once");
-    }
-
-    auto strongWrapper = weakWrapper.lock();
-    if (!strongWrapper) {
-      return;
-    }
-
-    strongWrapper->jsInvoker().invokeAsync([weakWrapper, responses]() {
-      auto strongWrapper2 = weakWrapper.lock();
-      if (!strongWrapper2) {
-        return;
-      }
-
-      const jsi::Value* args = convertNSArrayToJSICStyleArray(strongWrapper2->runtime(), responses);
-      strongWrapper2->callback().call(strongWrapper2->runtime(), args, static_cast<size_t>(responses.count));
-      strongWrapper2->destroy();
-      delete[] args;
-    });
-
-    wrapperWasCalled = YES;
-  };
-
-  return [callback copy];
 }
 
 } // namespace JSINSObjectConversion

--- a/package/ios/FrameProcessors/VisionCameraProxy.mm
+++ b/package/ios/FrameProcessors/VisionCameraProxy.mm
@@ -69,7 +69,7 @@ void VisionCameraProxy::removeFrameProcessor(jsi::Runtime& runtime, double jsVie
 jsi::Value VisionCameraProxy::initFrameProcessorPlugin(jsi::Runtime& runtime, const jsi::String& name, const jsi::Object& options) {
   std::string nameString = name.utf8(runtime);
   NSString* key = [NSString stringWithUTF8String:nameString.c_str()];
-  NSDictionary* optionsObjc = (NSDictionary*)JSINSObjectConversion::convertJSIValueToObjCObject(runtime, options);
+  NSDictionary* optionsObjc = JSINSObjectConversion::convertJSIObjectToObjCDictionary(runtime, options);
   VisionCameraProxyHolder* proxy = [[VisionCameraProxyHolder alloc] initWithProxy:this];
 
   @try {

--- a/package/ios/FrameProcessors/VisionCameraProxy.mm
+++ b/package/ios/FrameProcessors/VisionCameraProxy.mm
@@ -69,7 +69,7 @@ void VisionCameraProxy::removeFrameProcessor(jsi::Runtime& runtime, double jsVie
 jsi::Value VisionCameraProxy::initFrameProcessorPlugin(jsi::Runtime& runtime, const jsi::String& name, const jsi::Object& options) {
   std::string nameString = name.utf8(runtime);
   NSString* key = [NSString stringWithUTF8String:nameString.c_str()];
-  NSDictionary* optionsObjc = JSINSObjectConversion::convertJSIObjectToNSDictionary(runtime, options, _callInvoker);
+  NSDictionary* optionsObjc = (NSDictionary*)JSINSObjectConversion::convertJSIValueToObjCObject(runtime, options);
   VisionCameraProxyHolder* proxy = [[VisionCameraProxyHolder alloc] initWithProxy:this];
 
   @try {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Simplifies the `JSINSObjectConversion` class to avoid depending on ReactCommon.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
