### PR TITLE
fix: Correct android filenames for takeSnapshot [v4]

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+TakeSnapshot.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+TakeSnapshot.kt
@@ -18,7 +18,7 @@ fun CameraView.takeSnapshot(options: SnapshotOptions): WritableMap {
 
   onShutter(ShutterType.SNAPSHOT)
 
-  val file = FileUtils.createTempFile(context, "jpg")
+  val file = FileUtils.createTempFile(context, ".jpg")
   FileUtils.writeBitmapTofile(bitmap, file, options.quality)
 
   Log.i(TAG, "Successfully saved snapshot to file!")


### PR DESCRIPTION
## What

This PR fixes the filename generated when calling `takeSnapshot` on Android
Currently they are generated without a `.` in the filename. Eg: `mrousavy-1692260572662396982jpg`

## Changes

- Adds a dot to the filename extension

## Tested on

- Samsung Z Flip 5
- Pixel 5 (Emulator)

## Related issues
