### PR TITLE
fix: Fix CodeScanner crash

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
@@ -40,6 +40,7 @@ class CodeScannerPipeline(val configuration: CameraConfiguration.CodeScanner, va
           }
         }
         .addOnFailureListener { error ->
+          Log.e(TAG, "Failed to process Image!", error)
           callback.onError(error)
         }
         .addOnCompleteListener {

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
@@ -14,9 +14,9 @@ import java.io.Closeable
 class CodeScannerPipeline(val configuration: CameraConfiguration.CodeScanner, val callback: CameraSession.Callback) :
   Closeable,
   Analyzer {
-    companion object {
-      private const val TAG ="CodeScannerPipeline"
-    }
+  companion object {
+    private const val TAG = "CodeScannerPipeline"
+  }
   private val scanner: BarcodeScanner
 
   init {

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
@@ -30,9 +30,9 @@ class CodeScannerPipeline(val configuration: CameraConfiguration.CodeScanner, va
   @OptIn(ExperimentalGetImage::class)
   override fun analyze(imageProxy: ImageProxy) {
     val image = imageProxy.image ?: throw InvalidImageTypeError()
-    val inputImage = InputImage.fromMediaImage(image, imageProxy.imageInfo.rotationDegrees)
 
     try {
+      val inputImage = InputImage.fromMediaImage(image, imageProxy.imageInfo.rotationDegrees)
       scanner.process(inputImage)
         .addOnSuccessListener { barcodes ->
           if (barcodes.isNotEmpty()) {

--- a/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CodeScannerPipeline.kt
@@ -1,5 +1,6 @@
 package com.mrousavy.camera.core
 
+import android.util.Log
 import androidx.annotation.OptIn
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis.Analyzer
@@ -13,6 +14,9 @@ import java.io.Closeable
 class CodeScannerPipeline(val configuration: CameraConfiguration.CodeScanner, val callback: CameraSession.Callback) :
   Closeable,
   Analyzer {
+    companion object {
+      private const val TAG ="CodeScannerPipeline"
+    }
   private val scanner: BarcodeScanner
 
   init {
@@ -28,18 +32,23 @@ class CodeScannerPipeline(val configuration: CameraConfiguration.CodeScanner, va
     val image = imageProxy.image ?: throw InvalidImageTypeError()
     val inputImage = InputImage.fromMediaImage(image, imageProxy.imageInfo.rotationDegrees)
 
-    scanner.process(inputImage)
-      .addOnSuccessListener { barcodes ->
-        if (barcodes.isNotEmpty()) {
-          callback.onCodeScanned(barcodes, CodeScannerFrame(inputImage.width, inputImage.height))
+    try {
+      scanner.process(inputImage)
+        .addOnSuccessListener { barcodes ->
+          if (barcodes.isNotEmpty()) {
+            callback.onCodeScanned(barcodes, CodeScannerFrame(inputImage.width, inputImage.height))
+          }
         }
-      }
-      .addOnFailureListener { error ->
-        callback.onError(error)
-      }
-      .addOnCompleteListener {
-        imageProxy.close()
-      }
+        .addOnFailureListener { error ->
+          callback.onError(error)
+        }
+        .addOnCompleteListener {
+          imageProxy.close()
+        }
+    } catch (e: Throwable) {
+      Log.e(TAG, "Failed to process Image!", e)
+      imageProxy.close()
+    }
   }
 
   override fun close() {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes an issue where the CodeScanner would crash because it threw an error that didn't go into the `Task<T>`, but instead threw already before creating the `Task<T>`. This is Google's fault, but whatever we can catch it.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
