### PR TITLE
chore: Use `::names` helper init for `PropNameID`

### DIFF
--- a/package/android/src/main/cpp/frameprocessors/FrameProcessorPluginHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessors/FrameProcessorPluginHostObject.cpp
@@ -23,9 +23,7 @@ FrameProcessorPluginHostObject::~FrameProcessorPluginHostObject() {
 }
 
 std::vector<jsi::PropNameID> FrameProcessorPluginHostObject::getPropertyNames(jsi::Runtime& runtime) {
-  std::vector<jsi::PropNameID> result;
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("call")));
-  return result;
+  return jsi::PropNameID::names(runtime, "call");
 }
 
 jsi::Value FrameProcessorPluginHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {

--- a/package/android/src/main/cpp/frameprocessors/VisionCameraProxy.cpp
+++ b/package/android/src/main/cpp/frameprocessors/VisionCameraProxy.cpp
@@ -38,12 +38,7 @@ VisionCameraProxy::~VisionCameraProxy() {
 }
 
 std::vector<jsi::PropNameID> VisionCameraProxy::getPropertyNames(jsi::Runtime& runtime) {
-  std::vector<jsi::PropNameID> result;
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("setFrameProcessor")));
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("removeFrameProcessor")));
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("initFrameProcessorPlugin")));
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("workletContext")));
-  return result;
+  return jsi::PropNameID::names(runtime, "setFrameProcessor", "removeFrameProcessor", "initFrameProcessorPlugin", "workletContext");
 }
 
 void VisionCameraProxy::setFrameProcessor(int viewTag, jsi::Runtime& runtime, const std::shared_ptr<jsi::Function>& function) {

--- a/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
+++ b/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
@@ -15,9 +15,7 @@
 using namespace facebook;
 
 std::vector<jsi::PropNameID> FrameProcessorPluginHostObject::getPropertyNames(jsi::Runtime& runtime) {
-  std::vector<jsi::PropNameID> result;
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("call")));
-  return result;
+  return jsi::PropNameId::names(runtime "call");
 }
 
 jsi::Value FrameProcessorPluginHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {

--- a/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
+++ b/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
@@ -15,7 +15,7 @@
 using namespace facebook;
 
 std::vector<jsi::PropNameID> FrameProcessorPluginHostObject::getPropertyNames(jsi::Runtime& runtime) {
-  return jsi::PropNameId::names(runtime "call");
+  return jsi::PropNameID::names(runtime "call");
 }
 
 jsi::Value FrameProcessorPluginHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {

--- a/package/ios/FrameProcessors/VisionCameraProxy.mm
+++ b/package/ios/FrameProcessors/VisionCameraProxy.mm
@@ -43,12 +43,7 @@ VisionCameraProxy::~VisionCameraProxy() {
 }
 
 std::vector<jsi::PropNameID> VisionCameraProxy::getPropertyNames(jsi::Runtime& runtime) {
-  std::vector<jsi::PropNameID> result;
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("setFrameProcessor")));
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("removeFrameProcessor")));
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("initFrameProcessorPlugin")));
-  result.push_back(jsi::PropNameID::forUtf8(runtime, std::string("workletContext")));
-  return result;
+  return jsi::PropNameID::names(runtime, "setFrameProcessor", "removeFrameProcessor", "initFrameProcessorPlugin", "workletContext");
 }
 
 void VisionCameraProxy::setFrameProcessor(jsi::Runtime& runtime, double jsViewTag, jsi::Function&& function) {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Just a code style change

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
