### PR TITLE
fix: Fix `runAsync` not properly retaining/releasing Frame

### DIFF
--- a/package/ios/FrameProcessors/Frame.h
+++ b/package/ios/FrameProcessors/Frame.h
@@ -19,6 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation;
 - (instancetype)init NS_UNAVAILABLE;
 
+- (void)incrementRefCount;
+- (void)decrementRefCount;
+
 @property(nonatomic, readonly) CMSampleBufferRef buffer;
 @property(nonatomic, readonly) UIImageOrientation orientation;
 

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -20,12 +20,15 @@
   if (self) {
     _buffer = buffer;
     _orientation = orientation;
-    CFRetain(buffer);
   }
   return self;
 }
 
-- (void)dealloc {
+- (void)incrementRefCount {
+  CFRetain(_buffer);
+}
+
+- (void)decrementRefCount {
   CFRelease(_buffer);
 }
 

--- a/package/ios/FrameProcessors/FrameHostObject.h
+++ b/package/ios/FrameProcessors/FrameHostObject.h
@@ -10,7 +10,6 @@
 
 #import <CoreMedia/CMSampleBuffer.h>
 #import <jsi/jsi.h>
-#import <mutex>
 
 #import "Frame.h"
 
@@ -29,8 +28,4 @@ public:
 
 private:
   Frame* getFrame();
-
-private:
-  std::mutex _mutex;
-  size_t _refCount = 0;
 };


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes an issue that actually should've occurred always, but apparently only occurred in `runAsync`, where the `Frame` was not properly released.

Before, we manually ref-counted using `_refCount`, and only if we hit `_refCount < 1` we set the `_frame` to `nil`.

Now, we moved `incrementRefCount` and `decrementRefCount` into `Frame` itself, which now uses `CFRetain` and `CFRelease`.

This seems safer as we use ARC/MRC from NS, but also it now properly executes `runAsync` without halting.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
