### PR TITLE
feat: Create `Frame.withBaseClass` to ensure it's always a `FrameHostObject`

### DIFF
--- a/package/android/src/main/cpp/frameprocessors/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessors/FrameHostObject.cpp
@@ -19,7 +19,7 @@ namespace vision {
 
 using namespace facebook;
 
-FrameHostObject::FrameHostObject(const jni::alias_ref<JFrame::javaobject>& frame) : frame(make_global(frame)) {}
+FrameHostObject::FrameHostObject(const jni::alias_ref<JFrame::javaobject>& frame) : _frame(make_global(frame)), _baseClass(nullptr) {}
 
 FrameHostObject::~FrameHostObject() {
   // Hermes GC might destroy HostObjects on an arbitrary Thread which might not be
@@ -49,6 +49,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
     result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toString")));
     result.push_back(jsi::PropNameID::forUtf8(rt, std::string("toArrayBuffer")));
     result.push_back(jsi::PropNameID::forUtf8(rt, std::string("getNativeBuffer")));
+    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("withBaseClass")));
   }
 
   return result;
@@ -64,39 +65,47 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     return jsi::Value(this->frame && this->frame->getIsValid());
   }
   if (name == "width") {
-    return jsi::Value(this->frame->getWidth());
+    const auto& frame = this->getFrame();
+    return jsi::Value(frame->getWidth());
   }
   if (name == "height") {
-    return jsi::Value(this->frame->getHeight());
+    const auto& frame = this->getFrame();
+    return jsi::Value(frame->getHeight());
   }
   if (name == "isMirrored") {
-    return jsi::Value(this->frame->getIsMirrored());
+    const auto& frame = this->getFrame();
+    return jsi::Value(frame->getIsMirrored());
   }
   if (name == "orientation") {
-    auto orientation = this->frame->getOrientation();
+    const auto& frame = this->getFrame();
+    auto orientation = frame->getOrientation();
     auto string = orientation->getUnionValue();
     return jsi::String::createFromUtf8(runtime, string->toStdString());
   }
   if (name == "pixelFormat") {
-    auto pixelFormat = this->frame->getPixelFormat();
+    const auto& frame = this->getFrame();
+    auto pixelFormat = frame->getPixelFormat();
     auto string = pixelFormat->getUnionValue();
     return jsi::String::createFromUtf8(runtime, string->toStdString());
   }
   if (name == "timestamp") {
-    return jsi::Value(static_cast<double>(this->frame->getTimestamp()));
+    const auto& frame = this->getFrame();
+    return jsi::Value(static_cast<double>(frame->getTimestamp()));
   }
   if (name == "bytesPerRow") {
-    return jsi::Value(this->frame->getBytesPerRow());
+    const auto& frame = this->getFrame();
+    return jsi::Value(frame->getBytesPerRow());
   }
   if (name == "planesCount") {
-    return jsi::Value(this->frame->getPlanesCount());
+    const auto& frame = this->getFrame();
+    return jsi::Value(frame->getPlanesCount());
   }
 
   // Internal Methods
   if (name == "incrementRefCount") {
     jsi::HostFunctionType incrementRefCount = JSI_FUNC {
       // Increment retain count by one.
-      this->frame->incrementRefCount();
+      this->_frame->incrementRefCount();
       return jsi::Value::undefined();
     };
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "incrementRefCount"), 0, incrementRefCount);
@@ -104,7 +113,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "decrementRefCount") {
     auto decrementRefCount = JSI_FUNC {
       // Decrement retain count by one. If the retain count is zero, the Frame gets closed.
-      this->frame->decrementRefCount();
+      this->_frame->decrementRefCount();
       return jsi::Value::undefined();
     };
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "decrementRefCount"), 0, decrementRefCount);
@@ -117,7 +126,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
         throw jsi::JSError(runtime, "Cannot get Platform Buffer - this Frame is already closed!");
       }
 #if __ANDROID_API__ >= 26
-      AHardwareBuffer* hardwareBuffer = this->frame->getHardwareBuffer();
+      const auto& frame = this->getFrame();
+      AHardwareBuffer* hardwareBuffer = frame->getHardwareBuffer();
       AHardwareBuffer_acquire(hardwareBuffer);
       uintptr_t pointer = reinterpret_cast<uintptr_t>(hardwareBuffer);
       jsi::HostFunctionType deleteFunc = [=](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args,
@@ -141,7 +151,8 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "toArrayBuffer") {
     jsi::HostFunctionType toArrayBuffer = JSI_FUNC {
 #if __ANDROID_API__ >= 26
-      AHardwareBuffer* hardwareBuffer = this->frame->getHardwareBuffer();
+      const auto& frame = this->getFrame();
+      AHardwareBuffer* hardwareBuffer = frame->getHardwareBuffer();
       AHardwareBuffer_acquire(hardwareBuffer);
 
       AHardwareBuffer_Desc bufferDescription;
@@ -193,17 +204,33 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   }
   if (name == "toString") {
     jsi::HostFunctionType toString = JSI_FUNC {
-      if (!this->frame) {
+      if (!this->_frame) {
         return jsi::String::createFromUtf8(runtime, "[closed frame]");
       }
-      auto width = this->frame->getWidth();
-      auto height = this->frame->getHeight();
-      auto format = this->frame->getPixelFormat();
+      auto width = this->_frame->getWidth();
+      auto height = this->_frame->getHeight();
+      auto format = this->_frame->getPixelFormat();
       auto formatString = format->getUnionValue();
       auto str = std::to_string(width) + " x " + std::to_string(height) + " " + formatString->toString() + " Frame";
       return jsi::String::createFromUtf8(runtime, str);
     };
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "toString"), 0, toString);
+  }
+  if (name == "withBaseClass") {
+    auto withBaseClass = JSI_FUNC {
+      jsi::Object newBaseClass = arguments[0].asObject(runtime);
+      this->_baseClass = std::make_unique<jsi::Object>(std::move(newBaseClass));
+      return jsi::Object::createFromHostObject(runtime, shared_from_this());
+    };
+    return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "withBaseClass"), 1, withBaseClass);
+  }
+
+  if (_baseClass != nullptr) {
+    // look up value in base class if we have a custom base class
+    jsi::Value value = _baseClass->getProperty(runtime, name.c_str());
+    if (!value.isUndefined()) {
+      return value;
+    }
   }
 
   // fallback to base implementation

--- a/package/android/src/main/cpp/frameprocessors/FrameHostObject.h
+++ b/package/android/src/main/cpp/frameprocessors/FrameHostObject.h
@@ -7,6 +7,7 @@
 #include <fbjni/fbjni.h>
 #include <jni.h>
 #include <jsi/jsi.h>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -26,7 +27,11 @@ public:
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& rt) override;
 
 public:
-  jni::global_ref<JFrame> frame;
+  jni::global_ref<JFrame> getFrame();
+
+private:
+  jni::global_ref<JFrame> _frame;
+  std::unique_ptr<jsi::Object> _baseClass;
 };
 
 } // namespace vision

--- a/package/android/src/main/cpp/frameprocessors/FrameHostObject.h
+++ b/package/android/src/main/cpp/frameprocessors/FrameHostObject.h
@@ -17,7 +17,7 @@ namespace vision {
 
 using namespace facebook;
 
-class JSI_EXPORT FrameHostObject : public jsi::HostObject {
+class JSI_EXPORT FrameHostObject : public jsi::HostObject, public std::enable_shared_from_this<FrameHostObject> {
 public:
   explicit FrameHostObject(const jni::alias_ref<JFrame::javaobject>& frame);
   ~FrameHostObject();

--- a/package/android/src/main/cpp/frameprocessors/FrameProcessorPluginHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessors/FrameProcessorPluginHostObject.cpp
@@ -44,7 +44,7 @@ jsi::Value FrameProcessorPluginHostObject::get(jsi::Runtime& runtime, const jsi:
             jsi::Object actualFrame = frameHolder.getPropertyAsObject(runtime, "__frame");
             frameHostObject = actualFrame.asHostObject<FrameHostObject>(runtime);
           }
-          auto frame = frameHostObject->frame;
+          auto frame = frameHostObject->getFrame();
 
           // Options are second argument (possibly undefined)
           local_ref<JMap<jstring, jobject>> options = nullptr;

--- a/package/android/src/main/cpp/frameprocessors/JSIJNIConversion.cpp
+++ b/package/android/src/main/cpp/frameprocessors/JSIJNIConversion.cpp
@@ -68,8 +68,8 @@ jni::local_ref<jobject> JSIJNIConversion::convertJSIValueToJNIObject(jsi::Runtim
       if (valueAsObject.isHostObject<FrameHostObject>(runtime)) {
         // Frame
 
-        auto frame = valueAsObject.getHostObject<FrameHostObject>(runtime);
-        return jni::make_local(frame->frame);
+        auto frameHostObject = valueAsObject.getHostObject<FrameHostObject>(runtime);
+        return jni::make_local(frameHostObject->getFrame());
 
       } else {
         throw std::runtime_error("The given HostObject is not supported by a Frame Processor Plugin.");

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessors/Frame.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessors/Frame.java
@@ -61,8 +61,7 @@ public class Frame {
 
     @SuppressWarnings("unused")
     @DoNotStrip
-    public boolean getIsValid() throws FrameInvalidError {
-        assertIsValid();
+    public boolean getIsValid() {
         return getIsImageValid(imageProxy);
     }
 

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -467,16 +467,16 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - SocketRocket (0.6.1)
-  - VisionCamera (4.0.1):
-    - VisionCamera/Core (= 4.0.1)
-    - VisionCamera/FrameProcessors (= 4.0.1)
-    - VisionCamera/React (= 4.0.1)
-  - VisionCamera/Core (4.0.1)
-  - VisionCamera/FrameProcessors (4.0.1):
+  - VisionCamera (4.0.2):
+    - VisionCamera/Core (= 4.0.2)
+    - VisionCamera/FrameProcessors (= 4.0.2)
+    - VisionCamera/React (= 4.0.2)
+  - VisionCamera/Core (4.0.2)
+  - VisionCamera/FrameProcessors (4.0.2):
     - React
     - React-callinvoker
     - react-native-worklets-core
-  - VisionCamera/React (4.0.1):
+  - VisionCamera/React (4.0.2):
     - React-Core
     - VisionCamera/FrameProcessors
   - Yoga (1.14.0)
@@ -708,7 +708,7 @@ SPEC CHECKSUMS:
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNVectorIcons: 23b6e11af4aaf104d169b1b0afa7e5cf96c676ce
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 8e00df84a76cf26ca70ecd3b6ed05dc0d3b60beb
+  VisionCamera: 14a6a4a53c65b8b9bd441f80c2b29048f820ae01
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: 66976ac26c778d788a06e6c1bab624e6a1233cdd

--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -9,7 +9,7 @@ import {
   runAtTargetFps,
   useCameraDevice,
   useCameraFormat,
-  useSkiaFrameProcessor,
+  useFrameProcessor,
   useLocationPermission,
   useMicrophonePermission,
 } from 'react-native-vision-camera'
@@ -178,10 +178,8 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
     location.requestPermission()
   }, [location])
 
-  const frameProcessor = useSkiaFrameProcessor((frame) => {
+  const frameProcessor = useFrameProcessor((frame) => {
     'worklet'
-
-    frame.render()
 
     runAtTargetFps(10, () => {
       'worklet'

--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -9,7 +9,7 @@ import {
   runAtTargetFps,
   useCameraDevice,
   useCameraFormat,
-  useFrameProcessor,
+  useSkiaFrameProcessor,
   useLocationPermission,
   useMicrophonePermission,
 } from 'react-native-vision-camera'
@@ -178,8 +178,10 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
     location.requestPermission()
   }, [location])
 
-  const frameProcessor = useFrameProcessor((frame) => {
+  const frameProcessor = useSkiaFrameProcessor((frame) => {
     'worklet'
+
+    frame.render()
 
     runAtTargetFps(10, () => {
       'worklet'

--- a/package/ios/FrameProcessors/FrameHostObject.h
+++ b/package/ios/FrameProcessors/FrameHostObject.h
@@ -10,22 +10,24 @@
 
 #import <CoreMedia/CMSampleBuffer.h>
 #import <jsi/jsi.h>
+#import <memory.h>
 
 #import "Frame.h"
 
 using namespace facebook;
 
-class JSI_EXPORT FrameHostObject : public jsi::HostObject {
+class JSI_EXPORT FrameHostObject : public jsi::HostObject, public std::enable_shared_from_this<FrameHostObject> {
 public:
-  explicit FrameHostObject(Frame* frame) : frame(frame) {}
+  explicit FrameHostObject(Frame* frame) : _frame(frame), _baseClass(nullptr) {}
 
 public:
   jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& rt) override;
 
 public:
-  Frame* frame;
-
-private:
   Frame* getFrame();
+  
+private:
+  Frame* _frame;
+  std::unique_ptr<jsi::Object> _baseClass;
 };

--- a/package/ios/FrameProcessors/FrameHostObject.h
+++ b/package/ios/FrameProcessors/FrameHostObject.h
@@ -26,7 +26,7 @@ public:
 
 public:
   Frame* getFrame();
-  
+
 private:
   Frame* _frame;
   std::unique_ptr<jsi::Object> _baseClass;

--- a/package/ios/FrameProcessors/FrameHostObject.mm
+++ b/package/ios/FrameProcessors/FrameHostObject.mm
@@ -58,41 +58,41 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
 
   // Properties
   if (name == "width") {
-    Frame* frame = this->getFrame();
+    Frame* frame = getFrame();
     return jsi::Value((double)frame.width);
   }
   if (name == "height") {
-    Frame* frame = this->getFrame();
+    Frame* frame = getFrame();
     return jsi::Value((double)frame.height);
   }
   if (name == "orientation") {
-    Frame* frame = this->getFrame();
+    Frame* frame = getFrame();
     NSString* orientation = [NSString stringWithParsed:frame.orientation];
     return jsi::String::createFromUtf8(runtime, orientation.UTF8String);
   }
   if (name == "isMirrored") {
-    Frame* frame = this->getFrame();
+    Frame* frame = getFrame();
     return jsi::Value(frame.isMirrored);
   }
   if (name == "timestamp") {
-    Frame* frame = this->getFrame();
+    Frame* frame = getFrame();
     return jsi::Value(frame.timestamp);
   }
   if (name == "pixelFormat") {
-    Frame* frame = this->getFrame();
+    Frame* frame = getFrame();
     return jsi::String::createFromUtf8(runtime, frame.pixelFormat.UTF8String);
   }
   if (name == "isValid") {
     // unsafely access the Frame and try to see if it's valid
-    Frame* frame = this->_frame;
+    Frame* frame = _frame;
     return jsi::Value(frame != nil && frame.isValid);
   }
   if (name == "bytesPerRow") {
-    Frame* frame = this->getFrame();
+    Frame* frame = getFrame();
     return jsi::Value((double)frame.bytesPerRow);
   }
   if (name == "planesCount") {
-    Frame* frame = this->getFrame();
+    Frame* frame = getFrame();
     return jsi::Value((double)frame.planesCount);
   }
 
@@ -116,7 +116,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "getNativeBuffer") {
     auto getNativeBuffer = JSI_FUNC {
       // Box-cast to uintptr (just 64-bit address)
-      Frame* frame = this->getFrame();
+      Frame* frame = getFrame();
       CMSampleBufferRef sampleBuffer = frame.buffer;
       CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
       uintptr_t pointer = reinterpret_cast<uintptr_t>(pixelBuffer);
@@ -137,7 +137,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "toArrayBuffer") {
     auto toArrayBuffer = JSI_FUNC {
       // Get CPU readable Pixel Buffer from Frame and write it to a jsi::ArrayBuffer
-      Frame* frame = this->getFrame();
+      Frame* frame = getFrame();
       auto pixelBuffer = CMSampleBufferGetImageBuffer(frame.buffer);
       auto bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
       auto height = CVPixelBufferGetHeight(pixelBuffer);
@@ -172,7 +172,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "toString") {
     auto toString = JSI_FUNC {
       // Print debug description (width, height)
-      Frame* frame = this->getFrame();
+      Frame* frame = getFrame();
       NSMutableString* string = [NSMutableString stringWithFormat:@"%lu x %lu %@ Frame", frame.width, frame.height, frame.pixelFormat];
       return jsi::String::createFromUtf8(runtime, string.UTF8String);
     };
@@ -181,7 +181,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "withBaseClass") {
     auto withBaseClass = JSI_FUNC {
       jsi::Object newBaseClass = arguments[0].asObject(runtime);
-      this->_baseClass = std::make_unique<jsi::Object>(std::move(newBaseClass));
+      _baseClass = std::make_unique<jsi::Object>(std::move(newBaseClass));
       return jsi::Object::createFromHostObject(runtime, shared_from_this());
     };
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "withBaseClass"), 1, withBaseClass);

--- a/package/ios/FrameProcessors/FrameHostObject.mm
+++ b/package/ios/FrameProcessors/FrameHostObject.mm
@@ -186,7 +186,7 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     };
     return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, "withBaseClass"), 1, withBaseClass);
   }
-  
+
   if (_baseClass != nullptr) {
     // look up value in base class if we have a custom base class
     jsi::Value value = _baseClass->getProperty(runtime, name.c_str());

--- a/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
+++ b/package/ios/FrameProcessors/FrameProcessorPluginHostObject.mm
@@ -36,7 +36,7 @@ jsi::Value FrameProcessorPluginHostObject::get(jsi::Runtime& runtime, const jsi:
             jsi::Object actualFrame = frameHolder.getPropertyAsObject(runtime, "__frame");
             frameHostObject = actualFrame.asHostObject<FrameHostObject>(runtime);
           }
-          Frame* frame = frameHostObject->frame;
+          Frame* frame = frameHostObject->getFrame();
 
           // Options are second argument (possibly undefined)
           NSDictionary* options = nil;

--- a/package/ios/FrameProcessors/JSINSObjectConversion.mm
+++ b/package/ios/FrameProcessors/JSINSObjectConversion.mm
@@ -129,7 +129,7 @@ id convertJSIValueToObjCObject(jsi::Runtime& runtime, const jsi::Value& value) {
       if (object.isHostObject<FrameHostObject>(runtime)) {
         // Frame
         auto hostObject = object.getHostObject<FrameHostObject>(runtime);
-        return hostObject->frame;
+        return hostObject->getFrame();
       } else {
         throw std::runtime_error("The given HostObject is not supported by a Frame Processor Plugin!");
       }

--- a/package/src/skia/useSkiaFrameProcessor.ts
+++ b/package/src/skia/useSkiaFrameProcessor.ts
@@ -10,6 +10,10 @@ import { SkiaProxy } from '../dependencies/SkiaProxy'
 import { withFrameRefCounting } from '../frame-processors/withFrameRefCounting'
 import { VisionCameraProxy } from '../frame-processors/VisionCameraProxy'
 
+/**
+ * Represents a Texture that can be drawn onto.
+ * Essentially this is just a `SkImage` and `SkCanvas` combined.
+ */
 interface Drawable extends SkCanvas {
   /**
    * Renders the Camera Frame to the Canvas.
@@ -21,7 +25,10 @@ interface Drawable extends SkCanvas {
    * @internal
    */
   readonly __skImage: SkImage
-
+  /**
+   * A private method to dispose the internally created Texture after rendering has completed.
+   * @internal
+   */
   dispose(): void
 }
 

--- a/package/src/types/Frame.ts
+++ b/package/src/types/Frame.ts
@@ -86,13 +86,18 @@ export interface Frame {
    */
   toString(): string
   /**
-   * Assign a new base instance to this Frame, and have all methods on {@linkcode baseInstance}
-   * also be a part of this Frame.
+   * Assign a new base instance to this Frame, and have all properties and methods of
+   * {@linkcode baseInstance} also be a part of this Frame.
+   *
+   * This is useful if you need to pass this {@linkcode Frame} to another consumer
+   * (e.g. a native Frame Processor Plugin) and still need it to be a `jsi::HostObject` of
+   * type `FrameHostObject` while containing properties of another instance ({@linkcode baseInstance})
    * @param baseInstance The base instance to use.
    * @example ```ts
    * const canvas = skSurface.getCanvas()
    * const drawableFrame = frame.withBaseClass(canvas)
    * // now `drawableFrame` has all methods from `canvas`, as well as `frame`.
+   * // it's actual type is still `FrameHostObject`, no `Proxy`, no `Object`, no `Canvas`.
    * drawableFrame.drawRect(...)
    * ```
    */

--- a/package/src/types/Frame.ts
+++ b/package/src/types/Frame.ts
@@ -93,6 +93,7 @@ export interface Frame {
    * (e.g. a native Frame Processor Plugin) and still need it to be a `jsi::HostObject` of
    * type `FrameHostObject` while containing properties of another instance ({@linkcode baseInstance})
    * @param baseInstance The base instance to use.
+   * @internal
    * @example ```ts
    * const canvas = skSurface.getCanvas()
    * const drawableFrame = frame.withBaseClass(canvas)

--- a/package/src/types/Frame.ts
+++ b/package/src/types/Frame.ts
@@ -85,6 +85,18 @@ export interface Frame {
    * ```
    */
   toString(): string
+  /**
+   * Assign a new base instance to this Frame, and have all methods on {@linkcode baseInstance}
+   * also be a part of this Frame.
+   * @param baseInstance The base instance to use.
+   * @example ```ts
+   * const canvas = skSurface.getCanvas()
+   * const drawableFrame = frame.withBaseClass(canvas)
+   * // now `drawableFrame` has all methods from `canvas`, as well as `frame`.
+   * drawableFrame.drawRect(...)
+   * ```
+   */
+  withBaseClass<T>(baseInstance: T): T & Frame
 }
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds the `Frame.withBaseClass(..)` method, which takes a `jsi::Object` and uses the given `jsi::Object` as it's new base class.

Before, there were two approaches for combining objects in JS:

1. Combine with spread: 
    ```ts
    const frame = ...
    const canvas = surface.getCanvas()
    const drawableFrame = { ...frame, ...canvas } 
    ```
    This is eager, and slow as it has to iterate through all C++ properties and methods of both `frame` and `canvas` and copies them here, even if you don't use them.
2. Use `Proxy`:
    ```ts
    const frame = ...
    const canvas = surface.getCanvas()
    const drawableFrame = new Proxy({}, {
      get: (property, target) => {
        return frame[property] ?? canvas[property]
      }
    })
    ```
    Unfortunately Proxies are also slow, but with well implemented Proxies this lazy-approach should be better and more flexible than the spread approach.

Unfortunately both of these approaches have a common problem; the `drawableFrame` value is no longer a `FrameHostObject`/`jsi::HostObject`, but instead a conventional `jsi::Object` now. It will also no longer hold the native `shared_ptr` of buffer data.

This causes two issues:

- The `drawableFrame` cannot be passed to native Frame Processor Plugins, because those expect a `FrameHostObject`, not a normal `jsi::Object`. That should've thrown an error actually, maybe in some runtimes it was swallowed? Not sure
- Using the Frame outside of the `useFrameProcessor` context (e.g. `runAsync`) wouldn't work anymore, as the `drawableFrame` is not a HostObject that can be easily shared. Instead, it was a conventional `jsi::Object` that had to be deep-copied.

So instead, we need to make sure that the `frame` stays the instance it currently is, and we do that by adding a new method to `FrameHostObject`: `withBaseClass`.

This basically just uses the object it receives and sets it as a class property, and all properties that do not exist on `FrameHostObject` will now be looked up on the new `jsi::Object` base class.

This means that the code is now:

```ts
const frame = ...
const canvas = surface.getCanvas()
const drawableFrame = frame.withBaseClass(canvas)
```

..and `drawableFrame` is now still a `FrameHostObject` - so it can be passed to Frame Processor Plugins without an issue. Also `runAsync` should now work fine.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2842

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
