### PR TITLE
Update TakePhotoOptions default value comment

### DIFF
--- a/package/src/types/PhotoFile.ts
+++ b/package/src/types/PhotoFile.ts
@@ -5,7 +5,7 @@ export interface TakePhotoOptions {
   /**
    * Whether the Flash should be enabled or disabled
    *
-   * @default "auto"
+   * @default "off"
    */
   flash?: 'on' | 'off' | 'auto'
   /**


### PR DESCRIPTION
Default flash behavior resolves to 'off'.

## What
This PR updates the comment documenting the default value of the `flash` option in `TakePhotoOptions`.

## Changes

- One-word change to the comment.