### PR TITLE
Fix component did update if statement

### DIFF
--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -562,7 +562,7 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
   componentDidUpdate(): void {
     if (!this.isNativeViewMounted) return
     const frameProcessor = this.props.frameProcessor
-    if (frameProcessor !== this.lastFrameProcessor) {
+    if (frameProcessor?.frameProcessor !== this.lastFrameProcessor) {
       // frameProcessor argument identity changed. Update native to reflect the change.
       if (frameProcessor != null) this.setFrameProcessor(frameProcessor.frameProcessor)
       else this.unsetFrameProcessor()


### PR DESCRIPTION
Currently the if statement is always true since ReadonlyFrameProcesser != FrameProcessor

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes if boolean

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
