### PR TITLE
fix: Fix `runOnUiThread` executing twice if called from UI

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/utils/runOnUiThread.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/utils/runOnUiThread.kt
@@ -23,7 +23,7 @@ suspend inline fun <T> runOnUiThreadAndWait(crossinline function: () -> T): T {
 inline fun runOnUiThread(crossinline function: () -> Unit) {
   if (UiThreadUtil.isOnUiThread()) {
     // We are already on UI Thread - immediately call the function
-    function()
+    return function()
   }
 
   UiThreadUtil.runOnUiThread {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

When `runOnUiThread` was called from the UI Thread, it would execute twice.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
