### PR TITLE
fix: Fix WorkletContext initialization

### DIFF
--- a/package/android/src/main/cpp/frameprocessors/java-bindings/JVisionCameraProxy.cpp
+++ b/package/android/src/main/cpp/frameprocessors/java-bindings/JVisionCameraProxy.cpp
@@ -41,7 +41,8 @@ JVisionCameraProxy::JVisionCameraProxy(const jni::alias_ref<JVisionCameraProxy::
     // Run on Frame Processor Worklet Runtime
     scheduler->cthis()->dispatchAsync([f = std::move(f)]() { f(); });
   };
-  _workletContext = std::make_shared<RNWorklet::JsiWorkletContext>("VisionCamera", runtime, runOnJS, runOnWorklet);
+  _workletContext = std::make_shared<RNWorklet::JsiWorkletContext>("VisionCamera");
+  _workletContext->initialize("VisionCamera", runtime, runOnJS, runOnWorklet);
   __android_log_write(ANDROID_LOG_INFO, TAG, "Worklet Context created!");
 #else
   __android_log_write(ANDROID_LOG_INFO, TAG, "Frame Processors are disabled!");

--- a/package/ios/FrameProcessors/VisionCameraProxy.mm
+++ b/package/ios/FrameProcessors/VisionCameraProxy.mm
@@ -34,7 +34,8 @@ VisionCameraProxy::VisionCameraProxy(jsi::Runtime& runtime, std::shared_ptr<reac
     dispatch_async(delegate.getDispatchQueue, [f = std::move(f)]() { f(); });
   };
 
-  _workletContext = std::make_shared<RNWorklet::JsiWorkletContext>("VisionCamera", &runtime, runOnJS, runOnWorklet);
+  _workletContext = std::make_shared<RNWorklet::JsiWorkletContext>("VisionCamera");
+  _workletContext->initialize("VisionCamera", &runtime, runOnJS, runOnWorklet);
   NSLog(@"VisionCameraProxy: Worklet Context Created!");
 }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

`initialize` is a bit safer, I am not sure if this changes anything though.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
