### PR TITLE
fix: Fix photos being black/erroring out because of `photoQualityBalance="balanced"`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
@@ -72,7 +72,8 @@ class CameraView(context: Context) :
   var videoStabilizationMode: VideoStabilizationMode? = null
   var videoHdr = false
   var photoHdr = false
-  var photoQualityBalance = QualityBalance.BALANCED
+  // TODO: Use .BALANCED once CameraX fixes it https://issuetracker.google.com/issues/337214687
+  var photoQualityBalance = QualityBalance.SPEED
   var lowLightBoost = false
 
   // other props


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

On some Android phones, using `photoQualityBalance="balanced"` would just error out and either crash the Camera session (= black screen https://github.com/mrousavy/react-native-vision-camera/issues/2862, https://github.com/mrousavy/react-native-vision-camera/issues/2881, https://github.com/mrousavy/react-native-vision-camera/issues/2878), error when taking photos (= "an error occured, but the camera can recover" https://github.com/mrousavy/react-native-vision-camera/issues/2885) or produce green images (https://github.com/mrousavy/react-native-vision-camera/issues/2686).

This is because `"balanced"` uses ZSL (zero-shutter-lag) to reduce latency while maintaining image quality. Apparently not all phones support this, and even though CameraX should automatically disable it when video streams are enabled or this is just not supported, it doesn't always do it.

We created an issue in their issuetracker here: https://issuetracker.google.com/issues/337214687

For now the temporary solution is to use `"speed"` as a default on Android until the ZSL bug is fixed.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2862
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2686
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2878
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2881
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2885

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
