### PR TITLE
fix: Fix view surface orientation mapping

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/types/Orientation.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/types/Orientation.kt
@@ -2,18 +2,22 @@ package com.mrousavy.camera.core.types
 
 import android.view.Surface
 
+// This orientation represents the orientation of the device home button.
 enum class Orientation(override val unionValue: String) : JSUnionValue {
   PORTRAIT("portrait"),
   LANDSCAPE_RIGHT("landscape-right"),
   PORTRAIT_UPSIDE_DOWN("portrait-upside-down"),
   LANDSCAPE_LEFT("landscape-left");
 
+  // The SurfaceOrientation represents the orientation of the Android UI view.
+  // When you rotate your device in one direction, the UI view rotates in the opposite direction.
+  // For example, when you rotate the device clockwise, the view rotates counterclockwise.
   fun toSurfaceRotation(): Int =
     when (this) {
       PORTRAIT -> Surface.ROTATION_0
-      LANDSCAPE_LEFT -> Surface.ROTATION_90
+      LANDSCAPE_LEFT -> Surface.ROTATION_270
       PORTRAIT_UPSIDE_DOWN -> Surface.ROTATION_180
-      LANDSCAPE_RIGHT -> Surface.ROTATION_270
+      LANDSCAPE_RIGHT -> Surface.ROTATION_90
     }
 
   companion object : JSUnionValue.Companion<Orientation> {

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
@@ -72,6 +72,7 @@ class CameraView(context: Context) :
   var videoStabilizationMode: VideoStabilizationMode? = null
   var videoHdr = false
   var photoHdr = false
+
   // TODO: Use .BALANCED once CameraX fixes it https://issuetracker.google.com/issues/337214687
   var photoQualityBalance = QualityBalance.SPEED
   var lowLightBoost = false


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

This PR fixes the orientation mapping on Android.
The Android surface view orientation, represents the rotation of the "ui elements".
When you rotate your device clockwise, then the view is rotated counter clockwise.

I deduced this behaviour by looking and running cameraX examples from google. ([here](https://github.com/android/camera-samples/blob/main/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/fragments/CameraFragment.kt#L124))

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

This PR changes the surface view orientation mapping on Android.
Output image were vertically inverted when the orientation prop were set to landscape-left or landscape-right .

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

Samsung galaxy tab A8, Android 14

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2802 
