### PR TITLE
fix: Apply orientation to video output

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -531,6 +531,7 @@ class CameraSession(private val context: Context, private val callback: Callback
   fun startRecording(
     enableAudio: Boolean,
     options: RecordVideoOptions,
+    outputOrientation: Orientation,
     callback: (video: Video) -> Unit,
     onError: (error: CameraError) -> Unit
   ) {
@@ -545,6 +546,7 @@ class CameraSession(private val context: Context, private val callback: Callback
         outputOptions.setLocation(location)
       }
     }.build()
+    videoOutput.setTargetRotation(outputOrientation.toSurfaceRotation())
     var pendingRecording = videoOutput.output.prepareRecording(context, outputOptions)
     if (enableAudio) {
       checkMicrophonePermission()

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+RecordVideo.kt
@@ -31,7 +31,7 @@ fun CameraView.startRecording(options: RecordVideoOptions, onRecordCallback: Cal
     val errorMap = makeErrorMap(error.code, error.message)
     onRecordCallback(null, errorMap)
   }
-  cameraSession.startRecording(audio, options, callback, onError)
+  cameraSession.startRecording(audio, options, orientation, callback, onError)
 }
 
 fun CameraView.pauseRecording() {

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
@@ -72,6 +72,7 @@ class CameraView(context: Context) :
   var videoStabilizationMode: VideoStabilizationMode? = null
   var videoHdr = false
   var photoHdr = false
+
   // TODO: Use .BALANCED once CameraX fixes it https://issuetracker.google.com/issues/337214687
   var photoQualityBalance = QualityBalance.SPEED
   var lowLightBoost = false


### PR DESCRIPTION
## What
This PR updates video recording on Android to respect the orientation prop.

## Changes

- Call `startRecording` with `orientation` from `cameraView`.
- Apply a rotation derived from the orientation to the video output via `setTargetRotation`.

## Tested on
- Pixel 3a, Android 12
- Moto Stylus 5G (2022), Android 12
