### PR TITLE
Attach the VisionCameraProxy runtime to FrameProcessorPluginHostObject

### DIFF
--- a/package/ios/FrameProcessors/VisionCameraProxy.h
+++ b/package/ios/FrameProcessors/VisionCameraProxy.h
@@ -43,6 +43,6 @@ private:
 private:
   std::shared_ptr<RNWorklet::JsiWorkletContext> _workletContext;
   std::shared_ptr<react::CallInvoker> _callInvoker;
-  jsi::Runtime& _runtime;
+  jsi::Runtime* _runtimePtr;
   id<VisionCameraProxyDelegate> _delegate;
 };

--- a/package/ios/FrameProcessors/VisionCameraProxy.h
+++ b/package/ios/FrameProcessors/VisionCameraProxy.h
@@ -43,5 +43,6 @@ private:
 private:
   std::shared_ptr<RNWorklet::JsiWorkletContext> _workletContext;
   std::shared_ptr<react::CallInvoker> _callInvoker;
+  jsi::Runtime& _runtime;
   id<VisionCameraProxyDelegate> _delegate;
 };

--- a/package/ios/FrameProcessors/VisionCameraProxy.mm
+++ b/package/ios/FrameProcessors/VisionCameraProxy.mm
@@ -20,9 +20,10 @@
 using namespace facebook;
 
 VisionCameraProxy::VisionCameraProxy(jsi::Runtime& runtime, std::shared_ptr<react::CallInvoker> callInvoker,
-                                     id<VisionCameraProxyDelegate> delegate) : _runtime(runtime) {
+                                     id<VisionCameraProxyDelegate> delegate) {
   _callInvoker = callInvoker;
   _delegate = delegate;
+  _runtimePtr = &runtime; // Store a pointer to the runtime
 
   NSLog(@"VisionCameraProxy: Creating Worklet Context...");
   auto runOnJS = [callInvoker](std::function<void()>&& f) {
@@ -75,7 +76,7 @@ jsi::Value VisionCameraProxy::initFrameProcessorPlugin(jsi::Runtime& runtime, co
     }
 
     auto pluginHostObject = std::make_shared<FrameProcessorPluginHostObject>(plugin, _callInvoker);
-    return jsi::Object::createFromHostObject(_runtime, pluginHostObject);
+    return jsi::Object::createFromHostObject(*_runtimePtr, pluginHostObject);
   } @catch (NSException* exception) {
     // Objective-C plugin threw an error when initializing.
     NSString* message = [NSString stringWithFormat:@"%@: %@", exception.name, exception.reason];

--- a/package/ios/FrameProcessors/VisionCameraProxy.mm
+++ b/package/ios/FrameProcessors/VisionCameraProxy.mm
@@ -20,10 +20,9 @@
 using namespace facebook;
 
 VisionCameraProxy::VisionCameraProxy(jsi::Runtime& runtime, std::shared_ptr<react::CallInvoker> callInvoker,
-                                     id<VisionCameraProxyDelegate> delegate) {
+                                     id<VisionCameraProxyDelegate> delegate) : _runtime(runtime) {
   _callInvoker = callInvoker;
   _delegate = delegate;
-  _initRuntime = runtime;
 
   NSLog(@"VisionCameraProxy: Creating Worklet Context...");
   auto runOnJS = [callInvoker](std::function<void()>&& f) {
@@ -66,7 +65,7 @@ void VisionCameraProxy::removeFrameProcessor(jsi::Runtime& runtime, double jsVie
 jsi::Value VisionCameraProxy::initFrameProcessorPlugin(jsi::Runtime& runtime, const jsi::String& name, const jsi::Object& options) {
   std::string nameString = name.utf8(runtime);
   NSString* key = [NSString stringWithUTF8String:nameString.c_str()];
-  NSDictionary* optionsObjc = JSINSObjectConversion::convertJSIObjectToObjCDictionary(_initRuntime, options);
+  NSDictionary* optionsObjc = JSINSObjectConversion::convertJSIObjectToObjCDictionary(runtime, options);
   VisionCameraProxyHolder* proxy = [[VisionCameraProxyHolder alloc] initWithProxy:this];
 
   @try {
@@ -76,7 +75,7 @@ jsi::Value VisionCameraProxy::initFrameProcessorPlugin(jsi::Runtime& runtime, co
     }
 
     auto pluginHostObject = std::make_shared<FrameProcessorPluginHostObject>(plugin, _callInvoker);
-    return jsi::Object::createFromHostObject(_initRuntime, pluginHostObject);
+    return jsi::Object::createFromHostObject(_runtime, pluginHostObject);
   } @catch (NSException* exception) {
     // Objective-C plugin threw an error when initializing.
     NSString* message = [NSString stringWithFormat:@"%@: %@", exception.name, exception.reason];


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Since Frame Processor Plugin will always be called within the context of the RNVC, shouldn't it be attached to the vision camera runtime instead of the runtime of the initializer.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

Potentially related to https://github.com/mrousavy/react-native-vision-camera/issues/2820 and https://github.com/margelo/react-native-worklets-core/issues/173
