### PR TITLE
DOC update: Replace `qualityBalance` with `photoQualityBalance` in accordance with the `Camera` props

### DIFF
--- a/docs/docs/guides/PERFORMANCE.mdx
+++ b/docs/docs/guides/PERFORMANCE.mdx
@@ -98,10 +98,10 @@ The [`isActive`](/docs/api/interfaces/CameraProps#isactive) prop controls whethe
 
 ### Fast Photos
 
-If you need to take photos as fast as possible, use a [`qualityBalance`](/docs/api/interfaces/CameraProps#qualitybalance) of `'speed'` to speed up the photo pipeline:
+If you need to take photos as fast as possible, use a [`photoQualityBalance`](/docs/api/interfaces/CameraProps#photoQualityBalance) of `'speed'` to speed up the photo pipeline:
 
 ```jsx
-return <Camera {...props} qualityBalance="speed" />
+return <Camera {...props} photoQualityBalance="speed" />
 ```
 
 ### Snapshot Capture

--- a/docs/docs/guides/TAKING_PHOTOS.mdx
+++ b/docs/docs/guides/TAKING_PHOTOS.mdx
@@ -81,13 +81,13 @@ const photo = await camera.current.takePhoto({
 
 Note that flash is only available on camera devices where [`hasFlash`](/docs/api/interfaces/CameraDevice#hasflash) is `true`; for example most front cameras don't have a flash.
 
-### Quality Balance
+### Photo Quality Balance
 
-The photo capture pipeline can be configured to prioritize speed over quality, quality over speed or balance both quality and speed using the [`qualityBalance`](/docs/api/interfaces/CameraProps#qualitybalance) prop.
+The photo capture pipeline can be configured to prioritize speed over quality, quality over speed or balance both quality and speed using the [`photoQualityBalance`](/docs/api/interfaces/CameraProps#photoQualityBalance) prop.
 If set to `speed`, the Camera pipeline will capture photos faster at the cost of lower quality:
 
 ```jsx
-return <Camera {...props} qualityBalance="speed" />
+return <Camera {...props} photoQualityBalance="speed" />
 ```
 
 ## Taking Snapshots


### PR DESCRIPTION
## What
This PR replaces the `qualityBalance` prop with the correct `photoQualityBalance` in the docs.