### PR TITLE
feat: Set `fps` for Frame Processor on Android

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -347,6 +347,13 @@ class CameraSession(private val context: Context, private val callback: Callback
       val analyzer = ImageAnalysis.Builder().also { analysis ->
         analysis.setBackpressureStrategy(ImageAnalysis.STRATEGY_BLOCK_PRODUCER)
         analysis.setOutputImageFormat(pixelFormat.toImageAnalysisFormat())
+        if (fpsRange != null) {
+          assertFormatRequirement("fps", format, InvalidFpsError(fpsRange.upper)) {
+            fpsRange.lower >= it.minFps &&
+                fpsRange.upper <= it.maxFps
+          }
+          analysis.setTargetFrameRate(fpsRange)
+        }
         if (format != null) {
           Log.i(TAG, "Frame Processor size: ${format.videoSize}")
           val resolutionSelector = ResolutionSelector.Builder()

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -47,6 +47,7 @@ import com.mrousavy.camera.core.extensions.forSize
 import com.mrousavy.camera.core.extensions.getCameraError
 import com.mrousavy.camera.core.extensions.id
 import com.mrousavy.camera.core.extensions.isSDR
+import com.mrousavy.camera.core.extensions.setTargetFrameRate
 import com.mrousavy.camera.core.extensions.takePicture
 import com.mrousavy.camera.core.extensions.toCameraError
 import com.mrousavy.camera.core.extensions.withExtension

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -350,7 +350,7 @@ class CameraSession(private val context: Context, private val callback: Callback
         if (fpsRange != null) {
           assertFormatRequirement("fps", format, InvalidFpsError(fpsRange.upper)) {
             fpsRange.lower >= it.minFps &&
-                fpsRange.upper <= it.maxFps
+              fpsRange.upper <= it.maxFps
           }
           analysis.setTargetFrameRate(fpsRange)
         }

--- a/package/android/src/main/java/com/mrousavy/camera/core/extensions/ImageAnalysis.Builder+setTargetFrameRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/extensions/ImageAnalysis.Builder+setTargetFrameRate.kt
@@ -1,0 +1,17 @@
+package com.mrousavy.camera.core.extensions
+
+import android.hardware.camera2.CaptureRequest
+import android.util.Range
+import androidx.annotation.OptIn
+import androidx.camera.camera2.interop.Camera2Interop
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop
+import androidx.camera.core.ImageAnalysis
+
+@OptIn(ExperimentalCamera2Interop::class)
+fun ImageAnalysis.Builder.setTargetFrameRate(frameRate: Range<Int>) {
+  val camera2Interop = Camera2Interop.Extender(this)
+  camera2Interop.setCaptureRequestOption(
+    CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
+    frameRate
+  )
+}


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Actually set the target FPS on the ImageAnalysis usecase.

Inspired by @wuguishifu's comment in https://github.com/mrousavy/react-native-vision-camera/issues/2838

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
