### PR TITLE
fix: messed skia processor coordinate system after canvas rotation / translate

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSORS_SKIA.mdx
+++ b/docs/docs/guides/FRAME_PROCESSORS_SKIA.mdx
@@ -111,6 +111,23 @@ The Camera Frame is a GPU-texture-backed `SkImage`, and it's coordinate system i
 - (`0`, `0`) is top left
 - (`frame.width`, `frame.height`) is bottom right
 
+### Ensuring Consistent Drawing Across Different Devices
+
+To achieve consistent drawing across different devices, it is essential to manually set the video resolution instead of using the maximum resolution available. This ensures that the aspect ratio and resolution remain consistent, providing a uniform drawing experience regardless of the device's capabilities.
+
+Here's an example of how to manually set the video resolution:
+
+```ts
+const screenAspectRatio = SCREEN_HEIGHT / SCREEN_WIDTH
+const format = useCameraFormat(device, [
+  { fps: targetFps },
+  { videoAspectRatio: screenAspectRatio },
+  { videoResolution: { width: 1080, height: 1920 } },
+  { photoAspectRatio: screenAspectRatio },
+  { photoResolution: 'max' },
+])
+```
+
 ### Performance
 
 Just like normal Frame Processors, Skia Frame Processors are _really fast_. Skia is GPU-accelerated by Metal and OpenGL, and VisionCamera Frames are streamed as efficiently as possible using GPU-buffers and textures.

--- a/package/src/skia/useSkiaFrameProcessor.ts
+++ b/package/src/skia/useSkiaFrameProcessor.ts
@@ -200,8 +200,11 @@ export function createSkiaFrameProcessor(
           case 'render':
             return (paint?: SkPaint) => {
               'worklet'
-              if (paint != null) canvas.drawImage(image, 0, 0, paint)
-              else canvas.drawImage(image, 0, 0)
+              // rotate the frame properly to make sure it's upright
+              withRotatedFrame(frame, canvas, () => {
+                if (paint != null) canvas.drawImage(image, 0, 0, paint)
+                else canvas.drawImage(image, 0, 0)
+              })
             }
           case 'dispose':
             return () => {
@@ -234,16 +237,13 @@ export function createSkiaFrameProcessor(
         const black = Skia.Color('black')
         canvas.clear(black)
 
-        // 4. rotate the frame properly to make sure it's upright
-        withRotatedFrame(frame, canvas, () => {
-          // 5. Run any user drawing operations
-          frameProcessor(drawableFrame)
-        })
+        // 4. Run any user drawing operations
+        frameProcessor(drawableFrame)
 
-        // 6. Flush draw operations and submit to GPU
+        // 5. Flush draw operations and submit to GPU
         surface.flush()
       } finally {
-        // 7. Delete the SkImage/Texture that holds the Frame
+        // 6. Delete the SkImage/Texture that holds the Frame
         drawableFrame.dispose()
       }
 


### PR DESCRIPTION
> [!WARNING]  
>  This will not work in 4.1.0 since the new orientation feature changed a lot of things, working just fine on 4.0.5

The pull request #2931 successfully addresses the issue of the image buffer not being aligned inside the canvas.

However, it introduces a complication with the coordinate system for drawing on the canvas, as the coordinates are rotated along with the canvas itself. This PR resolves that issue


