### PR TITLE
fix: Initialize orientations on session re-creation

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -147,6 +147,10 @@ extension CameraSession {
 
       self.codeScannerOutput = codeScannerOutput
     }
+    
+    // Re-initialize Orientations
+    onPreviewOrientationChanged(previewOrientation: orientationManager.previewOrientation)
+    onOutputOrientationChanged(outputOrientation: orientationManager.outputOrientation)
 
     // Done!
     VisionLogger.log(level: .info, message: "Successfully configured all outputs!")

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -147,7 +147,7 @@ extension CameraSession {
 
       self.codeScannerOutput = codeScannerOutput
     }
-    
+
     // Re-initialize Orientations
     onPreviewOrientationChanged(previewOrientation: orientationManager.previewOrientation)
     onOutputOrientationChanged(outputOrientation: orientationManager.outputOrientation)

--- a/package/ios/Core/CameraSession+Orientation.swift
+++ b/package/ios/Core/CameraSession+Orientation.swift
@@ -47,7 +47,7 @@ extension CameraSession: OrientationManagerDelegate {
    */
   func onPreviewOrientationChanged(previewOrientation: Orientation) {
     guard #available(iOS 13.0, *) else {
-      // Orientation is only available on iOS 13+.
+      // .videoPreviewLayer is only available on iOS 13+.
       return
     }
 

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -101,7 +101,7 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
 
   /**
    Update the session configuration.
-   Any changes in here will be re-configured only if required, and under a lock.
+   Any changes in here will be re-configured only if required, and under a lock (in this case, the serial cameraQueue DispatchQueue).
    The `configuration` object is a copy of the currently active configuration that can be modified by the caller in the lambda.
    */
   func configure(_ lambda: @escaping (_ configuration: CameraConfiguration) throws -> Void) {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
