### PR TITLE
fix: Fix react-native-reanimated is not installed! error

### DIFF
--- a/package/src/dependencies/ModuleProxy.ts
+++ b/package/src/dependencies/ModuleProxy.ts
@@ -9,6 +9,7 @@ export const createModuleProxy = <TModule>(getModule: () => ImportType): TModule
 
   const proxy = new Proxy(holder, {
     get: (target, property) => {
+      if (property === '$$typeof') return undefined
       if (target.module == null) {
         // lazy initialize module via require()
         // caller needs to make sure the require() call is wrapped in a try/catch

--- a/package/src/dependencies/ModuleProxy.ts
+++ b/package/src/dependencies/ModuleProxy.ts
@@ -9,7 +9,16 @@ export const createModuleProxy = <TModule>(getModule: () => ImportType): TModule
 
   const proxy = new Proxy(holder, {
     get: (target, property) => {
-      if (property === '$$typeof') return undefined
+      if (property === '$$typeof') {
+        // If inlineRequires is enabled, Metro will look up all imports
+        // with the $$typeof operator. In this case, this will throw the
+        // `OptionalDependencyNotInstalledError` error because we try to access the module
+        // even though we are not using it (Metro does it), so instead we return undefined
+        // to bail out of inlineRequires here.
+        // See https://github.com/mrousavy/react-native-vision-camera/pull/2953
+        return undefined
+      }
+
       if (target.module == null) {
         // lazy initialize module via require()
         // caller needs to make sure the require() call is wrapped in a try/catch


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->
This PR fixes the errors `react-native-reanimated is not installed!`, `@shopify/react-native-skia is not installed!`, and `react-native-worklets-core is not installed!` that occur when [inlineRequires](https://reactnative.dev/docs/ram-bundles-inline-requires#inline-requires) is disabled in `metro.config.js` (enabled by default).

![Capture333333](https://github.com/mrousavy/react-native-vision-camera/assets/13413154/1907ebdb-c36e-4c2d-88ca-73ccb894ba3a)


When `inlineRequires` is enabled, there are no errors because all modules are loaded lazily.

When `inlineRequires` is disabled, there is an attempt to read the property `$$typeof` at start time from a module created via `createModuleProxy`, which causes an error.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->
This PR changes `createModuleProxy` to return an object that contains the proxy instead of returning the proxy directly. This prevents unnecessary access to the proxy.

We could, for instance, add a check only for the `$$typeof` property, but I think the proxy doesn't need to be aware of this property. Additionally, I'm not sure if it will work if we create a proxy for a react element module.
## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->
* iPhone 13, ios 15.5
* Nexus 4 Emulator, Android 13
## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

Minimal reproducible example: https://github.com/mgefimov/vision-camera-inline-requires-error
1. Init new RN app, react-native version 0.71.0
2. Install `react-native-vision-camera`, setup camera code
3. Disable inlineRequires 
![Screenshot_1717927341](https://github.com/mrousavy/react-native-vision-camera/assets/13413154/3e5dc672-a914-42bb-9cfa-1e37bd4e1282)
