### PR TITLE
feat: Also expose `previewOrientation` in orientation changed event

### DIFF
--- a/docs/docs/guides/ORIENTATION.mdx
+++ b/docs/docs/guides/ORIENTATION.mdx
@@ -27,6 +27,14 @@ Photos and videos will be captured in a potentially "wrong" orientation, and Vis
 This is handled automatically, and it's behaviour can be controlled via the [`outputOrientation`](/docs/api/interfaces/CameraProps#outputorientation) property.
 :::
 
+#### Preview View
+
+The Preview output will stream in a potentially "wrong" orientation, but uses view transforms (rotate + translate matrix) to properly display the Camera stream "up-right".
+
+:::info
+This will always happen automatically according to the screen's rotation.
+:::
+
 #### Frame Processor Output
 
 Frame Processors will stream frames in a potentially "wrong" orientation, and the client is responsible for properly interpreting the Frame data.
@@ -34,14 +42,6 @@ Frame Processors will stream frames in a potentially "wrong" orientation, and th
 :::info
 This needs to be handled manually, see [`Frame.orientation`](/docs/api/interfaces/Frame#orientation).
 For example, in MLKit just pass the `Frame`'s `orientation` to the `detect(...)` method.
-:::
-
-#### Preview View
-
-The Preview output will stream in a potentially "wrong" orientation, but uses view transforms (rotate + translate matrix) to properly display the Camera stream "up-right".
-
-:::info
-This will always happen automatically according to the screen's rotation.
 :::
 
 ### The `outputOrientation` prop

--- a/docs/docs/guides/ORIENTATION.mdx
+++ b/docs/docs/guides/ORIENTATION.mdx
@@ -52,7 +52,7 @@ The orientation in which photos and videos are captured can be adjusted via the 
 <Camera {...props} outputOrientation="device" />
 ```
 
-Whenever the output orientation changes, the [`onOutputOrientationChanged`](/docs/api/interfaces/CameraProps#onoutputorientationchanged) event will be called with the new output orientation.
+Whenever the output orientation changes, the [`onOrientationChanged`](/docs/api/interfaces/CameraProps#onorientationchanged) event will be called with the new preview- and output orientation.
 
 #### `"device"`
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -521,8 +521,17 @@ class CameraSession(private val context: Context, private val callback: Callback
     frameProcessorOutput?.targetRotation = outputOrientation.toSurfaceRotation()
     codeScannerOutput?.targetRotation = outputOrientation.toSurfaceRotation()
 
-    // onOutputOrientationChanged(..) event
-    callback.onOutputOrientationChanged(outputOrientation)
+    notifyOrientationChanged()
+  }
+
+  override fun onPreviewOrientationChanged(previewOrientation: Orientation) {
+    Log.i(TAG, "Preview orientation changed! $previewOrientation")
+    notifyOrientationChanged()
+  }
+
+  private fun notifyOrientationChanged() {
+    // onOrientationChanged(..) event
+    callback.onOrientationChanged(orientationManager.previewOrientation, orientationManager.outputOrientation)
   }
 
   suspend fun takePhoto(flash: Flash, enableShutterSound: Boolean): Photo {
@@ -683,7 +692,7 @@ class CameraSession(private val context: Context, private val callback: Callback
     fun onStarted()
     fun onStopped()
     fun onShutter(type: ShutterType)
-    fun onOutputOrientationChanged(outputOrientation: Orientation)
+    fun onOrientationChanged(previewOrientation: Orientation, outputOrientation: Orientation)
     fun onCodeScanned(codes: List<Barcode>, scannerFrame: CodeScannerFrame)
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
@@ -80,13 +80,9 @@ class OrientationManager(private val context: Context, private val callback: Cal
     orientationListener.disable()
 
     when (targetOrientation) {
-      OutputOrientation.DEVICE -> {
-        Log.i(TAG, "Starting streaming device orientation updates...")
+      OutputOrientation.DEVICE, OutputOrientation.PREVIEW -> {
+        Log.i(TAG, "Starting streaming device and screen orientation updates...")
         orientationListener.enable()
-      }
-
-      OutputOrientation.PREVIEW -> {
-        Log.i(TAG, "Starting streaming screen rotation updates...")
         displayManager.registerDisplayListener(displayListener, null)
       }
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
@@ -14,7 +14,8 @@ class OrientationManager(private val context: Context, private val callback: Cal
   }
 
   private var targetOutputOrientation = OutputOrientation.DEVICE
-  private var lastOrientation: Orientation? = null
+  private var lastOutputOrientation: Orientation? = null
+  private var lastPreviewOrientation: Orientation? = null
 
   // Screen Orientation Listener
   private var screenRotation = Surface.ROTATION_0
@@ -40,6 +41,10 @@ class OrientationManager(private val context: Context, private val callback: Cal
     }
   }
 
+  // Get the current preview orientation (computed by screen/interface orientation)
+  val previewOrientation: Orientation
+    get() = Orientation.fromSurfaceRotation(screenRotation)
+
   // Get the current output orientation (a computed value)
   val outputOrientation: Orientation
     get() {
@@ -54,10 +59,15 @@ class OrientationManager(private val context: Context, private val callback: Cal
     }
 
   private fun maybeNotifyOrientation() {
-    val newOrientation = outputOrientation
-    if (lastOrientation != newOrientation) {
-      callback.onOutputOrientationChanged(newOrientation)
-      lastOrientation = newOrientation
+    val newOutputOrientation = outputOrientation
+    if (lastOutputOrientation != newOutputOrientation) {
+      callback.onOutputOrientationChanged(newOutputOrientation)
+      lastOutputOrientation = newOutputOrientation
+    }
+    val newPreviewOrientation = previewOrientation
+    if (lastPreviewOrientation != newPreviewOrientation) {
+      callback.onPreviewOrientationChanged(newPreviewOrientation)
+      lastPreviewOrientation = newPreviewOrientation
     }
   }
 
@@ -99,5 +109,6 @@ class OrientationManager(private val context: Context, private val callback: Cal
 
   interface Callback {
     fun onOutputOrientationChanged(outputOrientation: Orientation)
+    fun onPreviewOrientationChanged(previewOrientation: Orientation)
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+Events.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+Events.kt
@@ -49,11 +49,12 @@ fun CameraView.invokeOnShutter(type: ShutterType) {
   this.sendEvent(event)
 }
 
-fun CameraView.invokeOnOutputOrientationChanged(outputOrientation: Orientation) {
-  Log.i(CameraView.TAG, "invokeOnOutputOrientationChanged($outputOrientation)")
+fun CameraView.invokeOnOrientationChanged(previewOrientation: Orientation, outputOrientation: Orientation) {
+  Log.i(CameraView.TAG, "invokeOnOrientationChanged($previewOrientation, $outputOrientation)")
 
   val surfaceId = UIManagerHelper.getSurfaceId(this)
   val data = Arguments.createMap()
+  data.putString("previewOrientation", previewOrientation.unionValue)
   data.putString("outputOrientation", outputOrientation.unionValue)
 
   val event = CameraOrientationChangedEvent(surfaceId, id, data)

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
@@ -319,8 +319,8 @@ class CameraView(context: Context) :
     invokeOnShutter(type)
   }
 
-  override fun onOutputOrientationChanged(outputOrientation: Orientation) {
-    invokeOnOutputOrientationChanged(outputOrientation)
+  override fun onOrientationChanged(previewOrientation: Orientation, outputOrientation: Orientation) {
+    invokeOnOrientationChanged(previewOrientation, outputOrientation)
   }
 
   override fun onCodeScanned(codes: List<Barcode>, scannerFrame: CodeScannerFrame) {

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraViewManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraViewManager.kt
@@ -34,7 +34,7 @@ class CameraViewManager : ViewGroupManager<CameraView>() {
       .put("cameraStarted", MapBuilder.of("registrationName", "onStarted"))
       .put("cameraStopped", MapBuilder.of("registrationName", "onStopped"))
       .put("cameraShutter", MapBuilder.of("registrationName", "onShutter"))
-      .put("cameraOrientationChanged", MapBuilder.of("registrationName", "onOutputOrientationChanged"))
+      .put("cameraOrientationChanged", MapBuilder.of("registrationName", "onOrientationChanged"))
       .put("averageFpsChanged", MapBuilder.of("registrationName", "onAverageFpsChanged"))
       .put("cameraError", MapBuilder.of("registrationName", "onError"))
       .put("cameraCodeScanned", MapBuilder.of("registrationName", "onCodeScanned"))

--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -207,7 +207,7 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
                 onError={onError}
                 onStarted={() => console.log('Camera started!')}
                 onStopped={() => console.log('Camera stopped!')}
-                onOrientationChanged={(o) => console.log(`Orientation changed to ${o}!`)}
+                onOrientationChanged={(o) => console.log('Orientation changed to', o)}
                 format={format}
                 fps={fps}
                 photoHdr={photoHdr}

--- a/package/example/src/CameraPage.tsx
+++ b/package/example/src/CameraPage.tsx
@@ -207,7 +207,7 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
                 onError={onError}
                 onStarted={() => console.log('Camera started!')}
                 onStopped={() => console.log('Camera stopped!')}
-                onOutputOrientationChanged={(o) => console.log(`Orientation changed to ${o}!`)}
+                onOrientationChanged={(o) => console.log(`Orientation changed to ${o}!`)}
                 format={format}
                 fps={fps}
                 photoHdr={photoHdr}

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -149,8 +149,8 @@ extension CameraSession {
     }
 
     // Re-initialize Orientations
-    onPreviewOrientationChanged(previewOrientation: orientationManager.previewOrientation)
-    onOutputOrientationChanged(outputOrientation: orientationManager.outputOrientation)
+    configurePreviewOrientation(orientationManager.previewOrientation)
+    configureOutputOrientation(orientationManager.outputOrientation)
 
     // Done!
     VisionLogger.log(level: .info, message: "Successfully configured all outputs!")

--- a/package/ios/Core/CameraSession+Orientation.swift
+++ b/package/ios/Core/CameraSession+Orientation.swift
@@ -42,10 +42,20 @@ extension CameraSession: OrientationManagerDelegate {
     return orientation
   }
 
+  func onPreviewOrientationChanged(previewOrientation: Orientation) {
+    configurePreviewOrientation(previewOrientation)
+    notifyOrientationChanged()
+  }
+
+  func onOutputOrientationChanged(outputOrientation: Orientation) {
+    configureOutputOrientation(outputOrientation)
+    notifyOrientationChanged()
+  }
+
   /**
    Updates the connected PreviewView's output orientation angle
    */
-  func onPreviewOrientationChanged(previewOrientation: Orientation) {
+  func configurePreviewOrientation(_ previewOrientation: Orientation) {
     guard #available(iOS 13.0, *) else {
       // .videoPreviewLayer is only available on iOS 13+.
       return
@@ -58,11 +68,12 @@ extension CameraSession: OrientationManagerDelegate {
     for connection in previewConnections {
       connection.orientation = previewOrientation
     }
-
-    notifyOrientationChanged()
   }
 
-  func onOutputOrientationChanged(outputOrientation: Orientation) {
+  /**
+   Updates the orientation angle of all connected virtually-rotateable outputs.
+   */
+  func configureOutputOrientation(_ outputOrientation: Orientation) {
     VisionLogger.log(level: .info, message: "Updating Outputs rotation: \(outputOrientation)...")
 
     // update the orientation for each output that supports virtual (no-performance-overhead) rotation.
@@ -74,8 +85,6 @@ extension CameraSession: OrientationManagerDelegate {
         connection.orientation = outputOrientation
       }
     }
-
-    notifyOrientationChanged()
   }
 
   private func notifyOrientationChanged() {

--- a/package/ios/Core/CameraSession+Orientation.swift
+++ b/package/ios/Core/CameraSession+Orientation.swift
@@ -58,6 +58,8 @@ extension CameraSession: OrientationManagerDelegate {
     for connection in previewConnections {
       connection.orientation = previewOrientation
     }
+
+    notifyOrientationChanged()
   }
 
   func onOutputOrientationChanged(outputOrientation: Orientation) {
@@ -73,7 +75,12 @@ extension CameraSession: OrientationManagerDelegate {
       }
     }
 
+    notifyOrientationChanged()
+  }
+
+  private func notifyOrientationChanged() {
     // onOrientationChanged(..) event
-    delegate?.onOrientationChanged(outputOrientation: outputOrientation)
+    delegate?.onOrientationChanged(previewOrientation: orientationManager.previewOrientation,
+                                   outputOrientation: orientationManager.outputOrientation)
   }
 }

--- a/package/ios/Core/CameraSessionDelegate.swift
+++ b/package/ios/Core/CameraSessionDelegate.swift
@@ -34,9 +34,9 @@ protocol CameraSessionDelegate: AnyObject {
    */
   func onCaptureShutter(shutterType: ShutterType)
   /**
-   Called whenever the output orientation of the [CameraSession] changes.
+   Called whenever the preview- or output-orientation of the [CameraSession] changes.
    */
-  func onOrientationChanged(outputOrientation: Orientation)
+  func onOrientationChanged(previewOrientation: Orientation, outputOrientation: Orientation)
   /**
    Called for every frame (if video or frameProcessor is enabled)
    */

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -70,7 +70,7 @@ public final class CameraView: UIView, CameraSessionDelegate, FpsSampleCollector
   @objc var onStarted: RCTDirectEventBlock?
   @objc var onStopped: RCTDirectEventBlock?
   @objc var onShutter: RCTDirectEventBlock?
-  @objc var onOutputOrientationChanged: RCTDirectEventBlock?
+  @objc var onOrientationChanged: RCTDirectEventBlock?
   @objc var onViewReady: RCTDirectEventBlock?
   @objc var onAverageFpsChanged: RCTDirectEventBlock?
   @objc var onCodeScanned: RCTDirectEventBlock?
@@ -347,11 +347,12 @@ public final class CameraView: UIView, CameraSessionDelegate, FpsSampleCollector
     ])
   }
 
-  func onOrientationChanged(outputOrientation: Orientation) {
-    guard let onOutputOrientationChanged else {
+  func onOrientationChanged(previewOrientation: Orientation, outputOrientation: Orientation) {
+    guard let onOrientationChanged else {
       return
     }
-    onOutputOrientationChanged([
+    onOrientationChanged([
+      "previewOrientation": previewOrientation.jsValue,
       "outputOrientation": outputOrientation.jsValue,
     ])
   }

--- a/package/ios/React/CameraViewManager.m
+++ b/package/ios/React/CameraViewManager.m
@@ -58,7 +58,7 @@ RCT_EXPORT_VIEW_PROPERTY(onInitialized, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onStarted, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onStopped, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onShutter, RCTDirectEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onOutputOrientationChanged, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onOrientationChanged, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onViewReady, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAverageFpsChanged, RCTDirectEventBlock);
 // Code Scanner

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -521,11 +521,16 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
   }
 
   private onShutter(event: NativeSyntheticEvent<OnShutterEvent>): void {
-    this.props.onShutter?.(event.nativeEvent)
+    this.props.onShutter?.({
+      type: event.nativeEvent.type,
+    })
   }
 
   private onOrientationChanged(event: NativeSyntheticEvent<OutputOrientationChangedEvent>): void {
-    this.props.onOrientationChanged?.(event.nativeEvent)
+    this.props.onOrientationChanged?.({
+      outputOrientation: event.nativeEvent.outputOrientation,
+      previewOrientation: event.nativeEvent.previewOrientation,
+    })
   }
   //#endregion
 

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -91,7 +91,7 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
     this.onStarted = this.onStarted.bind(this)
     this.onStopped = this.onStopped.bind(this)
     this.onShutter = this.onShutter.bind(this)
-    this.onOutputOrientationChanged = this.onOutputOrientationChanged.bind(this)
+    this.onOrientationChanged = this.onOrientationChanged.bind(this)
     this.onError = this.onError.bind(this)
     this.onCodeScanned = this.onCodeScanned.bind(this)
     this.ref = React.createRef<RefType>()
@@ -524,8 +524,8 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
     this.props.onShutter?.(event.nativeEvent)
   }
 
-  private onOutputOrientationChanged(event: NativeSyntheticEvent<OutputOrientationChangedEvent>): void {
-    this.props.onOutputOrientationChanged?.(event.nativeEvent.outputOrientation)
+  private onOrientationChanged(event: NativeSyntheticEvent<OutputOrientationChangedEvent>): void {
+    this.props.onOrientationChanged?.(event.nativeEvent)
   }
   //#endregion
 
@@ -613,7 +613,7 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
         onStarted={this.onStarted}
         onStopped={this.onStopped}
         onShutter={this.onShutter}
-        onOutputOrientationChanged={this.onOutputOrientationChanged}
+        onOrientationChanged={this.onOrientationChanged}
         onError={this.onError}
         codeScannerOptions={codeScanner}
         enableFrameProcessor={frameProcessor != null}

--- a/package/src/NativeCameraView.ts
+++ b/package/src/NativeCameraView.ts
@@ -19,10 +19,11 @@ export interface AverageFpsChangedEvent {
 }
 export interface OutputOrientationChangedEvent {
   outputOrientation: Orientation
+  previewOrientation: Orientation
 }
 export type NativeCameraViewProps = Omit<
   CameraProps,
-  'device' | 'onInitialized' | 'onError' | 'onShutter' | 'onOutputOrientationChanged' | 'frameProcessor' | 'codeScanner'
+  'device' | 'onInitialized' | 'onError' | 'onShutter' | 'onOrientationChanged' | 'frameProcessor' | 'codeScanner'
 > & {
   // private intermediate props
   cameraId: string
@@ -38,7 +39,7 @@ export type NativeCameraViewProps = Omit<
   onStarted?: (event: NativeSyntheticEvent<void>) => void
   onStopped?: (event: NativeSyntheticEvent<void>) => void
   onShutter?: (event: NativeSyntheticEvent<OnShutterEvent>) => void
-  onOutputOrientationChanged?: (event: NativeSyntheticEvent<OutputOrientationChangedEvent>) => void
+  onOrientationChanged?: (event: NativeSyntheticEvent<OutputOrientationChangedEvent>) => void
 }
 
 // requireNativeComponent automatically resolves 'CameraView' to 'CameraViewManager'

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -6,7 +6,7 @@ import type { Frame } from './Frame'
 import type { ISharedValue } from 'react-native-worklets-core'
 import type { SkImage } from '@shopify/react-native-skia'
 import type { OutputOrientation } from './OutputOrientation'
-import type { Orientation } from './Orientation'
+import type { OutputOrientationChangedEvent } from '../NativeCameraView'
 
 export interface ReadonlyFrameProcessor {
   frameProcessor: (frame: Frame) => void
@@ -317,11 +317,11 @@ export interface CameraProps extends ViewProps {
    */
   onShutter?: (event: OnShutterEvent) => void
   /**
-   * Called whenever the output orientation changed.
+   * Called whenever the preview- or output-orientation changed.
    *
    * @see See ["Orientation"](https://react-native-vision-camera.com/docs/guides/orientation)
    */
-  onOutputOrientationChanged?: (outputOrientation: Orientation) => void
+  onOrientationChanged?: (orientations: OutputOrientationChangedEvent) => void
   /**
    * A worklet which will be called for every frame the Camera "sees".
    *


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Orientation changed event now holds both `outputOrientation` and `previewOrientation`.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
