### PR TITLE
chore: Split `CameraSession` into multiple files

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -1,0 +1,332 @@
+package com.mrousavy.camera.core
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.util.Range
+import android.util.Size
+import androidx.annotation.OptIn
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.CameraState
+import androidx.camera.core.DynamicRange
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.MirrorMode
+import androidx.camera.core.Preview
+import androidx.camera.core.TorchState
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.extensions.ExtensionMode
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.video.Recorder
+import androidx.camera.video.VideoCapture
+import androidx.lifecycle.Lifecycle
+import com.mrousavy.camera.core.extensions.byId
+import com.mrousavy.camera.core.extensions.forSize
+import com.mrousavy.camera.core.extensions.id
+import com.mrousavy.camera.core.extensions.isSDR
+import com.mrousavy.camera.core.extensions.setTargetFrameRate
+import com.mrousavy.camera.core.extensions.toCameraError
+import com.mrousavy.camera.core.extensions.withExtension
+import com.mrousavy.camera.core.types.CameraDeviceFormat
+import com.mrousavy.camera.core.types.Torch
+import com.mrousavy.camera.core.types.VideoStabilizationMode
+import kotlin.math.roundToInt
+
+internal fun CameraSession.getTargetFpsRange(configuration: CameraConfiguration): Range<Int>? {
+  val fps = configuration.fps ?: return null
+  return if (configuration.enableLowLightBoost) {
+    Range(fps / 2, fps)
+  } else {
+    Range(fps, fps)
+  }
+}
+
+internal fun CameraSession.assertFormatRequirement(
+  propName: String,
+  format: CameraDeviceFormat?,
+  throwIfNotMet: CameraError,
+  requirement: (format: CameraDeviceFormat) -> Boolean
+) {
+  if (format == null) {
+    // we need a format for this to work.
+    throw PropRequiresFormatToBeNonNullError(propName)
+  }
+  val isSupported = requirement(format)
+  if (!isSupported) {
+    throw throwIfNotMet
+  }
+}
+
+@OptIn(ExperimentalGetImage::class)
+@SuppressLint("RestrictedApi")
+@Suppress("LiftReturnOrAssignment")
+internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) {
+  Log.i(CameraSession.TAG, "Creating new Outputs for Camera #${configuration.cameraId}...")
+  val fpsRange = getTargetFpsRange(configuration)
+  val format = configuration.format
+
+  Log.i(CameraSession.TAG, "Using FPS Range: $fpsRange")
+
+  // 1. Preview
+  val previewConfig = configuration.preview as? CameraConfiguration.Output.Enabled<CameraConfiguration.Preview>
+  if (previewConfig != null) {
+    Log.i(CameraSession.TAG, "Creating Preview output...")
+    val preview = Preview.Builder().also { preview ->
+      // Configure Preview Output
+      if (configuration.videoStabilizationMode.isAtLeast(VideoStabilizationMode.CINEMATIC)) {
+        assertFormatRequirement("videoStabilizationMode", format, InvalidVideoStabilizationMode(configuration.videoStabilizationMode)) {
+          it.videoStabilizationModes.contains(configuration.videoStabilizationMode)
+        }
+        preview.setPreviewStabilizationEnabled(true)
+      }
+      if (fpsRange != null) {
+        assertFormatRequirement("fps", format, InvalidFpsError(fpsRange.upper)) {
+          fpsRange.lower >= it.minFps && fpsRange.upper <= it.maxFps
+        }
+        preview.setTargetFrameRate(fpsRange)
+      }
+    }.build()
+    preview.setSurfaceProvider(previewConfig.config.surfaceProvider)
+    previewOutput = preview
+  } else {
+    previewOutput = null
+  }
+
+  // 2. Image Capture
+  val photoConfig = configuration.photo as? CameraConfiguration.Output.Enabled<CameraConfiguration.Photo>
+  if (photoConfig != null) {
+    Log.i(CameraSession.TAG, "Creating Photo output...")
+    val photo = ImageCapture.Builder().also { photo ->
+      // Configure Photo Output
+      photo.setCaptureMode(photoConfig.config.photoQualityBalance.toCaptureMode())
+      if (format != null) {
+        Log.i(CameraSession.TAG, "Photo size: ${format.photoSize}")
+        val resolutionSelector = ResolutionSelector.Builder()
+          .forSize(format.photoSize)
+          .setAllowedResolutionMode(ResolutionSelector.PREFER_HIGHER_RESOLUTION_OVER_CAPTURE_RATE)
+          .build()
+        photo.setResolutionSelector(resolutionSelector)
+      }
+    }.build()
+    photoOutput = photo
+  } else {
+    photoOutput = null
+  }
+
+  // 3. Video Capture
+  val videoConfig = configuration.video as? CameraConfiguration.Output.Enabled<CameraConfiguration.Video>
+  if (videoConfig != null) {
+    Log.i(CameraSession.TAG, "Creating Video output...")
+    val currentRecorder = recorderOutput
+    val recorder = if (recording != null && currentRecorder != null) {
+      // If we are currently recording, then don't re-create the recorder instance.
+      // Instead, re-use it so we don't cancel the active recording.
+      Log.i(CameraSession.TAG, "Re-using active Recorder because we are currently recording...")
+      currentRecorder
+    } else {
+      // We are currently not recording, so we can re-create a recorder instance if needed.
+      Log.i(CameraSession.TAG, "Creating new Recorder...")
+      Recorder.Builder().also { recorder ->
+        configuration.format?.let { format ->
+          recorder.setQualitySelector(format.videoQualitySelector)
+        }
+        // TODO: Make videoBitRate a Camera Prop
+        // video.setTargetVideoEncodingBitRate()
+      }.build()
+    }
+
+    val video = VideoCapture.Builder(recorder).also { video ->
+      // Configure Video Output
+      video.setMirrorMode(MirrorMode.MIRROR_MODE_ON_FRONT_ONLY)
+      if (configuration.videoStabilizationMode.isAtLeast(VideoStabilizationMode.STANDARD)) {
+        assertFormatRequirement("videoStabilizationMode", format, InvalidVideoStabilizationMode(configuration.videoStabilizationMode)) {
+          it.videoStabilizationModes.contains(configuration.videoStabilizationMode)
+        }
+        video.setVideoStabilizationEnabled(true)
+      }
+      if (fpsRange != null) {
+        assertFormatRequirement("fps", format, InvalidFpsError(fpsRange.upper)) {
+          fpsRange.lower >= it.minFps &&
+            fpsRange.upper <= it.maxFps
+        }
+        video.setTargetFrameRate(fpsRange)
+      }
+      if (videoConfig.config.enableHdr) {
+        assertFormatRequirement("videoHdr", format, InvalidVideoHdrError()) { it.supportsVideoHdr }
+        video.setDynamicRange(DynamicRange.HDR_UNSPECIFIED_10_BIT)
+      }
+      if (format != null) {
+        Log.i(CameraSession.TAG, "Video size: ${format.videoSize}")
+        val resolutionSelector = ResolutionSelector.Builder()
+          .forSize(format.videoSize)
+          .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
+          .build()
+        video.setResolutionSelector(resolutionSelector)
+      }
+    }.build()
+    videoOutput = video
+    recorderOutput = recorder
+  } else {
+    videoOutput = null
+    recorderOutput = null
+  }
+
+  // 4. Frame Processor
+  val frameProcessorConfig = configuration.frameProcessor as? CameraConfiguration.Output.Enabled<CameraConfiguration.FrameProcessor>
+  if (frameProcessorConfig != null) {
+    val pixelFormat = frameProcessorConfig.config.pixelFormat
+    Log.i(CameraSession.TAG, "Creating $pixelFormat Frame Processor output...")
+    val analyzer = ImageAnalysis.Builder().also { analysis ->
+      analysis.setBackpressureStrategy(ImageAnalysis.STRATEGY_BLOCK_PRODUCER)
+      analysis.setOutputImageFormat(pixelFormat.toImageAnalysisFormat())
+      if (fpsRange != null) {
+        assertFormatRequirement("fps", format, InvalidFpsError(fpsRange.upper)) {
+          fpsRange.lower >= it.minFps &&
+            fpsRange.upper <= it.maxFps
+        }
+        analysis.setTargetFrameRate(fpsRange)
+      }
+      if (format != null) {
+        Log.i(CameraSession.TAG, "Frame Processor size: ${format.videoSize}")
+        val resolutionSelector = ResolutionSelector.Builder()
+          .forSize(format.videoSize)
+          .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
+          .build()
+        analysis.setResolutionSelector(resolutionSelector)
+      }
+    }.build()
+    val pipeline = FrameProcessorPipeline(callback)
+    analyzer.setAnalyzer(CameraQueues.videoQueue.executor, pipeline)
+    frameProcessorOutput = analyzer
+  } else {
+    frameProcessorOutput = null
+  }
+
+  // 5. Code Scanner
+  val codeScannerConfig = configuration.codeScanner as? CameraConfiguration.Output.Enabled<CameraConfiguration.CodeScanner>
+  if (codeScannerConfig != null) {
+    Log.i(CameraSession.TAG, "Creating CodeScanner output...")
+    val analyzer = ImageAnalysis.Builder().also { analysis ->
+      val targetSize = Size(1280, 720)
+      val resolutionSelector = ResolutionSelector.Builder().forSize(targetSize).build()
+      analysis.setResolutionSelector(resolutionSelector)
+    }.build()
+    val pipeline = CodeScannerPipeline(codeScannerConfig.config, callback)
+    analyzer.setAnalyzer(CameraQueues.analyzerExecutor, pipeline)
+    codeScannerOutput = analyzer
+  } else {
+    codeScannerOutput = null
+  }
+  Log.i(CameraSession.TAG, "Successfully created new Outputs for Camera #${configuration.cameraId}!")
+}
+
+@SuppressLint("RestrictedApi")
+internal suspend fun CameraSession.configureCamera(provider: ProcessCameraProvider, configuration: CameraConfiguration) {
+  Log.i(CameraSession.TAG, "Binding Camera #${configuration.cameraId}...")
+  checkCameraPermission()
+
+  // Outputs
+  val useCases = listOfNotNull(previewOutput, photoOutput, videoOutput, frameProcessorOutput, codeScannerOutput)
+  if (useCases.isEmpty()) {
+    throw NoOutputsError()
+  }
+
+  // Input
+  val cameraId = configuration.cameraId ?: throw NoCameraDeviceError()
+  var cameraSelector = CameraSelector.Builder().byId(cameraId).build()
+
+  // Wrap input with a vendor extension if needed (see https://developer.android.com/media/camera/camera-extensions)
+  val isStreamingHDR = useCases.any { !it.currentConfig.dynamicRange.isSDR }
+  val needsImageAnalysis = codeScannerOutput != null || frameProcessorOutput != null
+  val photoOptions = configuration.photo as? CameraConfiguration.Output.Enabled<CameraConfiguration.Photo>
+  val enableHdrExtension = photoOptions != null && photoOptions.config.enableHdr
+  if (enableHdrExtension) {
+    if (isStreamingHDR) {
+      // extensions don't work if a camera stream is running at 10-bit HDR.
+      throw PhotoHdrAndVideoHdrNotSupportedSimultaneously()
+    }
+    // Load HDR Vendor extension (HDR only applies to image capture)
+    cameraSelector = cameraSelector.withExtension(context, provider, needsImageAnalysis, ExtensionMode.HDR, "HDR")
+  }
+  if (configuration.enableLowLightBoost) {
+    if (isStreamingHDR) {
+      // extensions don't work if a camera stream is running at 10-bit HDR.
+      throw LowLightBoostNotSupportedWithHdr()
+    }
+    if (enableHdrExtension) {
+      // low-light boost does not work when another HDR extension is already applied
+      throw LowLightBoostNotSupportedWithHdr()
+    }
+    // Load night mode Vendor extension (only applies to image capture)
+    cameraSelector = cameraSelector.withExtension(context, provider, needsImageAnalysis, ExtensionMode.NIGHT, "NIGHT")
+  }
+
+  // Unbind all currently bound use-cases before rebinding
+  if (currentUseCases.isNotEmpty()) {
+    Log.i(CameraSession.TAG, "Unbinding ${currentUseCases.size} use-cases for Camera #${camera?.cameraInfo?.id}...")
+    provider.unbind(*currentUseCases.toTypedArray())
+  }
+
+  // Bind it all together (must be on UI Thread)
+  Log.i(CameraSession.TAG, "Binding ${useCases.size} use-cases...")
+  camera = provider.bindToLifecycle(this, cameraSelector, *useCases.toTypedArray())
+
+  // Update currentUseCases for next unbind
+  currentUseCases = useCases
+
+  // Listen to Camera events
+  var lastState = CameraState.Type.OPENING
+  camera!!.cameraInfo.cameraState.observe(this) { state ->
+    Log.i(CameraSession.TAG, "Camera State: ${state.type} (has error: ${state.error != null})")
+
+    if (state.type == CameraState.Type.OPEN && state.type != lastState) {
+      // Camera has now been initialized!
+      callback.onInitialized()
+      lastState = state.type
+    }
+
+    val error = state.error
+    if (error != null) {
+      // A Camera error occurred!
+      callback.onError(error.toCameraError())
+    }
+  }
+  Log.i(CameraSession.TAG, "Successfully bound Camera #${configuration.cameraId}!")
+}
+
+internal fun CameraSession.configureSideProps(config: CameraConfiguration) {
+  val camera = camera ?: throw CameraNotReadyError()
+
+  // Zoom
+  val currentZoom = camera.cameraInfo.zoomState.value?.zoomRatio
+  if (currentZoom != config.zoom) {
+    camera.cameraControl.setZoomRatio(config.zoom)
+  }
+
+  // Torch
+  val currentTorch = camera.cameraInfo.torchState.value == TorchState.ON
+  val newTorch = config.torch == Torch.ON
+  if (currentTorch != newTorch) {
+    if (newTorch && !camera.cameraInfo.hasFlashUnit()) {
+      throw FlashUnavailableError()
+    }
+    camera.cameraControl.enableTorch(newTorch)
+  }
+
+  // Exposure
+  val currentExposureCompensation = camera.cameraInfo.exposureState.exposureCompensationIndex
+  val exposureCompensation = config.exposure?.roundToInt() ?: 0
+  if (currentExposureCompensation != exposureCompensation) {
+    camera.cameraControl.setExposureCompensationIndex(exposureCompensation)
+  }
+}
+
+internal fun CameraSession.configureIsActive(config: CameraConfiguration) {
+  if (config.isActive) {
+    lifecycleRegistry.currentState = Lifecycle.State.STARTED
+    lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+  } else {
+    lifecycleRegistry.currentState = Lifecycle.State.STARTED
+    lifecycleRegistry.currentState = Lifecycle.State.CREATED
+  }
+}

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -32,7 +32,7 @@ import com.mrousavy.camera.core.types.Torch
 import com.mrousavy.camera.core.types.VideoStabilizationMode
 import kotlin.math.roundToInt
 
-internal fun CameraSession.getTargetFpsRange(configuration: CameraConfiguration): Range<Int>? {
+internal fun getTargetFpsRange(configuration: CameraConfiguration): Range<Int>? {
   val fps = configuration.fps ?: return null
   return if (configuration.enableLowLightBoost) {
     Range(fps / 2, fps)
@@ -41,7 +41,7 @@ internal fun CameraSession.getTargetFpsRange(configuration: CameraConfiguration)
   }
 }
 
-internal fun CameraSession.assertFormatRequirement(
+internal fun assertFormatRequirement(
   propName: String,
   format: CameraDeviceFormat?,
   throwIfNotMet: CameraError,

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Focus.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Focus.kt
@@ -1,0 +1,31 @@
+package com.mrousavy.camera.core
+
+import android.annotation.SuppressLint
+import android.util.Log
+import androidx.camera.core.CameraControl
+import androidx.camera.core.FocusMeteringAction
+import androidx.camera.core.MeteringPoint
+import com.mrousavy.camera.core.extensions.await
+
+@SuppressLint("RestrictedApi")
+suspend fun CameraSession.focus(meteringPoint: MeteringPoint) {
+  val camera = camera ?: throw CameraNotReadyError()
+
+  val action = FocusMeteringAction.Builder(meteringPoint).build()
+  if (!camera.cameraInfo.isFocusMeteringSupported(action)) {
+    throw FocusNotSupportedError()
+  }
+
+  try {
+    Log.i(CameraSession.TAG, "Focusing to ${action.meteringPointsAf.joinToString { "(${it.x}, ${it.y})" }}...")
+    val future = camera.cameraControl.startFocusAndMetering(action)
+    val result = future.await(CameraQueues.cameraExecutor)
+    if (result.isFocusSuccessful) {
+      Log.i(CameraSession.TAG, "Focused successfully!")
+    } else {
+      Log.i(CameraSession.TAG, "Focus failed.")
+    }
+  } catch (e: CameraControl.OperationCanceledException) {
+    throw FocusCanceledError()
+  }
+}

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Photo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Photo.kt
@@ -1,0 +1,38 @@
+package com.mrousavy.camera.core
+
+import android.media.AudioManager
+import android.util.Log
+import com.mrousavy.camera.core.extensions.takePicture
+import com.mrousavy.camera.core.types.Flash
+import com.mrousavy.camera.core.types.Orientation
+import com.mrousavy.camera.core.utils.FileUtils
+
+suspend fun CameraSession.takePhoto(flash: Flash, enableShutterSound: Boolean): Photo {
+  val camera = camera ?: throw CameraNotReadyError()
+  val photoOutput = photoOutput ?: throw PhotoNotEnabledError()
+
+  if (flash != Flash.OFF && !camera.cameraInfo.hasFlashUnit()) {
+    throw FlashUnavailableError()
+  }
+
+  photoOutput.flashMode = flash.toFlashMode()
+  val enableShutterSoundActual = getEnableShutterSoundActual(enableShutterSound)
+
+  val photoFile = photoOutput.takePicture(context, enableShutterSoundActual, metadataProvider, callback, CameraQueues.cameraExecutor)
+  val isMirrored = photoFile.metadata.isReversedHorizontal
+
+  val size = FileUtils.getImageSize(photoFile.uri.path)
+  val rotation = photoOutput.targetRotation
+  val orientation = Orientation.fromSurfaceRotation(rotation)
+
+  return Photo(photoFile.uri.path, size.width, size.height, orientation, isMirrored)
+}
+
+private fun CameraSession.getEnableShutterSoundActual(enable: Boolean): Boolean {
+  if (enable && audioManager.ringerMode != AudioManager.RINGER_MODE_NORMAL) {
+    Log.i(CameraSession.TAG, "Ringer mode is silent (${audioManager.ringerMode}), disabling shutter sound...")
+    return false
+  }
+
+  return enable
+}

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Video.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Video.kt
@@ -1,0 +1,106 @@
+package com.mrousavy.camera.core
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.util.Size
+import androidx.annotation.OptIn
+import androidx.camera.video.ExperimentalPersistentRecording
+import androidx.camera.video.FileOutputOptions
+import androidx.camera.video.VideoRecordEvent
+import com.mrousavy.camera.core.extensions.getCameraError
+import com.mrousavy.camera.core.types.RecordVideoOptions
+import com.mrousavy.camera.core.types.Video
+import com.mrousavy.camera.core.utils.FileUtils
+
+@OptIn(ExperimentalPersistentRecording::class)
+@SuppressLint("MissingPermission", "RestrictedApi")
+fun CameraSession.startRecording(
+  enableAudio: Boolean,
+  options: RecordVideoOptions,
+  callback: (video: Video) -> Unit,
+  onError: (error: CameraError) -> Unit
+) {
+  if (camera == null) throw CameraNotReadyError()
+  if (recording != null) throw RecordingInProgressError()
+  val videoOutput = videoOutput ?: throw VideoNotEnabledError()
+
+  val file = FileUtils.createTempFile(context, options.fileType.toExtension())
+  val outputOptions = FileOutputOptions.Builder(file).also { outputOptions ->
+    metadataProvider.location?.let { location ->
+      Log.i(CameraSession.TAG, "Setting Video Location to ${location.latitude}, ${location.longitude}...")
+      outputOptions.setLocation(location)
+    }
+  }.build()
+  var pendingRecording = videoOutput.output.prepareRecording(context, outputOptions)
+  if (enableAudio) {
+    checkMicrophonePermission()
+    pendingRecording = pendingRecording.withAudioEnabled()
+  }
+  pendingRecording = pendingRecording.asPersistentRecording()
+
+  val size = videoOutput.attachedSurfaceResolution ?: Size(0, 0)
+  isRecordingCanceled = false
+  recording = pendingRecording.start(CameraQueues.cameraExecutor) { event ->
+    when (event) {
+      is VideoRecordEvent.Start -> Log.i(CameraSession.TAG, "Recording started!")
+
+      is VideoRecordEvent.Resume -> Log.i(CameraSession.TAG, "Recording resumed!")
+
+      is VideoRecordEvent.Pause -> Log.i(CameraSession.TAG, "Recording paused!")
+
+      is VideoRecordEvent.Status -> Log.i(CameraSession.TAG, "Status update! Recorded ${event.recordingStats.numBytesRecorded} bytes.")
+
+      is VideoRecordEvent.Finalize -> {
+        if (isRecordingCanceled) {
+          Log.i(CameraSession.TAG, "Recording was canceled, deleting file..")
+          onError(RecordingCanceledError())
+          try {
+            file.delete()
+          } catch (e: Throwable) {
+            this.callback.onError(FileIOError(e))
+          }
+          return@start
+        }
+
+        Log.i(CameraSession.TAG, "Recording stopped!")
+        val error = event.getCameraError()
+        if (error != null) {
+          if (error.wasVideoRecorded) {
+            Log.e(CameraSession.TAG, "Video Recorder encountered an error, but the video was recorded anyways.", error)
+          } else {
+            Log.e(CameraSession.TAG, "Video Recorder encountered a fatal error!", error)
+            onError(error)
+            return@start
+          }
+        }
+        val durationMs = event.recordingStats.recordedDurationNanos / 1_000_000
+        Log.i(CameraSession.TAG, "Successfully completed video recording! Captured ${durationMs.toDouble() / 1_000.0} seconds.")
+        val path = event.outputResults.outputUri.path ?: throw UnknownRecorderError(false, null)
+        val video = Video(path, durationMs, size)
+        callback(video)
+      }
+    }
+  }
+}
+
+fun CameraSession.stopRecording() {
+  val recording = recording ?: throw NoRecordingInProgressError()
+
+  recording.stop()
+  this.recording = null
+}
+
+fun CameraSession.cancelRecording() {
+  isRecordingCanceled = true
+  stopRecording()
+}
+
+fun CameraSession.pauseRecording() {
+  val recording = recording ?: throw NoRecordingInProgressError()
+  recording.pause()
+}
+
+fun CameraSession.resumeRecording() {
+  val recording = recording ?: throw NoRecordingInProgressError()
+  recording.resume()
+}

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -1,39 +1,20 @@
 package com.mrousavy.camera.core
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
-import android.graphics.BitmapFactory
 import android.media.AudioManager
 import android.util.Log
-import android.util.Range
-import android.util.Size
 import androidx.annotation.MainThread
-import androidx.annotation.OptIn
 import androidx.camera.core.Camera
-import androidx.camera.core.CameraControl
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.CameraState
-import androidx.camera.core.DynamicRange
-import androidx.camera.core.ExperimentalGetImage
-import androidx.camera.core.FocusMeteringAction
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageCapture
-import androidx.camera.core.MeteringPoint
-import androidx.camera.core.MirrorMode
 import androidx.camera.core.Preview
-import androidx.camera.core.TorchState
 import androidx.camera.core.UseCase
-import androidx.camera.core.resolutionselector.ResolutionSelector
-import androidx.camera.extensions.ExtensionMode
 import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.video.ExperimentalPersistentRecording
-import androidx.camera.video.FileOutputOptions
 import androidx.camera.video.Recorder
 import androidx.camera.video.Recording
 import androidx.camera.video.VideoCapture
-import androidx.camera.video.VideoRecordEvent
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -42,67 +23,50 @@ import androidx.lifecycle.LifecycleRegistry
 import com.facebook.react.bridge.UiThreadUtil
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.mrousavy.camera.core.extensions.await
-import com.mrousavy.camera.core.extensions.byId
-import com.mrousavy.camera.core.extensions.forSize
-import com.mrousavy.camera.core.extensions.getCameraError
-import com.mrousavy.camera.core.extensions.id
-import com.mrousavy.camera.core.extensions.isSDR
-import com.mrousavy.camera.core.extensions.setTargetFrameRate
-import com.mrousavy.camera.core.extensions.takePicture
-import com.mrousavy.camera.core.extensions.toCameraError
-import com.mrousavy.camera.core.extensions.withExtension
-import com.mrousavy.camera.core.types.CameraDeviceFormat
-import com.mrousavy.camera.core.types.Flash
 import com.mrousavy.camera.core.types.Orientation
-import com.mrousavy.camera.core.types.RecordVideoOptions
 import com.mrousavy.camera.core.types.ShutterType
-import com.mrousavy.camera.core.types.Torch
-import com.mrousavy.camera.core.types.Video
-import com.mrousavy.camera.core.types.VideoStabilizationMode
-import com.mrousavy.camera.core.utils.FileUtils
 import com.mrousavy.camera.core.utils.runOnUiThread
 import com.mrousavy.camera.frameprocessors.Frame
 import java.io.Closeable
-import kotlin.math.roundToInt
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-class CameraSession(private val context: Context, private val callback: Callback) :
+class CameraSession(internal val context: Context, internal val callback: Callback) :
   Closeable,
   LifecycleOwner,
   OrientationManager.Callback {
   companion object {
-    private const val TAG = "CameraSession"
+    internal const val TAG = "CameraSession"
   }
 
   // Camera Configuration
-  private var configuration: CameraConfiguration? = null
-  private val cameraProvider = ProcessCameraProvider.getInstance(context)
-  private var camera: Camera? = null
+  internal var configuration: CameraConfiguration? = null
+  internal val cameraProvider = ProcessCameraProvider.getInstance(context)
+  internal var camera: Camera? = null
 
   // Camera Outputs
-  private var previewOutput: Preview? = null
-  private var photoOutput: ImageCapture? = null
-  private var videoOutput: VideoCapture<Recorder>? = null
-  private var frameProcessorOutput: ImageAnalysis? = null
-  private var codeScannerOutput: ImageAnalysis? = null
-  private var currentUseCases: List<UseCase> = emptyList()
+  internal var previewOutput: Preview? = null
+  internal var photoOutput: ImageCapture? = null
+  internal var videoOutput: VideoCapture<Recorder>? = null
+  internal var frameProcessorOutput: ImageAnalysis? = null
+  internal var codeScannerOutput: ImageAnalysis? = null
+  internal var currentUseCases: List<UseCase> = emptyList()
 
   // Camera Outputs State
-  private val metadataProvider = MetadataProvider(context)
-  private val orientationManager = OrientationManager(context, this)
-  private var recorderOutput: Recorder? = null
+  internal val metadataProvider = MetadataProvider(context)
+  internal val orientationManager = OrientationManager(context, this)
+  internal var recorderOutput: Recorder? = null
 
   // Camera State
-  private val mutex = Mutex()
-  private var isDestroyed = false
-  private val lifecycleRegistry = LifecycleRegistry(this)
-  private var recording: Recording? = null
-  private var isRecordingCanceled = false
-  private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+  internal val mutex = Mutex()
+  internal var isDestroyed = false
+  internal val lifecycleRegistry = LifecycleRegistry(this)
+  internal var recording: Recording? = null
+  internal var isRecordingCanceled = false
+  internal val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
   // Threading
-  private val mainExecutor = ContextCompat.getMainExecutor(context)
+  internal val mainExecutor = ContextCompat.getMainExecutor(context)
 
   // Orientation
   val outputOrientation: Orientation
@@ -202,315 +166,13 @@ class CameraSession(private val context: Context, private val callback: Callback
     }
   }
 
-  private fun checkCameraPermission() {
+  internal fun checkCameraPermission() {
     val status = ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
     if (status != PackageManager.PERMISSION_GRANTED) throw CameraPermissionError()
   }
-  private fun checkMicrophonePermission() {
+  internal fun checkMicrophonePermission() {
     val status = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO)
     if (status != PackageManager.PERMISSION_GRANTED) throw MicrophonePermissionError()
-  }
-
-  private fun getTargetFpsRange(configuration: CameraConfiguration): Range<Int>? {
-    val fps = configuration.fps ?: return null
-    return if (configuration.enableLowLightBoost) {
-      Range(fps / 2, fps)
-    } else {
-      Range(fps, fps)
-    }
-  }
-
-  private fun assertFormatRequirement(
-    propName: String,
-    format: CameraDeviceFormat?,
-    throwIfNotMet: CameraError,
-    requirement: (format: CameraDeviceFormat) -> Boolean
-  ) {
-    if (format == null) {
-      // we need a format for this to work.
-      throw PropRequiresFormatToBeNonNullError(propName)
-    }
-    val isSupported = requirement(format)
-    if (!isSupported) {
-      throw throwIfNotMet
-    }
-  }
-
-  @OptIn(ExperimentalGetImage::class)
-  @SuppressLint("RestrictedApi")
-  @Suppress("LiftReturnOrAssignment")
-  private fun configureOutputs(configuration: CameraConfiguration) {
-    Log.i(TAG, "Creating new Outputs for Camera #${configuration.cameraId}...")
-    val fpsRange = getTargetFpsRange(configuration)
-    val format = configuration.format
-
-    Log.i(TAG, "Using FPS Range: $fpsRange")
-
-    // 1. Preview
-    val previewConfig = configuration.preview as? CameraConfiguration.Output.Enabled<CameraConfiguration.Preview>
-    if (previewConfig != null) {
-      Log.i(TAG, "Creating Preview output...")
-      val preview = Preview.Builder().also { preview ->
-        // Configure Preview Output
-        if (configuration.videoStabilizationMode.isAtLeast(VideoStabilizationMode.CINEMATIC)) {
-          assertFormatRequirement("videoStabilizationMode", format, InvalidVideoStabilizationMode(configuration.videoStabilizationMode)) {
-            it.videoStabilizationModes.contains(configuration.videoStabilizationMode)
-          }
-          preview.setPreviewStabilizationEnabled(true)
-        }
-        if (fpsRange != null) {
-          assertFormatRequirement("fps", format, InvalidFpsError(fpsRange.upper)) {
-            fpsRange.lower >= it.minFps && fpsRange.upper <= it.maxFps
-          }
-          preview.setTargetFrameRate(fpsRange)
-        }
-      }.build()
-      preview.setSurfaceProvider(previewConfig.config.surfaceProvider)
-      previewOutput = preview
-    } else {
-      previewOutput = null
-    }
-
-    // 2. Image Capture
-    val photoConfig = configuration.photo as? CameraConfiguration.Output.Enabled<CameraConfiguration.Photo>
-    if (photoConfig != null) {
-      Log.i(TAG, "Creating Photo output...")
-      val photo = ImageCapture.Builder().also { photo ->
-        // Configure Photo Output
-        photo.setCaptureMode(photoConfig.config.photoQualityBalance.toCaptureMode())
-        if (format != null) {
-          Log.i(TAG, "Photo size: ${format.photoSize}")
-          val resolutionSelector = ResolutionSelector.Builder()
-            .forSize(format.photoSize)
-            .setAllowedResolutionMode(ResolutionSelector.PREFER_HIGHER_RESOLUTION_OVER_CAPTURE_RATE)
-            .build()
-          photo.setResolutionSelector(resolutionSelector)
-        }
-      }.build()
-      photoOutput = photo
-    } else {
-      photoOutput = null
-    }
-
-    // 3. Video Capture
-    val videoConfig = configuration.video as? CameraConfiguration.Output.Enabled<CameraConfiguration.Video>
-    if (videoConfig != null) {
-      Log.i(TAG, "Creating Video output...")
-      val currentRecorder = recorderOutput
-      val recorder = if (recording != null && currentRecorder != null) {
-        // If we are currently recording, then don't re-create the recorder instance.
-        // Instead, re-use it so we don't cancel the active recording.
-        Log.i(TAG, "Re-using active Recorder because we are currently recording...")
-        currentRecorder
-      } else {
-        // We are currently not recording, so we can re-create a recorder instance if needed.
-        Log.i(TAG, "Creating new Recorder...")
-        Recorder.Builder().also { recorder ->
-          configuration.format?.let { format ->
-            recorder.setQualitySelector(format.videoQualitySelector)
-          }
-          // TODO: Make videoBitRate a Camera Prop
-          // video.setTargetVideoEncodingBitRate()
-        }.build()
-      }
-
-      val video = VideoCapture.Builder(recorder).also { video ->
-        // Configure Video Output
-        video.setMirrorMode(MirrorMode.MIRROR_MODE_ON_FRONT_ONLY)
-        if (configuration.videoStabilizationMode.isAtLeast(VideoStabilizationMode.STANDARD)) {
-          assertFormatRequirement("videoStabilizationMode", format, InvalidVideoStabilizationMode(configuration.videoStabilizationMode)) {
-            it.videoStabilizationModes.contains(configuration.videoStabilizationMode)
-          }
-          video.setVideoStabilizationEnabled(true)
-        }
-        if (fpsRange != null) {
-          assertFormatRequirement("fps", format, InvalidFpsError(fpsRange.upper)) {
-            fpsRange.lower >= it.minFps &&
-              fpsRange.upper <= it.maxFps
-          }
-          video.setTargetFrameRate(fpsRange)
-        }
-        if (videoConfig.config.enableHdr) {
-          assertFormatRequirement("videoHdr", format, InvalidVideoHdrError()) { it.supportsVideoHdr }
-          video.setDynamicRange(DynamicRange.HDR_UNSPECIFIED_10_BIT)
-        }
-        if (format != null) {
-          Log.i(TAG, "Video size: ${format.videoSize}")
-          val resolutionSelector = ResolutionSelector.Builder()
-            .forSize(format.videoSize)
-            .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
-            .build()
-          video.setResolutionSelector(resolutionSelector)
-        }
-      }.build()
-      videoOutput = video
-      recorderOutput = recorder
-    } else {
-      videoOutput = null
-      recorderOutput = null
-    }
-
-    // 4. Frame Processor
-    val frameProcessorConfig = configuration.frameProcessor as? CameraConfiguration.Output.Enabled<CameraConfiguration.FrameProcessor>
-    if (frameProcessorConfig != null) {
-      val pixelFormat = frameProcessorConfig.config.pixelFormat
-      Log.i(TAG, "Creating $pixelFormat Frame Processor output...")
-      val analyzer = ImageAnalysis.Builder().also { analysis ->
-        analysis.setBackpressureStrategy(ImageAnalysis.STRATEGY_BLOCK_PRODUCER)
-        analysis.setOutputImageFormat(pixelFormat.toImageAnalysisFormat())
-        if (fpsRange != null) {
-          assertFormatRequirement("fps", format, InvalidFpsError(fpsRange.upper)) {
-            fpsRange.lower >= it.minFps &&
-              fpsRange.upper <= it.maxFps
-          }
-          analysis.setTargetFrameRate(fpsRange)
-        }
-        if (format != null) {
-          Log.i(TAG, "Frame Processor size: ${format.videoSize}")
-          val resolutionSelector = ResolutionSelector.Builder()
-            .forSize(format.videoSize)
-            .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
-            .build()
-          analysis.setResolutionSelector(resolutionSelector)
-        }
-      }.build()
-      val pipeline = FrameProcessorPipeline(callback)
-      analyzer.setAnalyzer(CameraQueues.videoQueue.executor, pipeline)
-      frameProcessorOutput = analyzer
-    } else {
-      frameProcessorOutput = null
-    }
-
-    // 5. Code Scanner
-    val codeScannerConfig = configuration.codeScanner as? CameraConfiguration.Output.Enabled<CameraConfiguration.CodeScanner>
-    if (codeScannerConfig != null) {
-      Log.i(TAG, "Creating CodeScanner output...")
-      val analyzer = ImageAnalysis.Builder().also { analysis ->
-        val targetSize = Size(1280, 720)
-        val resolutionSelector = ResolutionSelector.Builder().forSize(targetSize).build()
-        analysis.setResolutionSelector(resolutionSelector)
-      }.build()
-      val pipeline = CodeScannerPipeline(codeScannerConfig.config, callback)
-      analyzer.setAnalyzer(CameraQueues.analyzerExecutor, pipeline)
-      codeScannerOutput = analyzer
-    } else {
-      codeScannerOutput = null
-    }
-    Log.i(TAG, "Successfully created new Outputs for Camera #${configuration.cameraId}!")
-
-    // Update Orientation for all outputs
-    configureOrientation()
-  }
-
-  @SuppressLint("RestrictedApi")
-  private suspend fun configureCamera(provider: ProcessCameraProvider, configuration: CameraConfiguration) {
-    Log.i(TAG, "Binding Camera #${configuration.cameraId}...")
-    checkCameraPermission()
-
-    // Outputs
-    val useCases = listOfNotNull(previewOutput, photoOutput, videoOutput, frameProcessorOutput, codeScannerOutput)
-    if (useCases.isEmpty()) {
-      throw NoOutputsError()
-    }
-
-    // Input
-    val cameraId = configuration.cameraId ?: throw NoCameraDeviceError()
-    var cameraSelector = CameraSelector.Builder().byId(cameraId).build()
-
-    // Wrap input with a vendor extension if needed (see https://developer.android.com/media/camera/camera-extensions)
-    val isStreamingHDR = useCases.any { !it.currentConfig.dynamicRange.isSDR }
-    val needsImageAnalysis = codeScannerOutput != null || frameProcessorOutput != null
-    val photoOptions = configuration.photo as? CameraConfiguration.Output.Enabled<CameraConfiguration.Photo>
-    val enableHdrExtension = photoOptions != null && photoOptions.config.enableHdr
-    if (enableHdrExtension) {
-      if (isStreamingHDR) {
-        // extensions don't work if a camera stream is running at 10-bit HDR.
-        throw PhotoHdrAndVideoHdrNotSupportedSimultaneously()
-      }
-      // Load HDR Vendor extension (HDR only applies to image capture)
-      cameraSelector = cameraSelector.withExtension(context, provider, needsImageAnalysis, ExtensionMode.HDR, "HDR")
-    }
-    if (configuration.enableLowLightBoost) {
-      if (isStreamingHDR) {
-        // extensions don't work if a camera stream is running at 10-bit HDR.
-        throw LowLightBoostNotSupportedWithHdr()
-      }
-      if (enableHdrExtension) {
-        // low-light boost does not work when another HDR extension is already applied
-        throw LowLightBoostNotSupportedWithHdr()
-      }
-      // Load night mode Vendor extension (only applies to image capture)
-      cameraSelector = cameraSelector.withExtension(context, provider, needsImageAnalysis, ExtensionMode.NIGHT, "NIGHT")
-    }
-
-    // Unbind all currently bound use-cases before rebinding
-    if (currentUseCases.isNotEmpty()) {
-      Log.i(TAG, "Unbinding ${currentUseCases.size} use-cases for Camera #${camera?.cameraInfo?.id}...")
-      provider.unbind(*currentUseCases.toTypedArray())
-    }
-
-    // Bind it all together (must be on UI Thread)
-    Log.i(TAG, "Binding ${useCases.size} use-cases...")
-    camera = provider.bindToLifecycle(this, cameraSelector, *useCases.toTypedArray())
-
-    // Update currentUseCases for next unbind
-    currentUseCases = useCases
-
-    // Listen to Camera events
-    var lastState = CameraState.Type.OPENING
-    camera!!.cameraInfo.cameraState.observe(this) { state ->
-      Log.i(TAG, "Camera State: ${state.type} (has error: ${state.error != null})")
-
-      if (state.type == CameraState.Type.OPEN && state.type != lastState) {
-        // Camera has now been initialized!
-        callback.onInitialized()
-        lastState = state.type
-      }
-
-      val error = state.error
-      if (error != null) {
-        // A Camera error occurred!
-        callback.onError(error.toCameraError())
-      }
-    }
-    Log.i(TAG, "Successfully bound Camera #${configuration.cameraId}!")
-  }
-
-  private fun configureSideProps(config: CameraConfiguration) {
-    val camera = camera ?: throw CameraNotReadyError()
-
-    // Zoom
-    val currentZoom = camera.cameraInfo.zoomState.value?.zoomRatio
-    if (currentZoom != config.zoom) {
-      camera.cameraControl.setZoomRatio(config.zoom)
-    }
-
-    // Torch
-    val currentTorch = camera.cameraInfo.torchState.value == TorchState.ON
-    val newTorch = config.torch == Torch.ON
-    if (currentTorch != newTorch) {
-      if (newTorch && !camera.cameraInfo.hasFlashUnit()) {
-        throw FlashUnavailableError()
-      }
-      camera.cameraControl.enableTorch(newTorch)
-    }
-
-    // Exposure
-    val currentExposureCompensation = camera.cameraInfo.exposureState.exposureCompensationIndex
-    val exposureCompensation = config.exposure?.roundToInt() ?: 0
-    if (currentExposureCompensation != exposureCompensation) {
-      camera.cameraControl.setExposureCompensationIndex(exposureCompensation)
-    }
-  }
-
-  private fun configureIsActive(config: CameraConfiguration) {
-    if (config.isActive) {
-      lifecycleRegistry.currentState = Lifecycle.State.STARTED
-      lifecycleRegistry.currentState = Lifecycle.State.RESUMED
-    } else {
-      lifecycleRegistry.currentState = Lifecycle.State.STARTED
-      lifecycleRegistry.currentState = Lifecycle.State.CREATED
-    }
   }
 
   private fun configureOrientation(config: CameraConfiguration) {
@@ -519,177 +181,19 @@ class CameraSession(private val context: Context, private val callback: Callback
 
   override fun onOutputOrientationChanged(outputOrientation: Orientation) {
     Log.i(TAG, "Output orientation changed! $outputOrientation")
-    configureOrientation()
+    photoOutput?.targetRotation = outputOrientation.toSurfaceRotation()
+    videoOutput?.targetRotation = outputOrientation.toSurfaceRotation()
+    frameProcessorOutput?.targetRotation = outputOrientation.toSurfaceRotation()
+    codeScannerOutput?.targetRotation = outputOrientation.toSurfaceRotation()
+
     callback.onOutputOrientationChanged(outputOrientation)
   }
 
   override fun onPreviewOrientationChanged(previewOrientation: Orientation) {
     Log.i(TAG, "Preview orientation changed! $previewOrientation")
-    configureOrientation()
+    previewOutput?.targetRotation = previewOrientation.toSurfaceRotation()
+
     callback.onPreviewOrientationChanged(previewOrientation)
-  }
-
-  private fun configureOrientation() {
-    orientationManager.previewOrientation.toSurfaceRotation().let { previewRotation ->
-      previewOutput?.targetRotation = previewRotation
-    }
-    orientationManager.outputOrientation.toSurfaceRotation().let { outputRotation ->
-      photoOutput?.targetRotation = outputRotation
-      videoOutput?.targetRotation = outputRotation
-      frameProcessorOutput?.targetRotation = outputRotation
-      codeScannerOutput?.targetRotation = outputRotation
-    }
-  }
-
-  suspend fun takePhoto(flash: Flash, enableShutterSound: Boolean): Photo {
-    val camera = camera ?: throw CameraNotReadyError()
-    val photoOutput = photoOutput ?: throw PhotoNotEnabledError()
-
-    if (flash != Flash.OFF && !camera.cameraInfo.hasFlashUnit()) {
-      throw FlashUnavailableError()
-    }
-
-    photoOutput.flashMode = flash.toFlashMode()
-    val enableShutterSoundActual = getEnableShutterSoundActual(enableShutterSound)
-
-    val photoFile = photoOutput.takePicture(context, enableShutterSoundActual, metadataProvider, callback, CameraQueues.cameraExecutor)
-    val isMirrored = photoFile.metadata.isReversedHorizontal
-
-    val bitmapOptions = BitmapFactory.Options().also {
-      it.inJustDecodeBounds = true
-    }
-    BitmapFactory.decodeFile(photoFile.uri.path, bitmapOptions)
-    val width = bitmapOptions.outWidth
-    val height = bitmapOptions.outHeight
-    val rotation = photoOutput.targetRotation
-    val orientation = Orientation.fromSurfaceRotation(rotation)
-
-    return Photo(photoFile.uri.path, width, height, orientation, isMirrored)
-  }
-
-  private fun getEnableShutterSoundActual(enable: Boolean): Boolean {
-    if (enable && audioManager.ringerMode != AudioManager.RINGER_MODE_NORMAL) {
-      Log.i(TAG, "Ringer mode is silent (${audioManager.ringerMode}), disabling shutter sound...")
-      return false
-    }
-
-    return enable
-  }
-
-  @OptIn(ExperimentalPersistentRecording::class)
-  @SuppressLint("MissingPermission", "RestrictedApi")
-  fun startRecording(
-    enableAudio: Boolean,
-    options: RecordVideoOptions,
-    callback: (video: Video) -> Unit,
-    onError: (error: CameraError) -> Unit
-  ) {
-    if (camera == null) throw CameraNotReadyError()
-    if (recording != null) throw RecordingInProgressError()
-    val videoOutput = videoOutput ?: throw VideoNotEnabledError()
-
-    val file = FileUtils.createTempFile(context, options.fileType.toExtension())
-    val outputOptions = FileOutputOptions.Builder(file).also { outputOptions ->
-      metadataProvider.location?.let { location ->
-        Log.i(TAG, "Setting Video Location to ${location.latitude}, ${location.longitude}...")
-        outputOptions.setLocation(location)
-      }
-    }.build()
-    var pendingRecording = videoOutput.output.prepareRecording(context, outputOptions)
-    if (enableAudio) {
-      checkMicrophonePermission()
-      pendingRecording = pendingRecording.withAudioEnabled()
-    }
-    pendingRecording = pendingRecording.asPersistentRecording()
-
-    val size = videoOutput.attachedSurfaceResolution ?: Size(0, 0)
-    isRecordingCanceled = false
-    recording = pendingRecording.start(CameraQueues.cameraExecutor) { event ->
-      when (event) {
-        is VideoRecordEvent.Start -> Log.i(TAG, "Recording started!")
-
-        is VideoRecordEvent.Resume -> Log.i(TAG, "Recording resumed!")
-
-        is VideoRecordEvent.Pause -> Log.i(TAG, "Recording paused!")
-
-        is VideoRecordEvent.Status -> Log.i(TAG, "Status update! Recorded ${event.recordingStats.numBytesRecorded} bytes.")
-
-        is VideoRecordEvent.Finalize -> {
-          if (isRecordingCanceled) {
-            Log.i(TAG, "Recording was canceled, deleting file..")
-            onError(RecordingCanceledError())
-            try {
-              file.delete()
-            } catch (e: Throwable) {
-              this.callback.onError(FileIOError(e))
-            }
-            return@start
-          }
-
-          Log.i(TAG, "Recording stopped!")
-          val error = event.getCameraError()
-          if (error != null) {
-            if (error.wasVideoRecorded) {
-              Log.e(TAG, "Video Recorder encountered an error, but the video was recorded anyways.", error)
-            } else {
-              Log.e(TAG, "Video Recorder encountered a fatal error!", error)
-              onError(error)
-              return@start
-            }
-          }
-          val durationMs = event.recordingStats.recordedDurationNanos / 1_000_000
-          Log.i(TAG, "Successfully completed video recording! Captured ${durationMs.toDouble() / 1_000.0} seconds.")
-          val path = event.outputResults.outputUri.path ?: throw UnknownRecorderError(false, null)
-          val video = Video(path, durationMs, size)
-          callback(video)
-        }
-      }
-    }
-  }
-
-  fun stopRecording() {
-    val recording = recording ?: throw NoRecordingInProgressError()
-
-    recording.stop()
-    this.recording = null
-  }
-
-  fun cancelRecording() {
-    isRecordingCanceled = true
-    stopRecording()
-  }
-
-  fun pauseRecording() {
-    val recording = recording ?: throw NoRecordingInProgressError()
-    recording.pause()
-  }
-
-  fun resumeRecording() {
-    val recording = recording ?: throw NoRecordingInProgressError()
-    recording.resume()
-  }
-
-  @SuppressLint("RestrictedApi")
-  suspend fun focus(meteringPoint: MeteringPoint) {
-    val camera = camera ?: throw CameraNotReadyError()
-
-    val action = FocusMeteringAction.Builder(meteringPoint).build()
-    if (!camera.cameraInfo.isFocusMeteringSupported(action)) {
-      throw FocusNotSupportedError()
-    }
-
-    try {
-      Log.i(TAG, "Focusing to ${action.meteringPointsAf.joinToString { "(${it.x}, ${it.y})" }}...")
-      val future = camera.cameraControl.startFocusAndMetering(action)
-      val result = future.await(CameraQueues.cameraExecutor)
-      if (result.isFocusSuccessful) {
-        Log.i(TAG, "Focused successfully!")
-      } else {
-        Log.i(TAG, "Focus failed.")
-      }
-    } catch (e: CameraControl.OperationCanceledException) {
-      throw FocusCanceledError()
-    }
   }
 
   interface Callback {

--- a/package/android/src/main/java/com/mrousavy/camera/core/utils/FileUtils.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/utils/FileUtils.kt
@@ -2,6 +2,8 @@ package com.mrousavy.camera.core.utils
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Size
 import java.io.File
 import java.io.FileOutputStream
 
@@ -16,6 +18,16 @@ class FileUtils {
       FileOutputStream(file).use { stream ->
         bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
       }
+    }
+
+    fun getImageSize(imagePath: String): Size {
+      val bitmapOptions = BitmapFactory.Options().also {
+        it.inJustDecodeBounds = true
+      }
+      BitmapFactory.decodeFile(imagePath, bitmapOptions)
+      val width = bitmapOptions.outWidth
+      val height = bitmapOptions.outHeight
+      return Size(width, height)
     }
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+Focus.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+Focus.kt
@@ -3,6 +3,7 @@ package com.mrousavy.camera.react
 import android.content.res.Resources
 import com.facebook.react.bridge.ReadableMap
 import com.mrousavy.camera.core.FocusRequiresPreviewError
+import com.mrousavy.camera.core.focus
 import com.mrousavy.camera.core.utils.runOnUiThreadAndWait
 
 suspend fun CameraView.focus(pointMap: ReadableMap) {

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+RecordVideo.kt
@@ -7,6 +7,11 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Callback
 import com.mrousavy.camera.core.CameraError
 import com.mrousavy.camera.core.MicrophonePermissionError
+import com.mrousavy.camera.core.cancelRecording
+import com.mrousavy.camera.core.pauseRecording
+import com.mrousavy.camera.core.resumeRecording
+import com.mrousavy.camera.core.startRecording
+import com.mrousavy.camera.core.stopRecording
 import com.mrousavy.camera.core.types.RecordVideoOptions
 import com.mrousavy.camera.core.types.Video
 import com.mrousavy.camera.react.utils.makeErrorMap

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+TakePhoto.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+TakePhoto.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
+import com.mrousavy.camera.core.takePhoto
 import com.mrousavy.camera.core.types.Flash
 
 private const val TAG = "CameraView.takePhoto"


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Avoids having a giant `CameraSession.kt` file. Extensions in Kotlin suck, but at least better than having a 700 lines file.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
