### PR TITLE
feat: Expose `Frame.matrix`

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -467,16 +467,16 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - SocketRocket (0.6.1)
-  - VisionCamera (4.1.0):
-    - VisionCamera/Core (= 4.1.0)
-    - VisionCamera/FrameProcessors (= 4.1.0)
-    - VisionCamera/React (= 4.1.0)
-  - VisionCamera/Core (4.1.0)
-  - VisionCamera/FrameProcessors (4.1.0):
+  - VisionCamera (4.2.0):
+    - VisionCamera/Core (= 4.2.0)
+    - VisionCamera/FrameProcessors (= 4.2.0)
+    - VisionCamera/React (= 4.2.0)
+  - VisionCamera/Core (4.2.0)
+  - VisionCamera/FrameProcessors (4.2.0):
     - React
     - React-callinvoker
     - react-native-worklets-core
-  - VisionCamera/React (4.1.0):
+  - VisionCamera/React (4.2.0):
     - React-Core
     - VisionCamera/FrameProcessors
   - Yoga (1.14.0)
@@ -708,9 +708,9 @@ SPEC CHECKSUMS:
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNVectorIcons: 23b6e11af4aaf104d169b1b0afa7e5cf96c676ce
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: fae8e97a3e62aad93367abdcce0b1350618004c3
+  VisionCamera: 36e26146e9080bd78c101dd904723e424d0983a3
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: 66976ac26c778d788a06e6c1bab624e6a1233cdd
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.11.3

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -109,6 +109,7 @@ extension CameraSession {
       // 2. Configure
       videoOutput.setSampleBufferDelegate(self, queue: CameraQueues.videoQueue)
       videoOutput.alwaysDiscardsLateVideoFrames = true
+      videoOutput.isMatrixDeliveryEnabled = true
       if isMirrored {
         // rotate by 180 deg and mirror the selfie camera so it behaves like the back camera.
         // we later need to flip it alongside the horizontal axis when recording videos with it.
@@ -159,11 +160,7 @@ extension CameraSession {
   // pragma MARK: Video Stabilization
   func configureVideoStabilization(configuration: CameraConfiguration) {
     for output in captureSession.outputs {
-      for connection in output.connections {
-        if connection.isVideoStabilizationSupported {
-          connection.preferredVideoStabilizationMode = configuration.videoStabilizationMode.toAVCaptureVideoStabilizationMode()
-        }
-      }
+      output.videoStabilizationMode = configuration.videoStabilizationMode
     }
   }
 

--- a/package/ios/Core/Extensions/AVCaptureOutput+isMatrixDeliveryEnabled.swift
+++ b/package/ios/Core/Extensions/AVCaptureOutput+isMatrixDeliveryEnabled.swift
@@ -1,0 +1,30 @@
+//
+//  AVCaptureOutput+isMatrixDeliveryEnabled.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 10.06.24.
+//
+
+import Foundation
+import AVFoundation
+
+extension AVCaptureOutput {
+  /**
+   Gets or sets whether camera-intrinstic matrix delivery is enabled for this video output.
+   */
+  var isMatrixDeliveryEnabled: Bool {
+    get {
+      guard let connection = connections.first else {
+        return false
+      }
+      return connection.isCameraIntrinsicMatrixDeliveryEnabled
+    }
+    set {
+      for connection in connections {
+        if connection.isCameraIntrinsicMatrixDeliverySupported {
+          connection.isCameraIntrinsicMatrixDeliveryEnabled = newValue
+        }
+      }
+    }
+  }
+}

--- a/package/ios/Core/Extensions/AVCaptureOutput+videoStabilizationMode.swift
+++ b/package/ios/Core/Extensions/AVCaptureOutput+videoStabilizationMode.swift
@@ -1,0 +1,30 @@
+//
+//  AVCaptureOutput+videoStabilizationMode.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 10.06.24.
+//
+
+import Foundation
+import AVFoundation
+
+extension AVCaptureOutput {
+  /**
+   Gets or sets the preferred video stabilization mode of all connections in this [AVCaptureOutput].
+   */
+  var videoStabilizationMode: VideoStabilizationMode {
+    get {
+      guard let connection = connections.first else {
+        return .off
+      }
+      return VideoStabilizationMode(from: connection.preferredVideoStabilizationMode)
+    }
+    set {
+      for connection in connections {
+        if connection.isVideoStabilizationSupported {
+          connection.preferredVideoStabilizationMode = newValue.toAVCaptureVideoStabilizationMode()
+        }
+      }
+    }
+  }
+}

--- a/package/ios/FrameProcessors/Frame.h
+++ b/package/ios/FrameProcessors/Frame.h
@@ -11,6 +11,7 @@
 #import <CoreMedia/CMSampleBuffer.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIImage.h>
+#import "Matrix.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -33,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) double timestamp;
 @property(nonatomic, readonly) size_t bytesPerRow;
 @property(nonatomic, readonly) size_t planesCount;
-@property(nonatomic, readonly) float* matrix;
+@property(nonatomic, readonly) Matrix* matrix;
 
 @end
 

--- a/package/ios/FrameProcessors/Frame.h
+++ b/package/ios/FrameProcessors/Frame.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) double timestamp;
 @property(nonatomic, readonly) size_t bytesPerRow;
 @property(nonatomic, readonly) size_t planesCount;
+@property(nonatomic, readonly) float* matrix;
 
 @end
 

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -9,6 +9,7 @@
 #import "Frame.h"
 #import <CoreMedia/CMSampleBuffer.h>
 #import <Foundation/Foundation.h>
+#import <Accelerate/Accelerate.h>
 
 @implementation Frame {
   CMSampleBufferRef _Nonnull _buffer;
@@ -102,6 +103,21 @@
 - (size_t)planesCount {
   CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
   return CVPixelBufferGetPlaneCount(imageBuffer);
+}
+
+- (float*)matrix {
+  CFTypeRef matrix = CMGetAttachment(_buffer, kCMSampleBufferAttachmentKey_CameraIntrinsicMatrix, nil);
+  if (matrix == nil) {
+    // TODO: Return identity?
+    return NULL;
+  }
+  
+  CFArrayRef matrixArray = (CFArrayRef)matrix;
+  NSArray* matrixObjCArray = (__bridge NSArray*)matrixArray;
+  for (id obj in matrixObjCArray) {
+    NSLog(@"Item: %@", obj);
+  }
+  return NULL;
 }
 
 @end

--- a/package/ios/FrameProcessors/FrameHostObject.mm
+++ b/package/ios/FrameProcessors/FrameHostObject.mm
@@ -27,6 +27,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
     result.push_back(jsi::PropNameID::forUtf8(rt, "bytesPerRow"));
     result.push_back(jsi::PropNameID::forUtf8(rt, "planesCount"));
     result.push_back(jsi::PropNameID::forUtf8(rt, "orientation"));
+    result.push_back(jsi::PropNameID::forUtf8(rt, "matrix"));
     result.push_back(jsi::PropNameID::forUtf8(rt, "isMirrored"));
     result.push_back(jsi::PropNameID::forUtf8(rt, "timestamp"));
     result.push_back(jsi::PropNameID::forUtf8(rt, "pixelFormat"));
@@ -69,6 +70,10 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
     Frame* frame = getFrame();
     NSString* orientation = [NSString stringWithParsed:frame.orientation];
     return jsi::String::createFromUtf8(runtime, orientation.UTF8String);
+  }
+  if (name == "matrix") {
+    Frame* frame = getFrame();
+    return jsi::Value::undefined();
   }
   if (name == "isMirrored") {
     Frame* frame = getFrame();

--- a/package/ios/FrameProcessors/FrameHostObject.mm
+++ b/package/ios/FrameProcessors/FrameHostObject.mm
@@ -73,7 +73,21 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   }
   if (name == "matrix") {
     Frame* frame = getFrame();
-    return jsi::Value::undefined();
+    Matrix* matrix = frame.matrix;
+    
+    jsi::Array array(runtime, matrix.totalSize);
+    
+    int i = 0;
+    for (int rowIndex = 0; rowIndex < matrix.rows.count; rowIndex++) {
+      MatrixRow* row = [matrix.rows objectAtIndex:rowIndex];
+      for (int columnIndex = 0; columnIndex < row.size; columnIndex++) {
+        float value = [row valueAtIndex:columnIndex];
+        array.setValueAtIndex(runtime, i, jsi::Value(static_cast<double>(value)));
+        i++;
+      }
+    }
+    
+    return array;
   }
   if (name == "isMirrored") {
     Frame* frame = getFrame();

--- a/package/ios/FrameProcessors/Matrix.h
+++ b/package/ios/FrameProcessors/Matrix.h
@@ -1,0 +1,31 @@
+//
+//  Matrix.h
+//  Pods
+//
+//  Created by Marc Rousavy on 10.06.24.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <simd/matrix_types.h>
+#import <simd/vector_types.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MatrixRow : NSObject
+- (NSUInteger) size;
+- (float) valueAtIndex:(NSUInteger)index;
+
+- (instancetype) initWithVector:(simd_float3)vector ofSize:(NSUInteger)size;
+@end
+
+@interface Matrix : NSObject
++ (Matrix*) identityMatrix;
+- (NSArray<MatrixRow*>*) rows;
+- (NSUInteger) totalSize;
+
+- (instancetype) initWithSIMDMatrix:(matrix_float3x3)matrix;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/package/ios/FrameProcessors/Matrix.m
+++ b/package/ios/FrameProcessors/Matrix.m
@@ -1,0 +1,77 @@
+//
+//  Matrix.m
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 10.06.24.
+//
+
+#import <Foundation/Foundation.h>
+#import "Matrix.h"
+#import <simd/simd.h>
+
+@implementation MatrixRow {
+  simd_float3 _vector;
+  NSUInteger _size;
+}
+
+- (nonnull instancetype)initWithVector:(simd_float3)vector ofSize:(NSUInteger)size {
+  if (self = [super init]) {
+    _vector = vector;
+    _size = size;
+  }
+  return self;
+}
+
+- (float)valueAtIndex:(NSUInteger)index {
+  if (index >= _size) {
+    @throw [NSError errorWithDomain:@"Index cannot be greater than size of matrix row!" code:-1 userInfo:nil];
+  }
+  return _vector[index];
+}
+
+- (NSUInteger)size {
+  return _size;
+}
+
+@end
+
+@implementation Matrix {
+  NSArray<MatrixRow*>* _rows;
+}
+
+- (nonnull instancetype)initWithSIMDMatrix:(matrix_float3x3)matrix {
+  if (self = [super init]) {
+    _rows = @[
+      [[MatrixRow alloc] initWithVector:matrix.columns[0] ofSize:3],
+      [[MatrixRow alloc] initWithVector:matrix.columns[1] ofSize:3],
+      [[MatrixRow alloc] initWithVector:matrix.columns[2] ofSize:3],
+    ];
+  }
+  return self;
+}
+
+- (nonnull NSArray<MatrixRow *> *)rows {
+  return _rows;
+}
+
+- (NSUInteger) totalSize {
+  // 3 x 3
+  return _rows.count * _rows[0].size;
+}
+
++ (nonnull Matrix *)identityMatrix {
+  static Matrix* identity = nil;
+  if (identity == nil) {
+    matrix_float3x3 floatIdentityMatrix = (matrix_float3x3) {
+      .columns = {
+        {1.0f, 0.0f, 0.0f},
+        {0.0f, 1.0f, 0.0f},
+        {0.0f, 0.0f, 1.0f}
+      }
+    };
+    identity = [[Matrix alloc] initWithSIMDMatrix:floatIdentityMatrix];
+  }
+  return identity;
+}
+
+@end

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -5,6 +5,7 @@ export * from './CameraError'
 // Types
 export * from './types/CameraDevice'
 export * from './types/CameraProps'
+export * from './types/Matrix'
 export * from './types/Frame'
 export * from './types/Orientation'
 export * from './types/OutputOrientation'

--- a/package/src/types/Frame.ts
+++ b/package/src/types/Frame.ts
@@ -1,3 +1,4 @@
+import type { Matrix } from './Matrix'
 import type { Orientation } from './Orientation'
 import type { PixelFormat } from './PixelFormat'
 
@@ -63,6 +64,10 @@ export interface Frame {
    * Represents the pixel-format of the Frame.
    */
   readonly pixelFormat: PixelFormat
+  /**
+   * Represents it's transformation (rotation, scaling, and transform) as a 3x3 Matrix.
+   */
+  readonly matrix: Matrix<3, 3>
 
   /**
    * Get the underlying data of the Frame as a uint8 array buffer.

--- a/package/src/types/Matrix.ts
+++ b/package/src/types/Matrix.ts
@@ -1,0 +1,9 @@
+// Creates an array of the given specific length
+type BuildArray<Length extends number, Element = unknown, Arr extends unknown[] = []> = Arr['length'] extends Length
+  ? Arr
+  : BuildArray<Length, Element, [...Arr, Element]>
+
+/**
+ * Represents a Matrix of the given size
+ */
+export type Matrix<Rows extends number, Columns extends number> = BuildArray<Rows, BuildArray<Columns, number>>


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Exposes camera intrinsic frame matrix ([`kCMSampleBufferAttachmentKey_CameraIntrinsicMatrix`](https://developer.apple.com/documentation/coremedia/kcmsamplebufferattachmentkey_cameraintrinsicmatrix?language=objc)) to JS via a 3x3 Matrix.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
