### PR TITLE
feat: Add `onUIRotationChanged` event

### DIFF
--- a/docs/docs/guides/ORIENTATION.mdx
+++ b/docs/docs/guides/ORIENTATION.mdx
@@ -19,7 +19,7 @@ To avoid re-allocating such large buffers every time the phone rotates, the Came
 
 Since actually rotating pixels in such large buffers is really expensive and causes an unnecessary performance overhead, VisionCamera applies rotations through flags or transforms:
 
-#### Photo & Video Output
+### Photo & Video Output
 
 Photos and videos will be captured in a potentially "wrong" orientation, and VisionCamera will write an EXIF flag to the photo/video file with the correct presentation rotation.
 
@@ -27,7 +27,7 @@ Photos and videos will be captured in a potentially "wrong" orientation, and Vis
 This is handled automatically, and it's behaviour can be controlled via the [`outputOrientation`](/docs/api/interfaces/CameraProps#outputorientation) property.
 :::
 
-#### Preview View
+### Preview View
 
 The Preview output will stream in a potentially "wrong" orientation, but uses view transforms (rotate + translate matrix) to properly display the Camera stream "up-right".
 
@@ -35,7 +35,7 @@ The Preview output will stream in a potentially "wrong" orientation, but uses vi
 This will always happen automatically according to the screen's rotation.
 :::
 
-#### Frame Processor Output
+### Frame Processor Output
 
 Frame Processors will stream frames in a potentially "wrong" orientation, and the client is responsible for properly interpreting the Frame data.
 
@@ -43,6 +43,14 @@ Frame Processors will stream frames in a potentially "wrong" orientation, and th
 This needs to be handled manually, see [`Frame.orientation`](/docs/api/interfaces/Frame#orientation).
 For example, in MLKit just pass the `Frame`'s `orientation` to the `detect(...)` method.
 :::
+
+## Implementation
+
+VisionCamera supports three ways to implement orientation:
+
+- Camera UI (preview view) is locked, but the buttons can rotate to the desired photo/video output orientation (**recommended**)
+- Camera UI (preview view) also rotates alongside with the photo/video output orientation
+- Both Camera UI (preview view) and photo/video output orientation are locked to a specific orientation
 
 ### The `outputOrientation` prop
 
@@ -52,36 +60,39 @@ The orientation in which photos and videos are captured can be adjusted via the 
 <Camera {...props} outputOrientation="device" />
 ```
 
-Whenever the output orientation changes, the [`onOutputOrientationChanged`](/docs/api/interfaces/CameraProps#onoutputorientationchanged) event will be called with the new output orientation.
-The [`onPreviewOrientationChanged`](/docs/api/interfaces/CameraProps#onprevieworientationchanged) event will be called whenever the preview orientation changes, which might be unrelated to the output orientation.
-
-#### `"device"`
-
-With the output orientation set to `device` (the default), photos and videos will be captured in the phone's physical orientation, even if the screen-rotation is locked.
-
+- `"device"`: With the output orientation set to `device` (the default), photos and videos will be captured in the phone's physical orientation, even if the screen-rotation is locked.
 This means, even though the preview view and other views don't rotate to landscape, holding the phone in landscape mode will still capture landscape photos. This is the same behaviour as in the iOS stock Camera.
 
-#### `"preview"`
-
-Similar to `device`, the `preview` orientation mode will follow the phone's physical orientation, allowing the user to capture landscape photos and videos - but will always respect screen-rotation locks.
-
+- `"preview"`: Similar to `device`, the `preview` orientation mode will follow the phone's physical orientation, allowing the user to capture landscape photos and videos - but will always respect screen-rotation locks.
 This means that the user is not able to capture landscape photos or videos if the preview view and other views stay in portrait mode (e.g. if the screen-lock is on).
 
-#### `"portrait"`
+- `"portrait"`, `"portrait-upside-down"`, `"landscape-left"`, `"landscape-right"`: All captured photos and videos will be locked to the given orientation mode.
 
-All captured photos and videos will be locked to portrait (0°, home-button on the bottom).
+### Listen to orientation changes
 
-#### `"portrait-upside-down"`
+Whenever the output orientation changes, the [`onOutputOrientationChanged`](/docs/api/interfaces/CameraProps#onoutputorientationchanged) event will be called with the new output orientation. This is a good point to rotate the buttons to the desired output orientation now.
 
-All captured photos and videos will be locked to portrait-upside-down (180°, home-button on the top).
+The [`onPreviewOrientationChanged`](/docs/api/interfaces/CameraProps#onprevieworientationchanged) event will be called whenever the preview orientation changes, which might be unrelated to the output orientation. Depending on the device's natural orientation (e.g. iPads being landscape by default), you should rotate all buttons on the UI relative to the preview orientation.
 
-#### `"landscape-left"`
+As a helper method, VisionCamera fires the [`onUIRotationChanged`](/docs/api/interfaces/CameraProps#onuirotationchanged) event whenever the target UI rotation changes. You can directly apply this rotation to any UI elements such as buttons to rotate them to the correct orientation:
 
-All captured photos and videos will be locked to landscape-left (90°, home-button on the left).
+```tsx
+const [uiRotation, setUiRotation] = useState(0)
+const uiStyle: ViewStyle = {
+  transform: [{ rotate: `${uiRotation}deg` }]
+}
 
-#### `"landscape-right"`
+return (
+  <View>
+    <Camera {...props} onUIRotationChanged={setUiRotation} />
+    <FlipCameraButton style={uiStyle} />
+  </View>
+)
+```
 
-All captured photos and videos will be locked to landscape-right (270°, home-button on the right).
+:::tip
+For a smoother user experience, you should animate changes to the UI rotation. Use a library like react-native-reanimated to smoothly animate the `rotate` style.
+:::
 
 ### The `Frame`'s `orientation`
 

--- a/package/ios/Core/Recording/TrackTimeline.swift
+++ b/package/ios/Core/Recording/TrackTimeline.swift
@@ -25,7 +25,7 @@ class TrackTimeline {
    Represents whether the timeline has been marked as finished or not.
    A timeline will automatically be marked as finished when a timestamp arrives that appears after a stop().
    */
-  public private(set) var isFinished: Bool = false
+  public private(set) var isFinished = false
 
   /**
    Gets the latency of the buffers in this timeline.

--- a/package/src/RotationHelper.ts
+++ b/package/src/RotationHelper.ts
@@ -30,7 +30,6 @@ export class RotationHelper {
   get uiRotation(): number {
     const previewDegrees = orientationToDegrees(this.previewOrientation)
     const outputDegrees = orientationToDegrees(this.outputOrientation)
-    console.log(`UI ${previewDegrees}, ${outputDegrees}`)
     return ((previewDegrees + outputDegrees) % 360) - 180
   }
 }

--- a/package/src/RotationHelper.ts
+++ b/package/src/RotationHelper.ts
@@ -1,0 +1,36 @@
+import type { Orientation } from './types/Orientation'
+
+function orientationToDegrees(orientation: Orientation): number {
+  switch (orientation) {
+    case 'portrait':
+      return 0
+    case 'landscape-right':
+      return 90
+    case 'portrait-upside-down':
+      return 180
+    case 'landscape-left':
+      return 270
+  }
+}
+
+export class RotationHelper {
+  /**
+   * Gets or sets the current preview orientation.
+   */
+  previewOrientation: Orientation = 'portrait'
+  /**
+   * Gets or sets the current output orientation.
+   */
+  outputOrientation: Orientation = 'portrait'
+
+  /**
+   * Gets the current target rotation (in degrees) that needs to be applied
+   * to all UI elements so they appear up-right.
+   */
+  get uiRotation(): number {
+    const previewDegrees = orientationToDegrees(this.previewOrientation)
+    const outputDegrees = orientationToDegrees(this.outputOrientation)
+    console.log(`UI ${previewDegrees}, ${outputDegrees}`)
+    return ((previewDegrees + outputDegrees) % 360) - 180
+  }
+}

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -331,6 +331,11 @@ export interface CameraProps extends ViewProps {
    */
   onPreviewOrientationChanged?: (previewOrientation: Orientation) => void
   /**
+   * Called whenever the target UI rotation/orientation changes.
+   * @param uiRotation The degrees that UI elements need to be rotated by to appear up-right.
+   */
+  onUIRotationChanged?: (uiRotation: number) => void
+  /**
    * A worklet which will be called for every frame the Camera "sees".
    *
    * @see See [the Frame Processors documentation](https://react-native-vision-camera.com/docs/guides/frame-processors) for more information


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds the `onUIRotationChanged` event - an event that fires whenever the orientation of UI elements (such as buttons) should be changed.

This can directly be applied to UI elements (such as buttons) via the `transform: { rotate }` view style to rotate them to the target output orientation.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
