### PR TITLE
fix: onUIRotationChanged uiRotation

### DIFF
--- a/package/src/RotationHelper.ts
+++ b/package/src/RotationHelper.ts
@@ -30,6 +30,6 @@ export class RotationHelper {
   get uiRotation(): number {
     const previewDegrees = orientationToDegrees(this.previewOrientation)
     const outputDegrees = orientationToDegrees(this.outputOrientation)
-    return ((previewDegrees + outputDegrees) % 360) - 180
+    return (outputDegrees - previewDegrees) % 360
   }
 }


### PR DESCRIPTION
## What

This PR fixes the incorrect UI rotation returned by onUIRotationChanged on certain devices.

For example, on my ELE-L29, all rotations were inverted.

Indeed, when the previewOrientation and outputOrientation are identical, the uiRotation should be 0. This was not the case with the current formula.

## Changes

This PR changes the formula used to calculate uiRotation.

## Tested on

- iPhone 12, iOS 17.4.1
- Huawei ELE-L29, Android 12
