### PR TITLE
fix: EUNSPECIFIED quality error

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/types/SnapshotOptions.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/types/SnapshotOptions.kt
@@ -5,7 +5,7 @@ import com.facebook.react.bridge.ReadableMap
 data class SnapshotOptions(val quality: Int) {
   companion object {
     fun fromJSValue(options: ReadableMap): SnapshotOptions {
-      val quality = options.getInt("quality")
+      val quality = if (options.hasKey("quality")) options.getInt("quality") else 100
       return SnapshotOptions(quality)
     }
   }

--- a/package/android/src/main/java/com/mrousavy/camera/core/utils/FileUtils.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/utils/FileUtils.kt
@@ -14,7 +14,7 @@ class FileUtils {
         it.deleteOnExit()
       }
 
-    fun writeBitmapTofile(bitmap: Bitmap, file: File, quality: Int = 100) {
+    fun writeBitmapTofile(bitmap: Bitmap, file: File, quality: Int) {
       FileOutputStream(file).use { stream ->
         bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
       }


### PR DESCRIPTION
## What

`takeSnapshot()` throws an error when the quality parameter is not defined on Android.

## Changes

Fix the issue.

## Tested on

- iPhone 12, iOS 17.4.1
- Huawei ELE-L29, Android 12

## Related issues

- https://github.com/mrousavy/react-native-vision-camera/issues/2804