### PR TITLE
feat: Android preview aspect ratio

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
@@ -51,6 +51,22 @@ data class CameraConfiguration(
   data class Audio(val nothing: Unit)
   data class Preview(val surfaceProvider: SurfaceProvider)
 
+  val targetPreviewAspectRatio: Float?
+    get() {
+      val format = format ?: return null
+      val video = video as? Output.Enabled<Video>
+      val photo = photo as? Output.Enabled<Photo>
+      return if (video != null) {
+        // Video capture is enabled, use video aspect ratio
+        format.videoWidth.toFloat() / format.videoHeight.toFloat()
+      } else if (photo != null) {
+        // Photo capture is enabled, use photo aspect ratio
+        format.photoWidth.toFloat() / format.photoHeight.toFloat()
+      } else {
+        null
+      }
+    }
+
   @Suppress("EqualsOrHashCode")
   sealed class Output<T> {
     val isEnabled: Boolean

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -20,13 +20,7 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.Recorder
 import androidx.camera.video.VideoCapture
 import androidx.lifecycle.Lifecycle
-import com.mrousavy.camera.core.extensions.byId
-import com.mrousavy.camera.core.extensions.forSize
-import com.mrousavy.camera.core.extensions.id
-import com.mrousavy.camera.core.extensions.isSDR
-import com.mrousavy.camera.core.extensions.setTargetFrameRate
-import com.mrousavy.camera.core.extensions.toCameraError
-import com.mrousavy.camera.core.extensions.withExtension
+import com.mrousavy.camera.core.extensions.*
 import com.mrousavy.camera.core.types.CameraDeviceFormat
 import com.mrousavy.camera.core.types.Torch
 import com.mrousavy.camera.core.types.VideoStabilizationMode
@@ -67,6 +61,9 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
 
   Log.i(CameraSession.TAG, "Using FPS Range: $fpsRange")
 
+  val photoConfig = configuration.photo as? CameraConfiguration.Output.Enabled<CameraConfiguration.Photo>
+  val videoConfig = configuration.video as? CameraConfiguration.Output.Enabled<CameraConfiguration.Video>
+
   // 1. Preview
   val previewConfig = configuration.preview as? CameraConfiguration.Output.Enabled<CameraConfiguration.Preview>
   if (previewConfig != null) {
@@ -85,6 +82,21 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
         }
         preview.setTargetFrameRate(fpsRange)
       }
+      if (format != null) {
+        if (videoConfig != null) {
+          val previewResolutionSelector = ResolutionSelector.Builder()
+            .forAspectRatio(format.videoSize.width.toFloat() / format.videoSize.height.toFloat())
+            .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
+            .build()
+          preview.setResolutionSelector(previewResolutionSelector)
+        } else if (photoConfig != null) {
+          val previewResolutionSelector = ResolutionSelector.Builder()
+            .forAspectRatio(format.photoSize.width.toFloat() / format.photoSize.height.toFloat())
+            .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
+            .build()
+          preview.setResolutionSelector(previewResolutionSelector)
+        }
+      }
     }.build()
     preview.setSurfaceProvider(previewConfig.config.surfaceProvider)
     previewOutput = preview
@@ -93,7 +105,6 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
   }
 
   // 2. Image Capture
-  val photoConfig = configuration.photo as? CameraConfiguration.Output.Enabled<CameraConfiguration.Photo>
   if (photoConfig != null) {
     Log.i(CameraSession.TAG, "Creating Photo output...")
     val photo = ImageCapture.Builder().also { photo ->
@@ -114,7 +125,6 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
   }
 
   // 3. Video Capture
-  val videoConfig = configuration.video as? CameraConfiguration.Output.Enabled<CameraConfiguration.Video>
   if (videoConfig != null) {
     Log.i(CameraSession.TAG, "Creating Video output...")
     val currentRecorder = recorderOutput

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -82,20 +82,15 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
         }
         preview.setTargetFrameRate(fpsRange)
       }
-      if (format != null) {
-        if (videoConfig != null) {
-          val previewResolutionSelector = ResolutionSelector.Builder()
-            .forAspectRatio(format.videoSize.width.toFloat() / format.videoSize.height.toFloat())
-            .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
-            .build()
-          preview.setResolutionSelector(previewResolutionSelector)
-        } else if (photoConfig != null) {
-          val previewResolutionSelector = ResolutionSelector.Builder()
-            .forAspectRatio(format.photoSize.width.toFloat() / format.photoSize.height.toFloat())
-            .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
-            .build()
-          preview.setResolutionSelector(previewResolutionSelector)
-        }
+
+      val targetPreviewAspectRatio = configuration.targetPreviewAspectRatio
+      if (targetPreviewAspectRatio != null) {
+        Log.i(CameraSession.TAG, "Preview aspect ratio: $targetPreviewAspectRatio")
+        val previewResolutionSelector = ResolutionSelector.Builder()
+          .forAspectRatio(targetPreviewAspectRatio)
+          .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
+          .build()
+        preview.setResolutionSelector(previewResolutionSelector)
       }
     }.build()
     preview.setSurfaceProvider(previewConfig.config.surfaceProvider)

--- a/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forAspectRatio.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forAspectRatio.kt
@@ -10,7 +10,9 @@ fun ResolutionSelector.Builder.forAspectRatio(aspectRatio: Float): ResolutionSel
   return this.setResolutionFilter { supportedSizes, _ ->
     return@setResolutionFilter supportedSizes.sortedWith(
       compareBy(
+        // Compare difference in aspect ratios first,
         { abs(it.width.toFloat() / it.height - aspectRatio) },
+        // ..and total resolution afterwards.
         { -(it.width * it.height) }
       )
     )

--- a/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forAspectRatio.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forAspectRatio.kt
@@ -8,9 +8,11 @@ import kotlin.math.abs
  */
 fun ResolutionSelector.Builder.forAspectRatio(aspectRatio: Float): ResolutionSelector.Builder {
   return this.setResolutionFilter { supportedSizes, _ ->
-    return@setResolutionFilter supportedSizes.sortedWith(compareBy(
-      { abs(it.width.toFloat() / it.height - aspectRatio) },
-      { -(it.width * it.height) }
-    ))
+    return@setResolutionFilter supportedSizes.sortedWith(
+      compareBy(
+        { abs(it.width.toFloat() / it.height - aspectRatio) },
+        { -(it.width * it.height) }
+      )
+    )
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forAspectRatio.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forAspectRatio.kt
@@ -1,0 +1,16 @@
+package com.mrousavy.camera.core.extensions
+
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import kotlin.math.abs
+
+/**
+ * Gets a [ResolutionSelector] that finds a resolution closest to the given target aspect ratio.
+ */
+fun ResolutionSelector.Builder.forAspectRatio(aspectRatio: Float): ResolutionSelector.Builder {
+  return this.setResolutionFilter { supportedSizes, _ ->
+    return@setResolutionFilter supportedSizes.sortedWith(compareBy(
+      { abs(it.width.toFloat() / it.height - aspectRatio) },
+      { -(it.width * it.height) }
+    ))
+  }
+}


### PR DESCRIPTION
## What

Currently on iOS, the previewer ratio matches the video capture ratio (or the photo ratio if video mode is disabled).
This ensures that the preview corresponds to the captured result.

The idea of this pull request is to have the same behavior on Android.

## Changes

The previewer uses the resolution with the aspect ratio closest to the video capture resolution (or photo resolution if video mode is disabled).

Maybe someone has a better idea, such as adding the preview resolution to the format (but this would significantly increase the number of formats) or adding a new prop to define the previewer resolution.

## Tested on

- iPhone 12, iOS 17.4.1
- Huawei ELE-L29, Android 12
