### PR TITLE
fix: auto focus/exposure by default

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -195,6 +195,14 @@ extension CameraSession {
     // Set new device Format
     device.activeFormat = format
 
+    // Set auto focus/exposure
+    if device.isFocusModeSupported(.continuousAutoFocus) {
+      device.focusMode = .continuousAutoFocus
+    }
+    if device.isExposureModeSupported(.continuousAutoExposure) {
+      device.exposureMode = .continuousAutoExposure
+    }
+
     VisionLogger.log(level: .info, message: "Successfully configured Format!")
   }
 

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -45,6 +45,7 @@ extension CameraSession {
     captureSession.addInput(input)
     videoDeviceInput = input
 
+    // Update Orientation manager (uses device relative sensor orientation)
     orientationManager.setInputDevice(videoDevice)
 
     VisionLogger.log(level: .info, message: "Successfully configured Input Device!")
@@ -154,6 +155,9 @@ extension CameraSession {
 
     // Done!
     VisionLogger.log(level: .info, message: "Successfully configured all outputs!")
+
+    // Notify delegate
+    delegate?.onSessionInitialized()
   }
 
   // pragma MARK: Video Stabilization
@@ -194,14 +198,6 @@ extension CameraSession {
 
     // Set new device Format
     device.activeFormat = format
-
-    // Set auto focus/exposure
-    if device.isFocusModeSupported(.continuousAutoFocus) {
-      device.focusMode = .continuousAutoFocus
-    }
-    if device.isExposureModeSupported(.continuousAutoExposure) {
-      device.exposureMode = .continuousAutoExposure
-    }
 
     VisionLogger.log(level: .info, message: "Successfully configured Format!")
   }
@@ -272,6 +268,14 @@ extension CameraSession {
         throw CameraError.device(.lowLightBoostNotSupported)
       }
       device.automaticallyEnablesLowLightBoostWhenAvailable = configuration.enableLowLightBoost
+    }
+
+    // Configure auto-focus
+    if device.isFocusModeSupported(.continuousAutoFocus) {
+      device.focusMode = .continuousAutoFocus
+    }
+    if device.isExposureModeSupported(.continuousAutoExposure) {
+      device.exposureMode = .continuousAutoExposure
     }
   }
 


### PR DESCRIPTION
## What

On some iOS devices (e.g. on my iPod) the auto focus/exposure is not enabled by default. The focus/exposure is done when the camera is loaded and does not change afterwards.

## Changes

Enable the auto focus/exposure when a format is loaded.

## Tested on

- iPhone 12, iOS 17.4.1
- iPad Air 2, iOS 15.8.2
- iPod, iOS 12.5.7
