### PR TITLE
fix: Always keep `uiRotation` a "short" rotation

### DIFF
--- a/package/src/RotationHelper.ts
+++ b/package/src/RotationHelper.ts
@@ -30,6 +30,17 @@ export class RotationHelper {
   get uiRotation(): number {
     const previewDegrees = orientationToDegrees(this.previewOrientation)
     const outputDegrees = orientationToDegrees(this.outputOrientation)
-    return (outputDegrees - previewDegrees) % 360
+    const diffDegrees = (outputDegrees - previewDegrees) % 360
+
+    if (diffDegrees < -180) {
+      // Changes e.g. -270 to +90, so it is a shorter rotation on UI
+      return diffDegrees + 360
+    } else if (diffDegrees > 180) {
+      // Changes e.g. +270 to -90, so it is a shorter rotation on UI
+      return diffDegrees - 360
+    } else {
+      // It is a short rotation already, return it
+      return diffDegrees
+    }
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

As a follow-up to #2962 by @j-jonathan, we now always keep `uiRotation` a "short" value, so that animations don't look weird.

If `uiRotation` is -270, it will rotate a full round around the other way. With this PR, such values are clamped to their opposite values that have the same rotation value.

-  -270 -> +90, which is a shorter rotation the other way around
- +270 -> -90, which is a shorter rotation the other way around

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
