### PR TITLE
fix: Fix `MetadataProvider` location `onStatusChanged` crash

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/MetadataProvider.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/MetadataProvider.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
+import android.os.Bundle
 import android.util.Log
 import androidx.core.content.ContextCompat
 
@@ -54,5 +55,10 @@ class MetadataProvider(val context: Context) : LocationListener {
 
   override fun onProviderEnabled(provider: String) {
     Log.i(TAG, "Location Provider $provider has been enabled.")
+  }
+
+  @Deprecated("Deprecated in Java", ReplaceWith("", ""))
+  override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {
+    Log.i(TAG, "Location Provider $provider status changed: $status")
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/2969

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
