### PR TITLE
fix: Fix onStatusChanged crash before android 10

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/MetadataProvider.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/MetadataProvider.kt
@@ -7,6 +7,8 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
+import android.location.LocationProvider
+import android.os.Bundle
 import android.util.Log
 import androidx.core.content.ContextCompat
 
@@ -54,5 +56,15 @@ class MetadataProvider(val context: Context) : LocationListener {
 
   override fun onProviderEnabled(provider: String) {
     Log.i(TAG, "Location Provider $provider has been enabled.")
+  }
+
+  override fun onStatusChanged(provider: String, status: Int, extras: Bundle) {
+    var statusStr = "available."
+    if (status == LocationProvider.OUT_OF_SERVICE) {
+      statusStr = "out of service."
+    } else if (status == LocationProvider.TEMPORARILY_UNAVAILABLE) {
+      statusStr = "temporarily unavailable."
+    }
+    Log.i(TAG, "Provider $provider is $statusStr")
   }
 }


### PR DESCRIPTION
* Fixed onStatusChanged crash for android 9 and before. onStatusChanged function was removed in android api version 29 but api versions before 29 still call this function which results in app crash. Created function override to handle this call and prevent app crash on legacy versions of android.
* Tested on samsung galaxy s6 (android 7.0) and pixel 3xl (android 14.0).
* Closes #2969 