### PR TITLE
feat: Keep one last Video Frame in memory for Snapshot

### DIFF
--- a/package/ios/React/CameraView+TakeSnapshot.swift
+++ b/package/ios/React/CameraView+TakeSnapshot.swift
@@ -11,49 +11,27 @@ import UIKit
 
 extension CameraView {
   func takeSnapshot(options _: NSDictionary, promise: Promise) {
-    // If video is not enabled, we won't get any buffers in onFrameListeners. abort it.
-    guard video else {
-      promise.reject(error: .capture(.videoNotEnabled))
-      return
-    }
-
-    // If after 3 seconds we still didn't receive a snapshot, we abort it.
-    CameraQueues.cameraQueue.asyncAfter(deadline: .now() + 3) {
-      if !promise.didResolve {
-        promise.reject(error: .capture(.timedOut))
+    withPromise(promise) {
+      guard let snapshot = lastVideoFrame else {
+        throw CameraError.capture(.snapshotFailed)
       }
-    }
-
-    // Add a listener to the onFrame callbacks which will get called later if video is enabled.
-    snapshotOnFrameListeners.append { buffer in
-      if promise.didResolve {
-        // capture was already aborted (timed out)
-        return
+      guard let imageBuffer = CMSampleBufferGetImageBuffer(snapshot) else {
+        throw CameraError.capture(.imageDataAccessError)
       }
 
       self.onCaptureShutter(shutterType: .snapshot)
 
-      guard let imageBuffer = CMSampleBufferGetImageBuffer(buffer) else {
-        promise.reject(error: .capture(.imageDataAccessError))
-        return
-      }
       let ciImage = CIImage(cvPixelBuffer: imageBuffer)
       let orientation = self.cameraSession.outputOrientation
       let image = UIImage(ciImage: ciImage, scale: 1.0, orientation: orientation.imageOrientation)
-      do {
-        let path = try FileUtils.writeUIImageToTempFile(image: image)
-        promise.resolve([
-          "path": path.absoluteString,
-          "width": image.size.width,
-          "height": image.size.height,
-          "orientation": orientation.jsValue,
-          "isMirrored": false,
-        ])
-      } catch let error as CameraError {
-        promise.reject(error: error)
-      } catch {
-        promise.reject(error: .capture(.unknown(message: "An unknown error occured while capturing the snapshot!")), cause: error as NSError)
-      }
+      let path = try FileUtils.writeUIImageToTempFile(image: image)
+      return [
+        "path": path.absoluteString,
+        "width": image.size.width,
+        "height": image.size.height,
+        "orientation": orientation.jsValue,
+        "isMirrored": false,
+      ]
     }
   }
 }

--- a/package/ios/React/CameraView+TakeSnapshot.swift
+++ b/package/ios/React/CameraView+TakeSnapshot.swift
@@ -12,7 +12,7 @@ import UIKit
 extension CameraView {
   func takeSnapshot(options _: NSDictionary, promise: Promise) {
     withPromise(promise) {
-      guard let snapshot = lastVideoFrame else {
+      guard let snapshot = latestVideoFrame else {
         throw CameraError.capture(.snapshotFailed)
       }
       guard let imageBuffer = CMSampleBufferGetImageBuffer(snapshot) else {

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -89,20 +89,23 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
     }
   }
 
-  // pragma MARK: Internal Properties
-  var cameraSession = CameraSession()
-  var previewView: PreviewView?
-  var isMounted = false
   #if VISION_CAMERA_ENABLE_FRAME_PROCESSORS
     @objc public var frameProcessor: FrameProcessor?
   #endif
 
+  // pragma MARK: Internal Properties
+  var cameraSession = CameraSession()
+  var previewView: PreviewView?
+  var isMounted = false
+  private var currentConfigureCall: DispatchTime?
+  private let fpsSampleCollector = FpsSampleCollector()
+
   // CameraView+Zoom
   var pinchGestureRecognizer: UIPinchGestureRecognizer?
   var pinchScaleOffset: CGFloat = 1.0
-  var snapshotOnFrameListeners: [(_: CMSampleBuffer) -> Void] = []
-  private var currentConfigureCall: DispatchTime?
-  private let fpsSampleCollector = FpsSampleCollector()
+
+  // CameraView+TakeSnapshot
+  var lastVideoFrame: CMSampleBuffer?
 
   // pragma MARK: Setup
 
@@ -364,10 +367,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
       }
     #endif
 
-    for callback in snapshotOnFrameListeners {
-      callback(sampleBuffer)
-    }
-    snapshotOnFrameListeners.removeAll()
+    lastVideoFrame = sampleBuffer
   }
 
   func onCodeScanned(codes: [CameraSession.Code], scannerFrame: CameraSession.CodeScannerFrame) {

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -105,7 +105,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
   var pinchScaleOffset: CGFloat = 1.0
 
   // CameraView+TakeSnapshot
-  var lastVideoFrame: CMSampleBuffer?
+  var latestVideoFrame: CMSampleBuffer?
 
   // pragma MARK: Setup
 
@@ -357,6 +357,10 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
   }
 
   func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation) {
+    // Update latest frame that can be used for snapshot capture
+    latestVideoFrame = sampleBuffer
+
+    // Notify FPS Collector that we just had a Frame
     fpsSampleCollector.onTick()
 
     #if VISION_CAMERA_ENABLE_FRAME_PROCESSORS
@@ -366,8 +370,6 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
         frameProcessor.call(frame)
       }
     #endif
-
-    lastVideoFrame = sampleBuffer
   }
 
   func onCodeScanned(codes: [CameraSession.Code], scannerFrame: CameraSession.CodeScannerFrame) {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Instead of waiting for a new Frame in `takeSnapshot`, just always keep one Frame in memory (`self.lastVideoFrame`) and immediately return that in `takeSnapshot(...)`.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
