### PR TITLE
fix: remove hardcoded resolution selector

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -3,7 +3,6 @@ package com.mrousavy.camera.core
 import android.annotation.SuppressLint
 import android.util.Log
 import android.util.Range
-import android.util.Size
 import androidx.annotation.OptIn
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.CameraState

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -211,11 +211,7 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
   val codeScannerConfig = configuration.codeScanner as? CameraConfiguration.Output.Enabled<CameraConfiguration.CodeScanner>
   if (codeScannerConfig != null) {
     Log.i(CameraSession.TAG, "Creating CodeScanner output...")
-    val analyzer = ImageAnalysis.Builder().also { analysis ->
-      val targetSize = Size(1280, 720)
-      val resolutionSelector = ResolutionSelector.Builder().forSize(targetSize).build()
-      analysis.setResolutionSelector(resolutionSelector)
-    }.build()
+    val analyzer = ImageAnalysis.Builder().build()
     val pipeline = CodeScannerPipeline(codeScannerConfig.config, callback)
     analyzer.setAnalyzer(CameraQueues.analyzerExecutor, pipeline)
     codeScannerOutput = analyzer


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

Hi! I noticed that on Android barcode corners detection works way better without hardcoded resolution selector. On Pixel XL automatically selected resolution is `{"height": 480, "width": 640}` vs `{"height": 720, "width": 1280}` with resolution selector
## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * Samsung Galaxy Tab s9+, Android 14
    * Pixel 2 Emulator, Android 13
--> 
* Samsung Galaxy Tab S9+, Android 14
* Pixel XL Emulator, Android 13

## Demo
### Galaxy tab s9+
#### Before
https://github.com/mrousavy/react-native-vision-camera/assets/13413154/18f002e5-1d41-4e18-94f9-7092aaf75c26
#### After


https://github.com/mrousavy/react-native-vision-camera/assets/13413154/c536fac4-2e30-41b8-8bd3-3419daedb5fc

### Pixel XL Emulator
#### Before
 

https://github.com/mrousavy/react-native-vision-camera/assets/13413154/28e830d5-7332-43e5-a37a-b24d657f33f9


#### After

https://github.com/mrousavy/react-native-vision-camera/assets/13413154/a68c0379-1c7f-4ba8-ac85-ddc290b1f886





