### PR TITLE
fix: iOS FPS

### DIFF
--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -121,7 +121,7 @@ extension CameraSession {
 
         // Init Video
         let videoSettings = try videoOutput.recommendedVideoSettings(forOptions: options)
-        try recordingSession.initializeVideoTrack(withSettings: videoSettings)
+        try recordingSession.initializeVideoTrack(withSettings: videoSettings, fps: self.configuration?.fps)
 
         // start recording session with or without audio.
         try recordingSession.start()

--- a/package/ios/Core/RecordingSession.swift
+++ b/package/ios/Core/RecordingSession.swift
@@ -97,7 +97,7 @@ class RecordingSession {
   /**
    Initializes the video track.
    */
-  func initializeVideoTrack(withSettings settings: [String: Any]) throws {
+  func initializeVideoTrack(withSettings settings: [String: Any], fps: Int32?) throws {
     guard !settings.isEmpty else {
       throw CameraError.capture(.createRecorderError(message: "Tried to initialize Video Track with empty options!"))
     }
@@ -112,6 +112,10 @@ class RecordingSession {
     let videoWriter = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
     videoWriter.expectsMediaDataInRealTime = true
     videoWriter.transform = videoOrientation.affineTransform
+    if let fps = fps {
+      videoWriter.mediaTimeScale = fps
+      assetWriter.movieTimeScale = fps
+    }
     assetWriter.add(videoWriter)
     videoTrack = Track(ofType: .video, withAssetWriterInput: videoWriter, andClock: clock)
     VisionLogger.log(level: .info, message: "Initialized Video AssetWriter.")


### PR DESCRIPTION
## What

Currently, the FPS of a video recorded by the vision camera library on iOS are not consistent.
The FPS vary from one video to another even when the “fps” prop is used.

Examples:
![image](https://github.com/mrousavy/react-native-vision-camera/assets/78229184/cfa0600b-ebf1-4b25-a7bd-9d468b0db053)
![image](https://github.com/mrousavy/react-native-vision-camera/assets/78229184/239fe6bb-97ff-4a12-aad9-c7151d1d6d35)


## Changes

Modification of recorder parameters to take into account the desired FPS.


## Tested on

- iPhone 12, iOS 17
