### PR TITLE
docs: Fix unclosed docstring

### DIFF
--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -385,6 +385,7 @@ export interface CameraProps extends ViewProps {
    * })
    *
    * return <Camera {...props} codeScanner={codeScanner} />
+   * ```
    */
   codeScanner?: CodeScanner
   //#endregion


### PR DESCRIPTION
## What

* This PR fixes an unclosed docstring in CameraProps type.

## Changes

* This PR adds ``` at the end of the codeScanner docstring

## Tested on

* I think there is no need to test :)

## Related issues

No related issues.
