### PR TITLE
fix: Android ResolutionSelector.Builder.forSize

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forSize.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forSize.kt
@@ -4,8 +4,7 @@ import android.util.Size
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import kotlin.math.abs
 
-private fun difference(left: Size, right: Size): Int =
-  abs(left.width * left.height - right.width * right.height) + abs(left.width - right.width) + abs(left.height - right.height)
+private fun difference(left: Size, right: Size): Int = abs(left.width - right.width) + abs(left.height - right.height)
 
 /**
  * Gets a [ResolutionSelector] that finds a resolution closest to the given target size.

--- a/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forSize.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forSize.kt
@@ -4,7 +4,8 @@ import android.util.Size
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import kotlin.math.abs
 
-private fun difference(left: Size, right: Size): Int = abs(left.width * left.height - right.width * right.height) + abs(left.width - right.width) + abs(left.height - right.height)
+private fun difference(left: Size, right: Size): Int =
+  abs(left.width * left.height - right.width * right.height) + abs(left.width - right.width) + abs(left.height - right.height)
 
 /**
  * Gets a [ResolutionSelector] that finds a resolution closest to the given target size.

--- a/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forSize.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/extensions/ResolutionSelector+forSize.kt
@@ -4,7 +4,7 @@ import android.util.Size
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import kotlin.math.abs
 
-private fun difference(left: Size, right: Size): Int = abs(left.width * left.height - right.width * right.height)
+private fun difference(left: Size, right: Size): Int = abs(left.width * left.height - right.width * right.height) + abs(left.width - right.width) + abs(left.height - right.height)
 
 /**
  * Gets a [ResolutionSelector] that finds a resolution closest to the given target size.


### PR DESCRIPTION
## What

This PR fixes an issue with the resolution selection logic where two formats with the same difference metric resulted in selecting the incorrect resolution.

I encountered a problem with a phone that supports the following two formats:
- "photoHeight": 2592, "photoWidth": 4608  --> (2592*4608 = 11943936)
- "photoHeight": 3456, "photoWidth": 3456  --> (3456*3456 = 11943936)

When the first format was selected, the resulting picture was taken with the resolution of 3456 x 3456 instead of the intended 2592 x 4608.

## Changes

This PR updates the difference function in the resolution selection code to consider both width and height differences in addition to the area difference.

## Tested on

- Samsung SM-G525F
