### PR TITLE
fix: unfocus on iOS

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -272,9 +272,15 @@ extension CameraSession {
 
     // Configure auto-focus
     if device.isFocusModeSupported(.continuousAutoFocus) {
+      if device.isFocusPointOfInterestSupported {
+        device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
+      }
       device.focusMode = .continuousAutoFocus
     }
     if device.isExposureModeSupported(.continuousAutoExposure) {
+      if device.isExposurePointOfInterestSupported {
+        device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
+      }
       device.exposureMode = .continuousAutoExposure
     }
   }

--- a/package/ios/Core/CameraSession+Focus.swift
+++ b/package/ios/Core/CameraSession+Focus.swift
@@ -70,11 +70,13 @@ extension CameraSession {
 
     // Reset Focus to continuous/auto
     if device.isFocusPointOfInterestSupported {
+      device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
       device.focusMode = .continuousAutoFocus
     }
 
     // Reset Exposure to continuous/auto
     if device.isExposurePointOfInterestSupported {
+      device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
       device.exposureMode = .continuousAutoExposure
     }
 


### PR DESCRIPTION
## What

Currently, the focus is never reset on iOS (even when the camera is restarted).

This pull request aims to fix this issue.

## Changes

- Fix for resetting autofocus/autoexposure

Info:
focusPointOfInterest / exposurePointOfInterest should be set to CGPoint(x: 0.5, y: 0.5) to be reset.

## Tested on

- iPhone 12, iOS 17

