### PR TITLE
fix: Fix wrong hardcode LANDSCPAPE_LEFT value

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
@@ -14,7 +14,7 @@ enum class OutputOrientation(override val unionValue: String) : JSUnionValue {
         PORTRAIT -> Orientation.PORTRAIT
         LANDSCAPE_LEFT -> Orientation.LANDSCAPE_LEFT
         PORTRAIT_UPSIDE_DOWN -> Orientation.PORTRAIT_UPSIDE_DOWN
-        LANDSCAPE_LEFT -> Orientation.LANDSCAPE_LEFT
+        LANDSCAPE_RIGHT -> Orientation.LANDSCAPE_RIGHT
         else -> null
       }
     }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
