### PR TITLE
#2995 Fix duplicate label in when.

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
@@ -12,7 +12,6 @@ enum class OutputOrientation(override val unionValue: String) : JSUnionValue {
     get() {
       return when (this) {
         PORTRAIT -> Orientation.PORTRAIT
-        LANDSCAPE_LEFT -> Orientation.LANDSCAPE_LEFT
         PORTRAIT_UPSIDE_DOWN -> Orientation.PORTRAIT_UPSIDE_DOWN
         LANDSCAPE_LEFT -> Orientation.LANDSCAPE_LEFT
         else -> null

--- a/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
@@ -2,11 +2,11 @@ package com.mrousavy.camera.core.types
 
 enum class OutputOrientation(override val unionValue: String) : JSUnionValue {
   DEVICE("device"),
-  LANDSCAPE_LEFT("landscape-left");
+  LANDSCAPE_LEFT("landscape-left"),
   LANDSCAPE_RIGHT("landscape-right"),
   PORTRAIT("portrait"),
   PORTRAIT_UPSIDE_DOWN("portrait-upside-down"),
-  PREVIEW("preview"),
+  PREVIEW("preview");
 
   val lockedOrientation: Orientation?
     get() {

--- a/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
@@ -2,18 +2,19 @@ package com.mrousavy.camera.core.types
 
 enum class OutputOrientation(override val unionValue: String) : JSUnionValue {
   DEVICE("device"),
-  PREVIEW("preview"),
-  PORTRAIT("portrait"),
-  LANDSCAPE_RIGHT("landscape-right"),
-  PORTRAIT_UPSIDE_DOWN("portrait-upside-down"),
   LANDSCAPE_LEFT("landscape-left");
+  LANDSCAPE_RIGHT("landscape-right"),
+  PORTRAIT("portrait"),
+  PORTRAIT_UPSIDE_DOWN("portrait-upside-down"),
+  PREVIEW("preview"),
 
   val lockedOrientation: Orientation?
     get() {
       return when (this) {
+        LANDSCAPE_LEFT -> Orientation.LANDSCAPE_LEFT
+        LANDSCAPE_RIGHT -> Orientation.LANDSCAPE_RIGHT
         PORTRAIT -> Orientation.PORTRAIT
         PORTRAIT_UPSIDE_DOWN -> Orientation.PORTRAIT_UPSIDE_DOWN
-        LANDSCAPE_LEFT -> Orientation.LANDSCAPE_LEFT
         else -> null
       }
     }
@@ -22,11 +23,11 @@ enum class OutputOrientation(override val unionValue: String) : JSUnionValue {
     override fun fromUnionValue(unionValue: String?): OutputOrientation =
       when (unionValue) {
         "device" -> DEVICE
-        "preview" -> PREVIEW
-        "portrait" -> PORTRAIT
-        "landscape-right" -> LANDSCAPE_RIGHT
-        "portrait-upside-down" -> PORTRAIT_UPSIDE_DOWN
         "landscape-left" -> LANDSCAPE_LEFT
+        "landscape-right" -> LANDSCAPE_RIGHT
+        "portrait" -> PORTRAIT
+        "portrait-upside-down" -> PORTRAIT_UPSIDE_DOWN
+        "preview" -> PREVIEW
         else -> PORTRAIT
       }
   }


### PR DESCRIPTION
## What

Does not build on latest react-native 0.74.2 with npx react-native run-android command, but works fine on RN 73.8

```
> Task :react-native-vision-camera:compileDebugKotlin
w: file:///Users/romick/app/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt:17:9 Duplicate label in when
w: file:///Users/romick/app/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/core/utils/CamcorderProfileUtils.kt:66:42 'get(Int, Int): CamcorderProfile!' is deprecated. Deprecated in Java
w: file:///Users/romick/app/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/core/utils/CamcorderProfileUtils.kt:90:42 'get(Int, Int): CamcorderProfile!' is deprecated. Deprecated in Java

> Task :app:compileDebugJavaWithJavac FAILED
545 actionable tasks: 541 executed, 4 up-to-date
```

Please remove duplicated [lines](https://github.com/mrousavy/react-native-vision-camera/blob/main/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt#L17C52-L17C53):

![image](https://github.com/mrousavy/react-native-vision-camera/assets/17779660/554a2a3e-1e05-44ad-981a-8178252c8a0e)


### Reproduceable Code

```tsx
Regular project on latest RN 0.74.2.
```


### Relevant log output

```shell
> Task :react-native-vision-camera:compileDebugKotlin
w: file:///Users/romick/app/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt:17:9 Duplicate label in when
w: file:///Users/romick/app/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/core/utils/CamcorderProfileUtils.kt:66:42 'get(Int, Int): CamcorderProfile!' is deprecated. Deprecated in Java
w: file:///Users/romick/app/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/core/utils/CamcorderProfileUtils.kt:90:42 'get(Int, Int): CamcorderProfile!' is deprecated. Deprecated in Java

> Task :app:compileDebugJavaWithJavac FAILED
545 actionable tasks: 541 executed, 4 up-to-date
```


## Changes

Fix duplicate label in when

## Tested on
    * Huawai P20, Android 10

## Related issues
#2995
