### PR TITLE
fix: Remove `portrait`, `portrait-upside-down`, `landscape-left` and `landscape-right` options for `outputOrientation`

### DIFF
--- a/docs/docs/guides/ORIENTATION.mdx
+++ b/docs/docs/guides/ORIENTATION.mdx
@@ -66,8 +66,6 @@ This means, even though the preview view and other views don't rotate to landsca
 - `"preview"`: Similar to `device`, the `preview` orientation mode will follow the phone's physical orientation, allowing the user to capture landscape photos and videos - but will always respect screen-rotation locks.
 This means that the user is not able to capture landscape photos or videos if the preview view and other views stay in portrait mode (e.g. if the screen-lock is on).
 
-- `"portrait"`, `"portrait-upside-down"`, `"landscape-left"`, `"landscape-right"`: All captured photos and videos will be locked to the given orientation mode.
-
 ### Listen to orientation changes
 
 Whenever the output orientation changes, the [`onOutputOrientationChanged`](/docs/api/interfaces/CameraProps#onoutputorientationchanged) event will be called with the new output orientation. This is a good point to rotate the buttons to the desired output orientation now.

--- a/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
@@ -50,11 +50,7 @@ class OrientationManager(private val context: Context, private val callback: Cal
     get() {
       return when (targetOutputOrientation) {
         OutputOrientation.DEVICE -> Orientation.fromSurfaceRotation(deviceRotation)
-        OutputOrientation.PREVIEW -> Orientation.fromSurfaceRotation(screenRotation)
-        OutputOrientation.PORTRAIT -> Orientation.PORTRAIT
-        OutputOrientation.LANDSCAPE_LEFT -> Orientation.LANDSCAPE_LEFT
-        OutputOrientation.PORTRAIT_UPSIDE_DOWN -> Orientation.PORTRAIT_UPSIDE_DOWN
-        OutputOrientation.LANDSCAPE_RIGHT -> Orientation.LANDSCAPE_RIGHT
+        OutputOrientation.PREVIEW -> previewOrientation
       }
     }
 
@@ -79,18 +75,16 @@ class OrientationManager(private val context: Context, private val callback: Cal
     displayManager.unregisterDisplayListener(displayListener)
     orientationListener.disable()
 
+
     when (targetOrientation) {
-      OutputOrientation.DEVICE, OutputOrientation.PREVIEW -> {
+      OutputOrientation.DEVICE -> {
         Log.i(TAG, "Starting streaming device and screen orientation updates...")
         orientationListener.enable()
         displayManager.registerDisplayListener(displayListener, null)
       }
-
-      OutputOrientation.PORTRAIT,
-      OutputOrientation.LANDSCAPE_RIGHT,
-      OutputOrientation.PORTRAIT_UPSIDE_DOWN,
-      OutputOrientation.LANDSCAPE_LEFT -> {
-        Log.i(TAG, "Setting output orientation to $targetOrientation. (locked)")
+      OutputOrientation.PREVIEW -> {
+        Log.i(TAG, "Starting streaming device and screen orientation updates...")
+        displayManager.registerDisplayListener(displayListener, null)
       }
     }
   }

--- a/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
@@ -75,13 +75,13 @@ class OrientationManager(private val context: Context, private val callback: Cal
     displayManager.unregisterDisplayListener(displayListener)
     orientationListener.disable()
 
-
     when (targetOrientation) {
       OutputOrientation.DEVICE -> {
         Log.i(TAG, "Starting streaming device and screen orientation updates...")
         orientationListener.enable()
         displayManager.registerDisplayListener(displayListener, null)
       }
+
       OutputOrientation.PREVIEW -> {
         Log.i(TAG, "Starting streaming device and screen orientation updates...")
         displayManager.registerDisplayListener(displayListener, null)

--- a/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/types/OutputOrientation.kt
@@ -2,33 +2,14 @@ package com.mrousavy.camera.core.types
 
 enum class OutputOrientation(override val unionValue: String) : JSUnionValue {
   DEVICE("device"),
-  PREVIEW("preview"),
-  PORTRAIT("portrait"),
-  LANDSCAPE_RIGHT("landscape-right"),
-  PORTRAIT_UPSIDE_DOWN("portrait-upside-down"),
-  LANDSCAPE_LEFT("landscape-left");
-
-  val lockedOrientation: Orientation?
-    get() {
-      return when (this) {
-        PORTRAIT -> Orientation.PORTRAIT
-        LANDSCAPE_LEFT -> Orientation.LANDSCAPE_LEFT
-        PORTRAIT_UPSIDE_DOWN -> Orientation.PORTRAIT_UPSIDE_DOWN
-        LANDSCAPE_RIGHT -> Orientation.LANDSCAPE_RIGHT
-        else -> null
-      }
-    }
+  PREVIEW("preview");
 
   companion object : JSUnionValue.Companion<OutputOrientation> {
     override fun fromUnionValue(unionValue: String?): OutputOrientation =
       when (unionValue) {
         "device" -> DEVICE
         "preview" -> PREVIEW
-        "portrait" -> PORTRAIT
-        "landscape-right" -> LANDSCAPE_RIGHT
-        "portrait-upside-down" -> PORTRAIT_UPSIDE_DOWN
-        "landscape-left" -> LANDSCAPE_LEFT
-        else -> PORTRAIT
+        else -> DEVICE
       }
   }
 }

--- a/package/ios/Core/OrientationManager.swift
+++ b/package/ios/Core/OrientationManager.swift
@@ -55,14 +55,6 @@ class OrientationManager: CameraOrientationCoordinatorDelegate {
     case .preview:
       // Outputs should use the same orientation as the preview view, which respects screen-lock.
       return previewOrientation
-    case .portrait, .landscapeLeft, .portraitUpsideDown, .landscapeRight:
-      // Outputs should be locked to the specific orientation given by the user.
-      guard let lockedOrientation = targetOutputOrientation.lockedOrientation,
-            let device else {
-        return previewOrientation
-      }
-      let sensorOrientation = device.sensorOrientation
-      return lockedOrientation.rotatedBy(orientation: sensorOrientation)
     }
   }
 

--- a/package/ios/Core/Types/OutputOrientation.swift
+++ b/package/ios/Core/Types/OutputOrientation.swift
@@ -16,51 +16,16 @@ enum OutputOrientation: String, JSUnionValue {
    Automatically rotate outputs based on preview view's rotation (obides to screen-lock)
    */
   case preview
-  /**
-   Fixed to portrait (0°, home-button on the bottom)
-   */
-  case portrait
-  /**
-   Fixed to landscape-left (90°, home-button on the left)
-   */
-  case landscapeLeft = "landscape-left"
-  /**
-   Fixed to portrait-upside-down (180°, home-button on the top)
-   */
-  case portraitUpsideDown = "portrait-upside-down"
-  /**
-   Fixed to landscape-right (270°, home-button on the right)
-   */
-  case landscapeRight = "landscape-right"
 
   init(jsValue: String) throws {
     if let parsed = OutputOrientation(rawValue: jsValue) {
       self = parsed
     } else {
-      throw CameraError.parameter(.invalid(unionName: "orientation", receivedValue: jsValue))
+      throw CameraError.parameter(.invalid(unionName: "outputOrientation", receivedValue: jsValue))
     }
   }
 
   var jsValue: String {
     return rawValue
-  }
-
-  /**
-   If the orientation is locked to a specific orientation, this will return the according Orientation.
-   If the orientation is dynamic/automatic (device/preview), this will return nil.
-   */
-  var lockedOrientation: Orientation? {
-    switch self {
-    case .portrait:
-      return .portrait
-    case .landscapeLeft:
-      return .landscapeLeft
-    case .portraitUpsideDown:
-      return .portraitUpsideDown
-    case .landscapeRight:
-      return .landscapeRight
-    default:
-      return nil
-    }
   }
 }

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -281,10 +281,6 @@ export interface CameraProps extends ViewProps {
    *
    * - `'preview'`: Use the same orientation as the preview view. If the device rotation is locked, the user cannot take photos or videos in different orientations.
    * - `'device'`: Use whatever orientation the device is held in, even if the preview view is not rotated to that orientation. If the device rotation is locked, the user can still rotate his phone to take photos or videos in different orientations than the preview view.
-   * - `'portrait'`: Force-rotate to **0°** (home-button at the bottom)
-   * - `'landscape-left'`: Force-rotate to **90°** (home-button on the left)
-   * - `'portrait-upside-down'`: Force-rotate to **180°** (home-button at the top)
-   * - `'landscape-right'`: Force-rotate to **270°** (home-button on the right)
    *
    * @note Preview orientation will not be affected by this property, as it is always dependant on screen orientation
    * @note Frame Processors will not be affected by this property, as their buffer size (respective to {@linkcode Frame.orientation}) is always the same

--- a/package/src/types/OutputOrientation.ts
+++ b/package/src/types/OutputOrientation.ts
@@ -1,9 +1,7 @@
-import type { Orientation } from './Orientation'
-
 /**
  * Represents the orientation of the camera outputs.
  *
- * Output orientation can either be automatically calculated (`'device'` or `'preview'`),
- * or fixed to a specific orientation ({@linkcode Orientation}).
+ * Output orientation can either be fixed to whatever the Preview View's orientation is (`'preview'`),
+ * or rotate alongside the device even if the Preview View is locked (`'device'`).
  */
-export type OutputOrientation = 'device' | 'preview' | Orientation
+export type OutputOrientation = 'device' | 'preview'


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

The fixed orientation options mentioned above just confused users and I don't think they should ever be used in a production app, because you need to counter-rotate them by the camera device's sensorOrientation first, and only then you could get a value you can use. Even then I don't see a reason to use a fixed orientation. 

Only `preview` and `device` are valid options in my opinion.

Either output in the same orientation as the view (if view is portrait -> output in portrait, if landscape -> output in landscape), or also allow rotating phone even if the view is locked. Two options. Makes sense.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
