### PR TITLE
feat: Dynamically determine `sensorOrientation` based on default output-connection-orientation

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -113,8 +113,8 @@ extension CameraSession {
       if configuration.isMirrored {
         // 2.1. If mirroring is enabled, mirror all connections along the vertical axis
         videoOutput.isMirrored = true
-        if videoOutput.orientation.isPortrait {
-          // 2.2. If we have a portrait orientation, we need to flip it upside down so it is mirrored on horizontal axis as well
+        if videoOutput.orientation.isLandscape {
+          // 2.2. If we have a landscape orientation, we need to flip it to counter the mirroring on the wrong axis.
           videoOutput.orientation = videoOutput.orientation.flipped()
           VisionLogger.log(level: .info, message: "AVCaptureVideoDataOutput will rotate Frames to \(videoOutput.orientation)...")
         }

--- a/package/ios/Core/CameraSession+Orientation.swift
+++ b/package/ios/Core/CameraSession+Orientation.swift
@@ -51,7 +51,7 @@ extension CameraSession: OrientationManagerDelegate {
     // update the orientation for each preview layer that is connected to this capture session
     let previewConnections = captureSession.connections.filter { $0.videoPreviewLayer != nil }
     for connection in previewConnections {
-      if connection.isVideoMirrored && sensorOrientation.isPortrait {
+      if connection.isVideoMirrored && sensorOrientation.isLandscape {
         // If this connection uses video mirroring, it flips frames alongside the vertical axis.
         // If the orientation is portrait, we flip it upside down to mirror alongside horizontal axis.
         VisionLogger.log(level: .info, message: "Flipping Preview orientation \(previewOrientation) to mirror it...")
@@ -74,7 +74,7 @@ extension CameraSession: OrientationManagerDelegate {
     for output in rotateableOutputs {
       // set orientation for all connections
       for connection in output.connections {
-        if connection.isVideoMirrored && sensorOrientation.isPortrait {
+        if connection.isVideoMirrored && sensorOrientation.isLandscape {
           // If this connection uses video mirroring, it flips frames alongside the vertical axis.
           // If the orientation is portrait, we flip it upside down to mirror alongside horizontal axis.
           VisionLogger.log(level: .info, message: "Flipping Output orientation \(outputOrientation) to mirror it...")

--- a/package/ios/Core/CameraSession+Orientation.swift
+++ b/package/ios/Core/CameraSession+Orientation.swift
@@ -10,6 +10,16 @@ import Foundation
 
 extension CameraSession: OrientationManagerDelegate {
   /**
+   Get the orientation of the currently connected camera device's sensor.
+   */
+  private var sensorOrientation: Orientation {
+    guard let input = videoDeviceInput else {
+      return DEFAULT_SENSOR_ORIENTATION
+    }
+    return input.device.sensorOrientation
+  }
+
+  /**
    Get the orientation all outputs should be configured to so they appear up-right.
    This is usually just a counter-rotation to whatever the input camera stream is.
    */
@@ -41,7 +51,7 @@ extension CameraSession: OrientationManagerDelegate {
     // update the orientation for each preview layer that is connected to this capture session
     let previewConnections = captureSession.connections.filter { $0.videoPreviewLayer != nil }
     for connection in previewConnections {
-      if connection.isVideoMirrored && previewOrientation.isPortrait {
+      if connection.isVideoMirrored && sensorOrientation.isPortrait {
         // If this connection uses video mirroring, it flips frames alongside the vertical axis.
         // If the orientation is portrait, we flip it upside down to mirror alongside horizontal axis.
         VisionLogger.log(level: .info, message: "Flipping Preview orientation \(previewOrientation) to mirror it...")
@@ -64,7 +74,7 @@ extension CameraSession: OrientationManagerDelegate {
     for output in rotateableOutputs {
       // set orientation for all connections
       for connection in output.connections {
-        if connection.isVideoMirrored && outputOrientation.isPortrait {
+        if connection.isVideoMirrored && sensorOrientation.isPortrait {
           // If this connection uses video mirroring, it flips frames alongside the vertical axis.
           // If the orientation is portrait, we flip it upside down to mirror alongside horizontal axis.
           VisionLogger.log(level: .info, message: "Flipping Output orientation \(outputOrientation) to mirror it...")

--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -91,12 +91,15 @@ extension CameraSession {
       VisionLogger.log(level: .info, message: "Will record to temporary file: \(tempURL)")
 
       do {
+        // Orientation is relative to our current output orientation
+        let orientation = self.outputOrientation.relativeTo(orientation: videoOutput.orientation)
+        
         // Create RecordingSession for the temp file
         let recordingSession = try RecordingSession(url: tempURL,
                                                     fileType: options.fileType,
                                                     metadataProvider: self.metadataProvider,
                                                     clock: self.captureSession.clock,
-                                                    orientation: self.outputOrientation,
+                                                    orientation: orientation,
                                                     completion: onFinish)
 
         // Init Audio + Activate Audio Session (optional)

--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -93,7 +93,7 @@ extension CameraSession {
       do {
         // Orientation is relative to our current output orientation
         let orientation = self.outputOrientation.relativeTo(orientation: videoOutput.orientation)
-        
+
         // Create RecordingSession for the temp file
         let recordingSession = try RecordingSession(url: tempURL,
                                                     fileType: options.fileType,

--- a/package/ios/Core/Extensions/AVCaptureConnection+orientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureConnection+orientation.swift
@@ -14,22 +14,13 @@ extension AVCaptureConnection {
    */
   var orientation: Orientation {
     get {
-      if #available(iOS 17.0, *) {
-        return Orientation(degrees: videoRotationAngle)
-      } else {
-        return Orientation(videoOrientation: videoOrientation)
-      }
+      // TODO: Use new videoRotationAngle APIs?
+      return Orientation(videoOrientation: videoOrientation)
     }
     set {
-      if #available(iOS 17.0, *) {
-        let degrees = newValue.degrees
-        if isVideoRotationAngleSupported(degrees) {
-          videoRotationAngle = degrees
-        }
-      } else {
-        if isVideoOrientationSupported {
-          videoOrientation = newValue.videoOrientation
-        }
+      // TODO: Use new videoRotationAngle APIs?
+      if isVideoOrientationSupported {
+        videoOrientation = newValue.videoOrientation
       }
     }
   }

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -36,6 +36,7 @@ extension AVCaptureDevice {
     let output = AVCaptureVideoDataOutput()
     output.automaticallyConfiguresOutputBufferDimensions = false
     output.deliversPreviewSizedOutputBuffers = true
+    output.isMirrored = false
     session.addOutput(output)
 
     // 4. Inspect the default orientation of the output

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -16,8 +16,39 @@ extension AVCaptureDevice {
    Get the natural orientation of the camera sensor of this specific device.
    */
   var sensorOrientation: Orientation {
-    // TODO: There is no iOS API to get native sensor orientation. The new `RotationCoordinator` API is a blackbox.
+    // TODO: There is no iOS API to get native sensor orientation.
+    //       - The new `RotationCoordinator` API is a blackbox, and cannot be used statically.
+    //       - The current approach (dynamically creating an AVCaptureSession) is very hacky and has a runtime overhead.
     //       Hopefully iOS adds an API to get sensor orientation soon so we can use that!
-    return DEFAULT_SENSOR_ORIENTATION
+
+    let start = DispatchTime.now()
+
+    // 1. Create a capture session
+    let session = AVCaptureSession()
+
+    // 2. Add this device as an input
+    guard let input = try? AVCaptureDeviceInput(device: self) else {
+      VisionLogger.log(level: .error, message: "Cannot dynamically determine \(uniqueID)'s sensorOrientation, " +
+        "falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
+      return DEFAULT_SENSOR_ORIENTATION
+    }
+    session.addInput(input)
+
+    // 3. Add an output (e.g. video data output)
+    let output = AVCaptureVideoDataOutput()
+    output.automaticallyConfiguresOutputBufferDimensions = false
+    output.deliversPreviewSizedOutputBuffers = true
+    session.addOutput(output)
+
+    // 4. Inspect the default orientation of the output
+    let defaultOrientation = output.orientation
+
+    let end = DispatchTime.now()
+    let ms = (end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+    print("Getting orientation took \(ms)ms.")
+
+    // 5. Rotate the default orientation by the default sensor orientation we know of
+    let sensorOrientation = defaultOrientation.rotatedBy(orientation: DEFAULT_SENSOR_ORIENTATION)
+    return sensorOrientation
   }
 }

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -40,11 +40,16 @@ extension AVCaptureDevice {
     session.addOutput(output)
 
     // 4. Inspect the default orientation of the output
-    output.isMirrored = false
     let defaultOrientation = output.orientation
 
     // 5. Rotate the default orientation by the default sensor orientation we know of
-    let sensorOrientation = defaultOrientation.rotatedBy(orientation: DEFAULT_SENSOR_ORIENTATION)
+    var sensorOrientation = defaultOrientation.rotatedBy(orientation: DEFAULT_SENSOR_ORIENTATION)
+    
+    // 6. If we are on the front Camera, AVCaptureVideoDataOutput.orientation is mirrored.
+    if position == .front {
+      sensorOrientation = sensorOrientation.flipped()
+    }
+    
     return sensorOrientation
   }
 }

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -44,12 +44,12 @@ extension AVCaptureDevice {
 
     // 5. Rotate the default orientation by the default sensor orientation we know of
     var sensorOrientation = defaultOrientation.rotatedBy(orientation: DEFAULT_SENSOR_ORIENTATION)
-    
+
     // 6. If we are on the front Camera, AVCaptureVideoDataOutput.orientation is mirrored.
     if position == .front {
       sensorOrientation = sensorOrientation.flipped()
     }
-    
+
     return sensorOrientation
   }
 }

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -18,7 +18,7 @@ extension AVCaptureDevice {
   var sensorOrientation: Orientation {
     // TODO: There is no iOS API to get native sensor orientation.
     //       - The new `RotationCoordinator` API is a blackbox, and cannot be used statically.
-    //       - The current approach (dynamically creating an AVCaptureSession) is very hacky and has a runtime overhead.
+    //       - Dynamically creating an AVCaptureSession is very hacky and has a runtime overhead.
     //       Hopefully iOS adds an API to get sensor orientation soon so we can use that!
 
     // 1. Create a capture session

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -23,6 +23,7 @@ extension AVCaptureDevice {
 
     // 1. Create a capture session
     let session = AVCaptureSession()
+    session.sessionPreset = .low
 
     // 2. Add this device as an input
     guard let input = try? AVCaptureDeviceInput(device: self) else {

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -21,8 +21,6 @@ extension AVCaptureDevice {
     //       - The current approach (dynamically creating an AVCaptureSession) is very hacky and has a runtime overhead.
     //       Hopefully iOS adds an API to get sensor orientation soon so we can use that!
 
-    let start = DispatchTime.now()
-
     // 1. Create a capture session
     let session = AVCaptureSession()
 
@@ -42,10 +40,6 @@ extension AVCaptureDevice {
 
     // 4. Inspect the default orientation of the output
     let defaultOrientation = output.orientation
-
-    let end = DispatchTime.now()
-    let ms = (end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
-    print("Getting orientation took \(ms)ms.")
 
     // 5. Rotate the default orientation by the default sensor orientation we know of
     let sensorOrientation = defaultOrientation.rotatedBy(orientation: DEFAULT_SENSOR_ORIENTATION)

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -36,10 +36,10 @@ extension AVCaptureDevice {
     let output = AVCaptureVideoDataOutput()
     output.automaticallyConfiguresOutputBufferDimensions = false
     output.deliversPreviewSizedOutputBuffers = true
-    output.isMirrored = false
     session.addOutput(output)
 
     // 4. Inspect the default orientation of the output
+    output.isMirrored = false
     let defaultOrientation = output.orientation
 
     // 5. Rotate the default orientation by the default sensor orientation we know of

--- a/package/ios/Core/Extensions/AVCaptureOutput+isMirrored.swift
+++ b/package/ios/Core/Extensions/AVCaptureOutput+isMirrored.swift
@@ -14,9 +14,13 @@ extension AVCaptureOutput {
    */
   var isMirrored: Bool {
     get {
-      return connections.contains { $0.isVideoMirrored == true }
+      guard let connection = connection(with: .video) else {
+        fatalError("AVCaptureOutput needs to be connected before accessing .isMirrored!")
+      }
+      return connection.isVideoMirrored
     }
     set {
+      assert(!connections.isEmpty, "isMirrored can only be set when connected to a session!")
       for connection in connections {
         if connection.isVideoMirroringSupported {
           connection.automaticallyAdjustsVideoMirroring = false

--- a/package/ios/Core/Extensions/AVCaptureOutput+orientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureOutput+orientation.swift
@@ -14,12 +14,13 @@ extension AVCaptureOutput {
    */
   var orientation: Orientation {
     get {
-      guard let connection = connections.first else {
+      guard let connection = connection(with: .video) else {
         fatalError("AVCaptureOutput needs to be connected before accessing .connection!")
       }
       return connection.orientation
     }
     set {
+      assert(!connections.isEmpty, "isMirrored can only be set when connected to a session!")
       for connection in connections {
         connection.orientation = newValue
       }

--- a/package/ios/Core/Extensions/CMAccelerometerData+deviceOrientation.swift
+++ b/package/ios/Core/Extensions/CMAccelerometerData+deviceOrientation.swift
@@ -1,0 +1,40 @@
+//
+//  CMAccelerometerData+deviceOrientation.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 03.07.24.
+//
+
+import Foundation
+import CoreMotion
+
+extension CMAccelerometerData {
+  /**
+   Get the current device orientation from the given acceleration/gyro data.
+   */
+  var deviceOrientation: Orientation {
+    let acceleration = acceleration
+    let xNorm = abs(acceleration.x)
+    let yNorm = abs(acceleration.y)
+    let zNorm = abs(acceleration.z)
+
+    // If the z-axis is greater than the other axes, the phone is flat.
+    if zNorm > xNorm && zNorm > yNorm {
+      return .portrait
+    }
+
+    if xNorm > yNorm {
+      if acceleration.x > 0 {
+        return .landscapeRight
+      } else {
+        return .landscapeLeft
+      }
+    } else {
+      if acceleration.y > 0 {
+        return .portraitUpsideDown
+      } else {
+        return .portrait
+      }
+    }
+  }
+}

--- a/package/ios/Core/Extensions/CMAccelerometerData+deviceOrientation.swift
+++ b/package/ios/Core/Extensions/CMAccelerometerData+deviceOrientation.swift
@@ -5,8 +5,8 @@
 //  Created by Marc Rousavy on 03.07.24.
 //
 
-import Foundation
 import CoreMotion
+import Foundation
 
 extension CMAccelerometerData {
   /**

--- a/package/ios/Core/OrientationManager.swift
+++ b/package/ios/Core/OrientationManager.swift
@@ -161,24 +161,12 @@ final class OrientationManager {
     stopDeviceOrientationListener()
     if motionManager.isAccelerometerAvailable {
       motionManager.accelerometerUpdateInterval = 0.2
-      motionManager.startAccelerometerUpdates(to: operationQueue) { accelerometerData, _ in
-        guard let accelerometerData = accelerometerData else {
-          return
+      motionManager.startAccelerometerUpdates(to: operationQueue) { accelerometerData, error in
+        if let error {
+          VisionLogger.log(level: .error, message: "Failed to get Accelerometer data! \(error)")
         }
-        let acceleration = accelerometerData.acceleration
-        let xNorm = abs(acceleration.x)
-        let yNorm = abs(acceleration.y)
-        let zNorm = abs(acceleration.z)
-
-        // If the z-axis is greater than the other axes, the orientation does not change
-        if zNorm > xNorm && zNorm > yNorm {
-          return
-        }
-
-        if xNorm > yNorm {
-          self.deviceOrientation = acceleration.x > 0 ? .landscapeRight : .landscapeLeft
-        } else {
-          self.deviceOrientation = acceleration.y > 0 ? .portraitUpsideDown : .portrait
+        if let accelerometerData {
+          self.deviceOrientation = accelerometerData.deviceOrientation
         }
       }
     }

--- a/package/ios/Core/Types/Orientation.swift
+++ b/package/ios/Core/Types/Orientation.swift
@@ -41,15 +41,19 @@ enum Orientation: String, JSUnionValue {
   }
 
   init(degrees: Double) {
-    switch degrees {
+    let normalized = Orientation.normalizeDegrees(degrees)
+    switch normalized {
     case 45 ..< 135:
       self = .landscapeLeft
     case 135 ..< 225:
       self = .portraitUpsideDown
     case 225 ..< 315:
       self = .landscapeRight
-    default:
+    case 315 ..< 360: fallthrough
+    case 0 ..< 45:
       self = .portrait
+    default:
+      fatalError("Orientation: Invalid degrees (\(degrees)°) specified!")
     }
   }
 
@@ -168,9 +172,7 @@ enum Orientation: String, JSUnionValue {
 
   @inlinable
   func rotatedBy(degrees: Double) -> Orientation {
-    let added = self.degrees + degrees + 360
-    let degress = added.truncatingRemainder(dividingBy: 360)
-    return Orientation(degrees: degress)
+    return Orientation(degrees: self.degrees + degrees)
   }
 
   @inline(__always)
@@ -186,5 +188,14 @@ enum Orientation: String, JSUnionValue {
   @inline(__always)
   func relativeTo(orientation: Orientation) -> Orientation {
     return rotatedBy(degrees: -orientation.degrees)
+  }
+  
+  @inlinable
+  static func normalizeDegrees(_ degrees: Double) -> Double {
+    let normalized = degrees.truncatingRemainder(dividingBy: 360)
+    if normalized < 0 {
+      return normalized + 360
+    }
+    return normalized
   }
 }

--- a/package/ios/Core/Types/Orientation.swift
+++ b/package/ios/Core/Types/Orientation.swift
@@ -49,8 +49,7 @@ enum Orientation: String, JSUnionValue {
       self = .portraitUpsideDown
     case 225 ..< 315:
       self = .landscapeRight
-    case 315 ..< 360: fallthrough
-    case 0 ..< 45:
+    case 315 ..< 360, 0 ..< 45:
       self = .portrait
     default:
       fatalError("Orientation: Invalid degrees (\(degrees)°) specified!")
@@ -189,7 +188,7 @@ enum Orientation: String, JSUnionValue {
   func relativeTo(orientation: Orientation) -> Orientation {
     return rotatedBy(degrees: -orientation.degrees)
   }
-  
+
   @inlinable
   static func normalizeDegrees(_ degrees: Double) -> Double {
     let normalized = degrees.truncatingRemainder(dividingBy: 360)

--- a/package/ios/Core/Types/Orientation.swift
+++ b/package/ios/Core/Types/Orientation.swift
@@ -169,7 +169,7 @@ enum Orientation: String, JSUnionValue {
     return self == .landscapeLeft || self == .landscapeRight
   }
 
-  @inlinable
+  @inline(__always)
   func rotatedBy(degrees: Double) -> Orientation {
     return Orientation(degrees: self.degrees + degrees)
   }
@@ -189,7 +189,7 @@ enum Orientation: String, JSUnionValue {
     return rotatedBy(degrees: -orientation.degrees)
   }
 
-  @inlinable
+  @inline(__always)
   static func normalizeDegrees(_ degrees: Double) -> Double {
     let normalized = degrees.truncatingRemainder(dividingBy: 360)
     if normalized < 0 {

--- a/package/ios/Core/Types/Orientation.swift
+++ b/package/ios/Core/Types/Orientation.swift
@@ -88,10 +88,12 @@ enum Orientation: String, JSUnionValue {
     case .portrait:
       self = .portrait
     case .landscapeRight:
+      // Interface orientation landscapeRight is the opposite of device orientation
       self = .landscapeLeft
     case .portraitUpsideDown:
       self = .portraitUpsideDown
     case .landscapeLeft:
+      // Interface orientation landscapeLeft is the opposite of device orientation
       self = .landscapeRight
     default:
       self = .portrait
@@ -160,6 +162,11 @@ enum Orientation: String, JSUnionValue {
   }
 
   @inline(__always)
+  var isLandscape: Bool {
+    return self == .landscapeLeft || self == .landscapeRight
+  }
+
+  @inlinable
   func rotatedBy(degrees: Double) -> Orientation {
     let added = self.degrees + degrees + 360
     let degress = added.truncatingRemainder(dividingBy: 360)


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Previously, we just assumed a default sensor orientation of `landscapeLeft` on iOS.

While this worked on my iPhone 15 Pro and was also posted as a safe-to-assume default value in Apple Developer Forums, it is apparently not safe to assume that this is the default value. 🤦 

On my iPhone 8, the preview was rotated by 90deg.

So instead, this PR now attempts to dynamically get the sensor orientation value by creating a dummy capture session, adding an output to it, and getting it's default orientation value. 

This then needs to be rotated by 90deg (I don't know why), and then we have a default orientation value for all phones - I think.

I'd need to test this on iPads and other iPhones first though

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
