### PR TITLE
fix: Set minFPS to 20 to allow maximum resolution photo

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
@@ -1,5 +1,6 @@
 package com.mrousavy.camera.core
 
+import android.util.Range
 import androidx.camera.core.Preview.SurfaceProvider
 import com.mrousavy.camera.core.types.CameraDeviceFormat
 import com.mrousavy.camera.core.types.CodeType
@@ -8,6 +9,7 @@ import com.mrousavy.camera.core.types.PixelFormat
 import com.mrousavy.camera.core.types.QualityBalance
 import com.mrousavy.camera.core.types.Torch
 import com.mrousavy.camera.core.types.VideoStabilizationMode
+import kotlin.math.min
 
 data class CameraConfiguration(
   // Input
@@ -50,6 +52,14 @@ data class CameraConfiguration(
   data class FrameProcessor(val isMirrored: Boolean, val pixelFormat: PixelFormat)
   data class Audio(val nothing: Unit)
   data class Preview(val surfaceProvider: SurfaceProvider)
+
+  val targetFpsRange: Range<Int>?
+    get() {
+      // due to a bug (or feature?) in CameraX, photo resolution will suffer if min FPS is higher than 20.
+      val maxFps = fps ?: return null
+      val minFps = min(20, maxFps)
+      return Range(minFps, maxFps)
+    }
 
   val targetPreviewAspectRatio: Float?
     get() {

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -2,7 +2,6 @@ package com.mrousavy.camera.core
 
 import android.annotation.SuppressLint
 import android.util.Log
-import android.util.Range
 import androidx.annotation.OptIn
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.CameraState
@@ -25,16 +24,7 @@ import com.mrousavy.camera.core.types.Torch
 import com.mrousavy.camera.core.types.VideoStabilizationMode
 import kotlin.math.roundToInt
 
-internal fun getTargetFpsRange(configuration: CameraConfiguration): Range<Int>? {
-  val fps = configuration.fps ?: return null
-  return if (configuration.enableLowLightBoost) {
-    Range(fps / 2, fps)
-  } else {
-    Range(fps, fps)
-  }
-}
-
-internal fun assertFormatRequirement(
+private fun assertFormatRequirement(
   propName: String,
   format: CameraDeviceFormat?,
   throwIfNotMet: CameraError,
@@ -55,7 +45,7 @@ internal fun assertFormatRequirement(
 @Suppress("LiftReturnOrAssignment")
 internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) {
   Log.i(CameraSession.TAG, "Creating new Outputs for Camera #${configuration.cameraId}...")
-  val fpsRange = getTargetFpsRange(configuration)
+  val fpsRange = configuration.targetFpsRange
   val format = configuration.format
 
   Log.i(CameraSession.TAG, "Using FPS Range: $fpsRange")


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

After research by @Dingenis, we found out that when setting FPS to `30` (min 30, max 30), the CameraX pipeline will reduce photo resolution to a very low value for some reason.

We are not sure if this is a bug or intended behaviour, that's why we will create an issue in the CameraX issue tracker.

As a temporary (or permanent?) solution for VisionCamera, we now change the FPS logic to not be a fixed rate (min 30 max 30), but instead lower the min FPS to 20 (min 20 max 30) - so it is variable.

In low light conditions, FPS will now drop to as low as 20, while in good light conditions it will go to the desired target FPS value.



<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Temporarily fixes https://github.com/mrousavy/react-native-vision-camera/issues/3031

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
