### PR TITLE
fix: Make `AVCaptureDevice.sensorOrientation` safer

### DIFF
--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -23,12 +23,17 @@ extension AVCaptureDevice {
 
     // 1. Create a capture session
     let session = AVCaptureSession()
-    session.sessionPreset = .low
+    if session.canSetSessionPreset(.low) {
+      session.sessionPreset = .low
+    }
 
     // 2. Add this device as an input
     guard let input = try? AVCaptureDeviceInput(device: self) else {
       VisionLogger.log(level: .error, message: "Cannot dynamically determine \(uniqueID)'s sensorOrientation, " +
         "falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
+      return DEFAULT_SENSOR_ORIENTATION
+    }
+    guard session.canAddInput(input) else {
       return DEFAULT_SENSOR_ORIENTATION
     }
     session.addInput(input)
@@ -37,6 +42,9 @@ extension AVCaptureDevice {
     let output = AVCaptureVideoDataOutput()
     output.automaticallyConfiguresOutputBufferDimensions = false
     output.deliversPreviewSizedOutputBuffers = true
+    guard session.canAddOutput(output) else {
+      return DEFAULT_SENSOR_ORIENTATION
+    }
     session.addOutput(output)
 
     // 4. Inspect the default orientation of the output


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Makes the getter for `sensorOrientation` safer by checking if we can set a preset, add the input, and add the output before actually doing it.

This could prevent some crashes with external/continouity cameras.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
