### PR TITLE
feat: Expose `.external` and `.continuityCamera` devices

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -1391,16 +1391,16 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.0)
-  - VisionCamera (4.4.0):
-    - VisionCamera/Core (= 4.4.0)
-    - VisionCamera/FrameProcessors (= 4.4.0)
-    - VisionCamera/React (= 4.4.0)
-  - VisionCamera/Core (4.4.0)
-  - VisionCamera/FrameProcessors (4.4.0):
+  - VisionCamera (4.4.1):
+    - VisionCamera/Core (= 4.4.1)
+    - VisionCamera/FrameProcessors (= 4.4.1)
+    - VisionCamera/React (= 4.4.1)
+  - VisionCamera/Core (4.4.1)
+  - VisionCamera/FrameProcessors (4.4.1):
     - React
     - React-callinvoker
     - react-native-worklets-core
-  - VisionCamera/React (4.4.0):
+  - VisionCamera/React (4.4.1):
     - React-Core
     - VisionCamera/FrameProcessors
   - Yoga (0.0.0)
@@ -1688,7 +1688,7 @@ SPEC CHECKSUMS:
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNVectorIcons: 2a2f79274248390b80684ea3c4400bd374a15c90
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  VisionCamera: 5b17187dd09e4c8bef7c0b1d5abebfb268ff703d
+  VisionCamera: 670bd7d5ec35b6e3bfaf9d48f4a102248291b00d
   Yoga: 2f71ecf38d934aecb366e686278102a51679c308
 
 PODFILE CHECKSUM: 49584be049764895189f1f88ebc9769116621103

--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -30,10 +30,12 @@ extension AVCaptureDevice {
     // 2. Add this device as an input
     guard let input = try? AVCaptureDeviceInput(device: self) else {
       VisionLogger.log(level: .error, message: "Cannot dynamically determine \(uniqueID)'s sensorOrientation, " +
-        "falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
+        "because the AVCaptureDeviceInput cannot be created. Falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
       return DEFAULT_SENSOR_ORIENTATION
     }
     guard session.canAddInput(input) else {
+      VisionLogger.log(level: .error, message: "Cannot dynamically determine \(uniqueID)'s sensorOrientation, because " +
+        "it cannot be added to the temporary AVCaptureSession. Falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
       return DEFAULT_SENSOR_ORIENTATION
     }
     session.addInput(input)
@@ -43,6 +45,8 @@ extension AVCaptureDevice {
     output.automaticallyConfiguresOutputBufferDimensions = false
     output.deliversPreviewSizedOutputBuffers = true
     guard session.canAddOutput(output) else {
+      VisionLogger.log(level: .error, message: "Cannot dynamically determine \(uniqueID)'s sensorOrientation, because " +
+        "the AVCaptureVideoDataOutput cannot be added to the AVCaptureSession. Falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
       return DEFAULT_SENSOR_ORIENTATION
     }
     session.addOutput(output)

--- a/package/ios/React/CameraDevicesManager.swift
+++ b/package/ios/React/CameraDevicesManager.swift
@@ -32,7 +32,7 @@ final class CameraDevicesManager: RCTEventEmitter {
     return [devicesChangedEventName]
   }
 
-  override class func requiresMainQueueSetup() -> Bool {
+  override static func requiresMainQueueSetup() -> Bool {
     return false
   }
 

--- a/package/ios/React/CameraDevicesManager.swift
+++ b/package/ios/React/CameraDevicesManager.swift
@@ -38,11 +38,11 @@ class CameraDevicesManager: RCTEventEmitter {
 
   override func constantsToExport() -> [AnyHashable: Any]! {
     let devices = getDevicesJson()
-    let preferredDevice = getPreferredDevice()
+    let preferredDevice = getPreferredDeviceJson()
 
     return [
       "availableCameraDevices": devices,
-      "userPreferredCameraDevice": preferredDevice?.toDictionary() as Any,
+      "userPreferredCameraDevice": preferredDevice as Any,
     ]
   }
 
@@ -50,6 +50,11 @@ class CameraDevicesManager: RCTEventEmitter {
     return discoverySession.devices.map {
       return $0.toDictionary()
     }
+  }
+
+  private func getPreferredDeviceJson() -> [String: Any]? {
+    let preferredDevice = getPreferredDevice()
+    return preferredDevice?.toDictionary()
   }
 
   private func getPreferredDevice() -> AVCaptureDevice? {
@@ -80,13 +85,14 @@ class CameraDevicesManager: RCTEventEmitter {
       deviceTypes.append(.builtInLiDARDepthCamera)
     }
 
-    // iOS 17 specifics:
-    //  This is only reported if `NSCameraUseExternalDeviceType` is set to true in Info.plist,
-    //  otherwise external devices are just reported as wide-angle-cameras
-    // deviceTypes.append(.external)
-    //  This is only reported if `NSCameraUseContinuityCameraDeviceType` is set to true in Info.plist,
-    //  otherwise continuity camera devices are just reported as wide-angle-cameras
-    // deviceTypes.append(.continuityCamera)
+    if #available(iOS 17.0, *) {
+      // This is only reported if `NSCameraUseExternalDeviceType` is set to true in Info.plist,
+      // otherwise external devices are just reported as wide-angle-cameras
+      deviceTypes.append(.external)
+      // This is only reported if `NSCameraUseContinuityCameraDeviceType` is set to true in Info.plist,
+      // otherwise continuity camera devices are just reported as wide-angle-cameras
+      deviceTypes.append(.continuityCamera)
+    }
 
     return deviceTypes
   }

--- a/package/ios/React/CameraDevicesManager.swift
+++ b/package/ios/React/CameraDevicesManager.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Foundation
 
 @objc(CameraDevicesManager)
-class CameraDevicesManager: RCTEventEmitter {
+final class CameraDevicesManager: RCTEventEmitter {
   private let discoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: getAllDeviceTypes(),
                                                                   mediaType: .video,
                                                                   position: .unspecified)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Exposes `.external` and `.continuityCamera` devices to the user in the Camera Devices API.

- `.external` only exists if `NSCameraUseExternalDeviceType` is set to YES in `Info.plist`
- `.continuityCamera` only exists if `NSCameraUseContinuityCameraDeviceType` is set to YES in `Info.plist`

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
