### PR TITLE
fix: Fix `zoom`/`torch`/`exposure` not being applied when switching `device`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
@@ -122,9 +122,6 @@ data class CameraConfiguration(
     fun copyOf(other: CameraConfiguration?): CameraConfiguration = other?.copy() ?: CameraConfiguration()
 
     fun difference(left: CameraConfiguration?, right: CameraConfiguration): Difference {
-      // input device
-      val deviceChanged = left?.cameraId != right.cameraId
-
       // outputs
       val outputsChanged = left?.photo != right.photo ||
         left.video != right.video ||
@@ -136,8 +133,11 @@ data class CameraConfiguration(
         left.format != right.format ||
         left.fps != right.fps
 
+      // input device
+      val deviceChanged = outputsChanged || left?.cameraId != right.cameraId
+
       // repeating request
-      val sidePropsChanged = outputsChanged ||
+      val sidePropsChanged = deviceChanged ||
         left?.torch != right.torch ||
         left.zoom != right.zoom ||
         left.exposure != right.exposure

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -136,7 +136,7 @@ class CameraSession(internal val context: Context, internal val callback: Callba
           // 1.1. whenever the outputs changed, we need to update their orientation as well
           configureOrientation()
         }
-        if (diff.deviceChanged || diff.outputsChanged) {
+        if (diff.deviceChanged) {
           // 2. input or outputs changed, or the session was destroyed from outside, rebind the session
           configureCamera(provider, config)
         }


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

On Android, `zoom`, `torch` and `exposure` are "side-props" that depend on the `camera`, which is re-created every time the `device` (`cameraId`) changes.

Before, we only updated "side-props" when outputs changed, which could cause a camera flip to mistakenly not set `zoom`/`torch`/`exposure` values.

Now after this PR this behaviour is fixed, and `zoom`/`torch`/`exposure` will always be re-set whenever the `camera` device changes.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #3027 


<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
