### PR TITLE
fix: Fix invalid `userPreferredCameraDevice`

### DIFF
--- a/package/ios/React/CameraDevicesManager.swift
+++ b/package/ios/React/CameraDevicesManager.swift
@@ -75,8 +75,16 @@ final class CameraDevicesManager: RCTEventEmitter {
         return userPreferred
       }
     }
-    // Just return the first device
-    return discoverySession.devices.first
+    // Usually prefer the wide angle back camera
+    if let defaultBackWideAngle = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back) {
+      return defaultBackWideAngle
+    }
+    // Fall back to the default video
+    if let defaultVideo = AVCaptureDevice.default(for: .video) {
+      return defaultVideo
+    }
+    // Return nil because apparently we couldn't find a default
+    return nil
   }
 
   private static func getAllDeviceTypes() -> [AVCaptureDevice.DeviceType] {

--- a/package/ios/React/CameraDevicesManager.swift
+++ b/package/ios/React/CameraDevicesManager.swift
@@ -63,14 +63,18 @@ final class CameraDevicesManager: RCTEventEmitter {
   }
 
   private func getPreferredDevice() -> AVCaptureDevice? {
-    #if swift(>=5.9)
-      if #available(iOS 17.0, *) {
-        if let userPreferred = AVCaptureDevice.userPreferredCamera {
-          // Return the device that was explicitly marked as a preferred camera by the user
-          return userPreferred
+    if #available(iOS 17.0, *) {
+      if let userPreferred = AVCaptureDevice.userPreferredCamera {
+        guard !userPreferred.uniqueID.isEmpty else {
+          // Due to an iOS 17 bug, Simulators return a non-nil AVCaptureDevice here,
+          // but all properties on this AVCaptureDevice are 0x0/empty/invalid.
+          // So we catch this bug and return a nil preferred device here.
+          return nil
         }
+        // Return the device that was explicitly marked as a preferred camera by the user
+        return userPreferred
       }
-    #endif
+    }
     // Just return the first device
     return discoverySession.devices.first
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Due to an iOS 17 bug, Simulators return a non-nil `AVCaptureDevice` in `AVCaptureDevice.userPreferredCamera`, but all properties on this `AVCaptureDevice` are `0x0`/empty/invalid - it is an invalid `AVCaptureDevice` that shouldn't even exist (it's not part of the `AVCaptureDevice.DiscoverySession` either!)

So we catch this bug and return a nil preferred device instead if the `uniqueID` (`device.id`) is empty (because the ID cannot be empty).

I already submitted a bug report to Apple (FB14262963).

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
