### PR TITLE
fix: Don't ask for camera permission in `getAvailableCameraDevices`

### DIFF
--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -21,6 +21,13 @@ extension AVCaptureDevice {
     //       - Dynamically creating an AVCaptureSession is very hacky and has a runtime overhead.
     //       Hopefully iOS adds an API to get sensor orientation soon so we can use that!
 
+    // 0. If we don't have Camera permission yet, we cannot create a temporary AVCaptureSession.
+    //    So we just return the default orientation as a workaround...
+    let cameraPermissionStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    if cameraPermissionStatus != .authorized {
+      return DEFAULT_SENSOR_ORIENTATION
+    }
+
     // 1. Create a capture session
     let session = AVCaptureSession()
     if session.canSetSessionPreset(.low) {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Unfortunately iOS/Apple does not provide an API to access a Camera Device's natural sensor orientation.

We need this natural sensor orientation **in advance**, because `Camera.getAvailableCameraDevices()` (or `useCameraDevice()`) looks up all devices, and the devices in there have a sensor orientation property.

Also, we need to rotate the output and preview orientations by the Camera Device's sensor orientation to achieve upright position, which is seemingly stupid that there is no other way. (I mean, **now** there is another way in iOS 17+ using `RotationCoordinator`, but we also need support below iOS 17)

As a current workaround I create a temporary `AVCaptureSession`, add the camera device to it, and check what default orientation the buffers in there have (I don't actually _start_ the session, I just create it)

Unfortunately this caused apps to request for Camera Permission at app startup, because constructing an `AVCaptureSession` apparently requires camera permission, even if you're not starting it.

So as a "fix" (workaround) I just return the default sensor orientation when camera permission has not been granted yet.

**This is all not a great idea** - I really need a better API to get the sensor orientation.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3071

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
