### PR TITLE
feat: Capture better quality photos by using `minFps` from `format`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
@@ -9,7 +9,6 @@ import com.mrousavy.camera.core.types.PixelFormat
 import com.mrousavy.camera.core.types.QualityBalance
 import com.mrousavy.camera.core.types.Torch
 import com.mrousavy.camera.core.types.VideoStabilizationMode
-import kotlin.math.min
 
 data class CameraConfiguration(
   // Input

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
@@ -55,9 +55,9 @@ data class CameraConfiguration(
 
   val targetFpsRange: Range<Int>?
     get() {
-      // due to a bug (or feature?) in CameraX, photo resolution will suffer if min FPS is higher than 20.
       val maxFps = fps ?: return null
-      val minFps = min(20, maxFps)
+      val format = format ?: throw PropRequiresFormatToBeNonNullError("fps")
+      val minFps = format.minFps.toInt()
       return Range(minFps, maxFps)
     }
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -81,7 +81,7 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
         preview.setResolutionSelector(previewResolutionSelector)
       }
     }.build()
-    preview.surfaceProvider = previewConfig.config.surfaceProvider
+    preview.setSurfaceProvider(previewConfig.config.surfaceProvider)
     previewOutput = preview
   } else {
     previewOutput = null


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Using a lower `minFps` value gives the Camera more time to capture lighting.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
