### PR TITLE
fix: Fix not-found plugins crashing the app

### DIFF
--- a/package/android/src/main/cpp/frameprocessors/VisionCameraProxy.cpp
+++ b/package/android/src/main/cpp/frameprocessors/VisionCameraProxy.cpp
@@ -54,7 +54,7 @@ jsi::Value VisionCameraProxy::initFrameProcessorPlugin(jsi::Runtime& runtime, co
 
   auto plugin = _javaProxy->cthis()->initFrameProcessorPlugin(name, options);
   if (plugin == nullptr) {
-      return jsi::Value::undefined();
+    return jsi::Value::undefined();
   }
 
   auto pluginHostObject = std::make_shared<FrameProcessorPluginHostObject>(plugin);

--- a/package/android/src/main/cpp/frameprocessors/VisionCameraProxy.cpp
+++ b/package/android/src/main/cpp/frameprocessors/VisionCameraProxy.cpp
@@ -53,6 +53,9 @@ jsi::Value VisionCameraProxy::initFrameProcessorPlugin(jsi::Runtime& runtime, co
   auto options = JSIJNIConversion::convertJSIObjectToJNIMap(runtime, jsOptions);
 
   auto plugin = _javaProxy->cthis()->initFrameProcessorPlugin(name, options);
+  if (plugin == nullptr) {
+      return jsi::Value::undefined();
+  }
 
   auto pluginHostObject = std::make_shared<FrameProcessorPluginHostObject>(plugin);
   return jsi::Object::createFromHostObject(runtime, pluginHostObject);

--- a/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.kt
+++ b/package/example/android/app/src/main/java/com/mrousavy/camera/example/MainApplication.kt
@@ -17,7 +17,7 @@ import com.mrousavy.camera.frameprocessors.FrameProcessorPluginRegistry
 class MainApplication : Application(), ReactApplication {
   companion object {
     init {
-        FrameProcessorPluginRegistry.addFrameProcessorPlugin("example") { proxy, args -> ExampleFrameProcessorPlugin(proxy, args) }
+        FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_plugin") { proxy, args -> ExampleFrameProcessorPlugin(proxy, args) }
         FrameProcessorPluginRegistry.addFrameProcessorPlugin("example_kotlin_swift_plugin") { proxy, args -> ExampleKotlinFrameProcessorPlugin(proxy, args) }
     }
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

The `VisionCameraProxy.initFrameProcessorPlugin` function returns `undefined` if a plugin cannot be found.

On iOS, this worked. On Android however, I internally (in C++) didn't check for `nullptr`, so I always tried to create a callable plugin (`FrameProcessorPluginHostObject`) with a `nullptr` implementation.
If the plugin was not found, it would crash the app with a very cryptic error:

```
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542] JNI DETECTED ERROR IN APPLICATION: java_object == null
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]     in call to GetObjectClass
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]     from void com.mrousavy.camera.frameprocessors.FrameProcessor.call(com.mrousavy.camera.frameprocessors.Frame)
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542] "mrousavy/VisionCamera.video" prio=5 tid=34 Runnable
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   | group="main" sCount=0 dsCount=0 flags=0 obj=0x13c80f38 self=0x7909eca400
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   | sysTid=20801 nice=0 cgrp=default sched=0/0 handle=0x79075f14f0
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   | state=R schedstat=( 11162500 14733333 15 ) utm=0 stm=0 core=2 HZ=100
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   | stack=0x79074ee000-0x79074f0000 stackSize=1041KB
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   | held mutexes= "mutator lock"(shared held)
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   native: #00 pc 00000000003d1348  /system/lib64/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, int, BacktraceMap*, char const*, art::ArtMethod*, void*, bool)+220)
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   native: #01 pc 00000000004ae718  /system/lib64/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, bool, BacktraceMap*, bool) const+352)
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   native: #02 pc 00000000002f27d8  /system/lib64/libart.so (art::JavaVMExt::JniAbort(char const*, char const*)+968)
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   native: #03 pc 000000000033f43c  /system/lib64/libart.so (art::JNI::GetObjectClass(_JNIEnv*, _jobject*)+1012)
12:49:18.683 .camera.exampl           A  java_vm_ext.cc:542]   native: #04 pc 0000000000057180  /data/app/com.mrousavy.camera.example-JFMaM26PVYjC58pOrIhyEQ==/base.apk (offset 4911000) (vision::JFrameProcessorPlugin::callback(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<vision::JFrame, facebook::jni::JObject, void>::_javaobject*> const&, facebook::jni::alias_ref<facebook::jni::JMap<_jstring*, _jobject*>> const&) const+68)
```

..which in hindsight is obvious; the `_plugin` was `nullptr` (not found), but I still tried to access data on it.

This error also lead to this error later on in the `adb logcat` logs:

```
12:49:19.728 ImageReader_JNI          W  Unable to acquire a buffer item, very likely client tried to acquire more than maxImages buffers
12:49:19.730 ImageAnalysisAnalyzer    E  Failed to acquire image.
                                         java.lang.IllegalStateException: maxImages (6) has already been acquired, call #close before acquiring more.
                                         	at android.media.ImageReader.acquireNextImage(ImageReader.java:502)
                                         	at androidx.camera.core.AndroidImageReaderProxy.acquireNextImage(AndroidImageReaderProxy.java:86)
                                         	at androidx.camera.core.SafeCloseImageReaderProxy.acquireNextImage(SafeCloseImageReaderProxy.java:86)
                                         	at androidx.camera.core.ImageAnalysisBlockingAnalyzer.acquireImage(ImageAnalysisBlockingAnalyzer.java:39)
                                         	at androidx.camera.core.ImageAnalysisAbstractAnalyzer.onImageAvailable(ImageAnalysisAbstractAnalyzer.java:126)
                                         	at androidx.camera.core.SafeCloseImageReaderProxy.lambda$setOnImageAvailableListener$1$androidx-camera-core-SafeCloseImageReaderProxy(SafeCloseImageReaderProxy.java:211)
                                         	at androidx.camera.core.SafeCloseImageReaderProxy$$ExternalSyntheticLambda1.onImageAvailable(Unknown Source:4)
                                         	at androidx.camera.core.AndroidImageReaderProxy.lambda$setOnImageAvailableListener$0$androidx-camera-core-AndroidImageReaderProxy(AndroidImageReaderProxy.java:167)
                                         	at androidx.camera.core.AndroidImageReaderProxy$$ExternalSyntheticLambda0.run(Unknown Source:4)
                                         	at java.util.concurrent.ThreadPoolExecutor.processTask(ThreadPoolExecutor.java:1187)
                                         	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1152)
                                         	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
                                         	at java.lang.Thread.run(Thread.java:784)
```

(and a lot of people only read the last error, they didn't read the one before that (`JNI DETECTED ERROR IN APPLICATION: java_object == null`) so it was very confusing)

This PR now prevents this issue by returning `undefined` if a plugin cannot be found.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Maybe fixes https://github.com/mrousavy/react-native-vision-camera/issues/2999

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
