### PR TITLE
fix: Fix `Frame.orientation`, it should always be fixed

### DIFF
--- a/docs/docs/guides/ORIENTATION.mdx
+++ b/docs/docs/guides/ORIENTATION.mdx
@@ -42,6 +42,8 @@ Frame Processors will stream frames in a potentially "wrong" orientation, and th
 :::info
 This needs to be handled manually, see [`Frame.orientation`](/docs/api/interfaces/Frame#orientation).
 For example, in MLKit just pass the `Frame`'s `orientation` to the `detect(...)` method.
+
+Instead of always rotating up-right to portrait, you might also want to rotate the Frame to either preview-, or output-orientation, depending on your use-case.
 :::
 
 ## Implementation
@@ -97,9 +99,12 @@ For a smoother user experience, you should animate changes to the UI rotation. U
 In a Frame Processor, frames are streamed in their native sensor orientation.
 This means even if the phone is rotated from portrait to landscape, the Frame's [`width`](/docs/api/interfaces/Frame#width) and [`height`](/docs/api/interfaces/Frame#height) stay the same.
 
-The Frame's [`orientation`](/docs/api/interfaces/Frame#orientation) represents it's orientation relative to the current target orientation.
+The Frame's [`orientation`](/docs/api/interfaces/Frame#orientation) represents the **image buffer's orientation, relative to the device's native portrait mode**.
 
-For example, if the phone is held in `portrait` mode and the Frame's `orientation` is `landscape-right`, it is 90° rotated and needs to be counter-rotated by -90° to appear "up-right".
+For example, if the Frame's `orientation` is `landscape-right`, it is 90° rotated and needs to be counter-rotated by -90° to appear "up-right".
+
+On an iPhone, "up-right" means portrait mode (the home-button is at the bottom). On an iPad, "up-right" might mean a landscape orientation.
+
 Instead of actually rotating pixels in the buffers, frame processor plugins just need to interpret the frame as being rotated.
 
 MLKit handles this via a `orientation` property on the `MLImage`/`VisionImage` object:
@@ -113,11 +118,24 @@ public override func callback(_ frame: Frame, withArguments _: [AnyHashable: Any
 }
 ```
 
+You can then either rotate to preview-, or output-orientation, depending on your use-case.
+
+#### Rotate `Frame.orientation` to output Orientation
+
+If you have a Frame Processor that detects objects or faces and the user holds the phone in a landscape orientation, your algorithm might not be able to detect the object or face because it is rotated.
+
+In this case you can just rotate the `Frame.orientation` by the `outputOrientation` (see [`onOutputOrientationChanged`](/docs/api/interfaces/CameraProps#onoutputorientationchanged)), and it will then be a landscape Frame if the user rotates the phone to landscape, or a portrait Frame if the user holds the phone in portrait.
+
+#### Rotate `Frame.orientation` to preview Orientation
+
+If you have a Frame Processor tht applies some drawing operations or provides visual feedback to the Preview, you don't want to use the `outputOrientation` as that can be different than the `previewOrientation`.
+
+In this case you can follow the same idea as above, just rotate the `Frame.orientation` by the `previewOrientation` (see [`onPreviewOrientationChanged`](/docs/api/interfaces/CameraProps#onprevieworientationchanged)) to receive a Frame in the same orientation the Preview view is currently in.
+
 ### Orientation in Skia Frame Processors
 
 A Skia Frame Processor applies orientation via rotation and translation. This means the coordinate system stays the same, but output will be rotated accordingly.
 For a `landscape-left` frame, `(0,0)` will not be top left, but rather top right.
-
 
 ## Mirroring (`isMirrored`)
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -193,7 +193,7 @@ class CameraSession(internal val context: Context, internal val callback: Callba
     // Preview Orientation
     orientationManager.previewOrientation.toSurfaceRotation().let { previewRotation ->
       previewOutput?.targetRotation = previewRotation
-      codeScannerOutput?.targetRotation = outputRotation
+      codeScannerOutput?.targetRotation = previewRotation
     }
     // Outputs Orientation
     orientationManager.outputOrientation.toSurfaceRotation().let { outputRotation ->

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -193,14 +193,14 @@ class CameraSession(internal val context: Context, internal val callback: Callba
     // Preview Orientation
     orientationManager.previewOrientation.toSurfaceRotation().let { previewRotation ->
       previewOutput?.targetRotation = previewRotation
+      codeScannerOutput?.targetRotation = outputRotation
     }
     // Outputs Orientation
     orientationManager.outputOrientation.toSurfaceRotation().let { outputRotation ->
       photoOutput?.targetRotation = outputRotation
       videoOutput?.targetRotation = outputRotation
-      frameProcessorOutput?.targetRotation = outputRotation
-      codeScannerOutput?.targetRotation = outputRotation
     }
+    // Frame Processor output will not receive a target rotation, user is responsible for rotating himself
   }
 
   interface Callback {

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -1391,16 +1391,16 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.0)
-  - VisionCamera (4.4.2):
-    - VisionCamera/Core (= 4.4.2)
-    - VisionCamera/FrameProcessors (= 4.4.2)
-    - VisionCamera/React (= 4.4.2)
-  - VisionCamera/Core (4.4.2)
-  - VisionCamera/FrameProcessors (4.4.2):
+  - VisionCamera (4.4.3):
+    - VisionCamera/Core (= 4.4.3)
+    - VisionCamera/FrameProcessors (= 4.4.3)
+    - VisionCamera/React (= 4.4.3)
+  - VisionCamera/Core (4.4.3)
+  - VisionCamera/FrameProcessors (4.4.3):
     - React
     - React-callinvoker
     - react-native-worklets-core
-  - VisionCamera/React (4.4.2):
+  - VisionCamera/React (4.4.3):
     - React-Core
     - VisionCamera/FrameProcessors
   - Yoga (0.0.0)
@@ -1688,7 +1688,7 @@ SPEC CHECKSUMS:
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNVectorIcons: 2a2f79274248390b80684ea3c4400bd374a15c90
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  VisionCamera: 0292805e99ae8d121c8ec5bb8a9554f6f1c36b82
+  VisionCamera: 7435f20f7ee7756a1e307e986195a97764da5142
   Yoga: 2f71ecf38d934aecb366e686278102a51679c308
 
 PODFILE CHECKSUM: 49584be049764895189f1f88ebc9769116621103

--- a/package/ios/Core/CameraSession+Orientation.swift
+++ b/package/ios/Core/CameraSession+Orientation.swift
@@ -60,6 +60,11 @@ extension CameraSession: OrientationManagerDelegate {
         connection.orientation = previewOrientation
       }
     }
+
+    // Code Scanner coordinates are relative to Preview Orientation
+    if let codeScannerOutput {
+      codeScannerOutput.orientation = previewOrientation
+    }
   }
 
   /**

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -290,8 +290,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
 
     if let delegate {
       // Call Frame Processor (delegate) for every Video Frame
-      let relativeBufferOrientation = orientation.relativeTo(orientation: outputOrientation)
-      delegate.onFrame(sampleBuffer: sampleBuffer, orientation: relativeBufferOrientation)
+      delegate.onFrame(sampleBuffer: sampleBuffer, orientation: orientation)
     }
   }
 

--- a/package/ios/React/CameraView+TakeSnapshot.swift
+++ b/package/ios/React/CameraView+TakeSnapshot.swift
@@ -15,14 +15,14 @@ extension CameraView {
       guard let snapshot = latestVideoFrame else {
         throw CameraError.capture(.snapshotFailed)
       }
-      guard let imageBuffer = CMSampleBufferGetImageBuffer(snapshot) else {
+      guard let imageBuffer = CMSampleBufferGetImageBuffer(snapshot.imageBuffer) else {
         throw CameraError.capture(.imageDataAccessError)
       }
 
       self.onCaptureShutter(shutterType: .snapshot)
 
       let ciImage = CIImage(cvPixelBuffer: imageBuffer)
-      let orientation = self.cameraSession.outputOrientation
+      let orientation = Orientation.portrait.relativeTo(orientation: snapshot.orientation)
       let image = UIImage(ciImage: ciImage, scale: 1.0, orientation: orientation.imageOrientation)
       let path = try FileUtils.writeUIImageToTempFile(image: image)
       return [

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -107,7 +107,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
   var pinchScaleOffset: CGFloat = 1.0
 
   // CameraView+TakeSnapshot
-  var latestVideoFrame: CMSampleBuffer?
+  var latestVideoFrame: Snapshot?
 
   // pragma MARK: Setup
 
@@ -362,7 +362,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
 
   func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation) {
     // Update latest frame that can be used for snapshot capture
-    latestVideoFrame = sampleBuffer
+    latestVideoFrame = Snapshot(imageBuffer: sampleBuffer, orientation: orientation)
 
     // Notify FPS Collector that we just had a Frame
     fpsSampleCollector.onTick()

--- a/package/ios/React/Snapshot.swift
+++ b/package/ios/React/Snapshot.swift
@@ -1,0 +1,14 @@
+//
+//  Snapshot.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 12.07.24.
+//
+
+import AVFoundation
+import Foundation
+
+struct Snapshot {
+  let imageBuffer: CMSampleBuffer
+  let orientation: Orientation
+}

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -553,6 +553,11 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
     this.rotationHelper.previewOrientation = previewOrientation
     this.props.onPreviewOrientationChanged?.(previewOrientation)
     this.maybeUpdateUIRotation()
+
+    if (isSkiaFrameProcessor(this.props.frameProcessor)) {
+      // If we have a Skia Frame Processor, we need to update it's orientation so it knows how to render.
+      this.props.frameProcessor.previewOrientation.value = previewOrientation
+    }
   }
 
   private maybeUpdateUIRotation(): void {

--- a/package/src/skia/useSkiaFrameProcessor.ts
+++ b/package/src/skia/useSkiaFrameProcessor.ts
@@ -53,27 +53,27 @@ function getDegrees(orientation: Orientation): number {
     case 'portrait':
       return 0
     case 'landscape-left':
-      return 270
+      return 90
     case 'portrait-upside-down':
       return 180
     case 'landscape-right':
-      return 90
+      return 270
   }
 }
 
 function getOrientation(degrees: number): Orientation {
   'worklet'
-  const clamped = degrees % 360
+  const clamped = (degrees + 360) % 360
   if (clamped >= 315 || clamped <= 45) return 'portrait'
-  else if (clamped >= 45 || clamped <= 135) return 'landscape-left'
-  else if (clamped >= 135 || clamped <= 225) return 'portrait-upside-down'
-  else if (clamped >= 225 || clamped <= 315) return 'landscape-right'
+  else if (clamped >= 45 && clamped <= 135) return 'landscape-left'
+  else if (clamped >= 135 && clamped <= 225) return 'portrait-upside-down'
+  else if (clamped >= 225 && clamped <= 315) return 'landscape-right'
   else throw new Error(`Invalid degrees! ${degrees}`)
 }
 
-function rotateBy(a: Orientation, b: Orientation): Orientation {
+function relativeTo(a: Orientation, b: Orientation): Orientation {
   'worklet'
-  return getOrientation(getDegrees(a) + getDegrees(b))
+  return getOrientation(getDegrees(a) - getDegrees(b))
 }
 
 /**
@@ -88,8 +88,7 @@ function withRotatedFrame(frame: Frame, canvas: SkCanvas, previewOrientation: Or
 
   try {
     // 2. properly rotate canvas so Frame is rendered up-right.
-    const orientation = rotateBy(frame.orientation, previewOrientation)
-    console.log(frame.orientation, previewOrientation, orientation)
+    const orientation = relativeTo(frame.orientation, previewOrientation)
     switch (orientation) {
       case 'portrait':
         // do nothing

--- a/package/src/skia/useSkiaFrameProcessor.ts
+++ b/package/src/skia/useSkiaFrameProcessor.ts
@@ -8,6 +8,7 @@ import { WorkletsProxy } from '../dependencies/WorkletsProxy'
 import { SkiaProxy } from '../dependencies/SkiaProxy'
 import { withFrameRefCounting } from '../frame-processors/withFrameRefCounting'
 import { VisionCameraProxy } from '../frame-processors/VisionCameraProxy'
+import type { Orientation } from '../types/Orientation'
 
 /**
  * Represents a Camera Frame that can be directly drawn to using Skia.
@@ -46,11 +47,40 @@ type SurfaceCache = Record<
   }
 >
 
+function getDegrees(orientation: Orientation): number {
+  'worklet'
+  switch (orientation) {
+    case 'portrait':
+      return 0
+    case 'landscape-left':
+      return 270
+    case 'portrait-upside-down':
+      return 180
+    case 'landscape-right':
+      return 90
+  }
+}
+
+function getOrientation(degrees: number): Orientation {
+  'worklet'
+  const clamped = degrees % 360
+  if (clamped >= 315 || clamped <= 45) return 'portrait'
+  else if (clamped >= 45 || clamped <= 135) return 'landscape-left'
+  else if (clamped >= 135 || clamped <= 225) return 'portrait-upside-down'
+  else if (clamped >= 225 || clamped <= 315) return 'landscape-right'
+  else throw new Error(`Invalid degrees! ${degrees}`)
+}
+
+function rotateBy(a: Orientation, b: Orientation): Orientation {
+  'worklet'
+  return getOrientation(getDegrees(a) + getDegrees(b))
+}
+
 /**
  * Counter-rotates the {@linkcode canvas} by the {@linkcode frame}'s {@linkcode Frame.orientation orientation}
  * to ensure the Frame will be drawn upright.
  */
-function withRotatedFrame(frame: Frame, canvas: SkCanvas, func: () => void): void {
+function withRotatedFrame(frame: Frame, canvas: SkCanvas, previewOrientation: Orientation, func: () => void): void {
   'worklet'
 
   // 1. save current translation matrix
@@ -58,7 +88,9 @@ function withRotatedFrame(frame: Frame, canvas: SkCanvas, func: () => void): voi
 
   try {
     // 2. properly rotate canvas so Frame is rendered up-right.
-    switch (frame.orientation) {
+    const orientation = rotateBy(frame.orientation, previewOrientation)
+    console.log(frame.orientation, previewOrientation, orientation)
+    switch (orientation) {
       case 'portrait':
         // do nothing
         break
@@ -139,6 +171,7 @@ export function createSkiaFrameProcessor(
   frameProcessor: (frame: DrawableFrame) => void,
   surfaceHolder: ISharedValue<SurfaceCache>,
   offscreenTextures: ISharedValue<SkImage[]>,
+  previewOrientation: ISharedValue<Orientation>,
 ): DrawableFrameProcessor {
   const Skia = SkiaProxy.Skia
   const Worklets = WorkletsProxy.Worklets
@@ -236,7 +269,7 @@ export function createSkiaFrameProcessor(
         canvas.clear(black)
 
         // 4. rotate the frame properly to make sure it's upright
-        withRotatedFrame(frame, canvas, () => {
+        withRotatedFrame(frame, canvas, previewOrientation.value, () => {
           // 5. Run any user drawing operations
           frameProcessor(drawableFrame)
         })
@@ -264,6 +297,7 @@ export function createSkiaFrameProcessor(
     }),
     type: 'drawable-skia',
     offscreenTextures: offscreenTextures,
+    previewOrientation: previewOrientation,
   }
 }
 
@@ -301,6 +335,7 @@ export function useSkiaFrameProcessor(
 ): DrawableFrameProcessor {
   const surface = WorkletsProxy.useSharedValue<SurfaceCache>({})
   const offscreenTextures = WorkletsProxy.useSharedValue<SkImage[]>([])
+  const previewOrientation = WorkletsProxy.useSharedValue<Orientation>('portrait')
 
   useEffect(() => {
     return () => {
@@ -322,7 +357,7 @@ export function useSkiaFrameProcessor(
   }, [offscreenTextures, surface])
 
   return useMemo(
-    () => createSkiaFrameProcessor(frameProcessor, surface, offscreenTextures),
+    () => createSkiaFrameProcessor(frameProcessor, surface, offscreenTextures, previewOrientation),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     dependencies,
   )

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -16,6 +16,7 @@ export interface DrawableFrameProcessor {
   frameProcessor: (frame: Frame) => void
   type: 'drawable-skia'
   offscreenTextures: ISharedValue<SkImage[]>
+  previewOrientation: ISharedValue<Orientation>
 }
 
 export interface OnShutterEvent {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

So this has been a topic for a while, people constantly asked questions about this.

@xulihang also pointed out that `Frame.orientation` is a bit confusing.

So I am making this (kinda breaking) change (sorry!) to get this right.

First we need to understand a few things:

1. Preview will always be rotated accordingly to screen/view rotation. User can lock this using the 🔒 button in control center.
2. Photo and Video can either be the same as the Preview (`outputOrientation="preview"`), **or** be allowed to rotate even if the phone is locked (`outputOrientation="device"`, this follows the gyroscope/accelerometer). This allows building UIs like the native iOS Camera app, where the view all stays the same, but only the buttons can actually rotate (again, taking gyro/accelerometer into consideration).
3. Code Scanner should follow the Preview orientation, since the coordinates it returns are always respective to screen coordinates (**this is now fixed with this PR!** previously it was not the case)
4. Frame Processors allow full control, and their Frame buffers are always in **native sensor orientation**, meaning it is always some fixed orientation (e.g. `landscape-left`), no matter if the phone is in portrait or landscape.

Now for Point 4 we really need to understand that the Frame cannot by physically rotated (rotating pixels in a 4k buffer is expensive), so that's why it is always in a fixed orientation, which is just coming from the native device sensor. (e.g. `landscape-left`)

In order to make Frame Processor Plugins (e.g. MLKit face detection) work, we need to tell the plugin in what orientation the Frame is, so it can internally know how to read the pixels in the Frame.
If it is portrait, it can assume that a Face is upright.

This graphic explains it quite well:

<table>
<tr>
<th>Portrait</th>
<th>Landscape</th>
</tr>
<tr>
<td> <img src="https://github.com/user-attachments/assets/08583b47-94d0-48d4-86b4-26f78286cf7a" width="100%" /> </td>
<td> <img src="https://github.com/user-attachments/assets/9f2459c4-fca2-4322-9f13-f84736fc49b1" width="100%" /> </td>
</tr>
</table>

The blue frame is always in the same orientation as you can see. The phone changes orientation, and the face inside the Frame changes orientation, but the Frame buffer itself is the same.

So now with this PR, `Frame.orientation` is always just the native device sensor orientation, and the user can then either just rotate it by this orientation (then it will just always be "up-right" in the phone/iPad's natural portrait orientation), or also rotate it more by `previewOrientation` or `outputOrientation` - this is fully up to the user depending on the use-case.

For example to detect faces you might want to rotate by `outputOrientation`, because otherwise the face is sideways in a portrait Frame and MLKit cannot detect faces sideways - only "up-right" faces.

### For Frame Processor Plugin authors

If you are a Frame Processor Plugin author, make sure that you use `Frame.orientation` correctly now.

For example, if you use Apple's Vision-SDK for Face/Image/Text recognition, set the `VisionImage.orientation` exactly to the `Frame.orientation`.

```swift
public override func callback(_ frame: Frame, withArguments arguments: [AnyHashable: Any]?) -> Any {
  let image = VisionImage(buffer: frame.buffer)
  image.orientation = frame.orientation
```

This is now in it's **native portrait orientation**.

If the user holds his phone sideways (aka _not_ in it's native portrait orientation), then you would also need to rotate that Orientation.

**VisionCamera does not do that automatically**, because each use case is different - for example in a Skia Frame Processor you want to lock the orientation to portrait, otherwise the canvas would rotate within itself.

So if you also want to support orientation in your Frame Processor, you need to rotate the `Frame.orientation` by whatever the current output orientation is.

To get the current output orientation you can just add it as a parameter to your Frame Processor Plugin - then the user can also decide whether he wants to support it or not. 

In your plugin:

```swift
public override func callback(_ frame: Frame, withArguments arguments: [AnyHashable: Any]?) -> Any {
  let image = VisionImage(buffer: frame.buffer)
  image.orientation = frame.orientation

  if let outputOrientation = arguments["outputOrientation"] as? String {
    // parse outputOrientation String and then rotate image.orientation by that
  }
```

From the user perspective:

```ts
function App() {
  const outputOrientation = useSharedValue('portrait')

  const frameProcessor = useFrameProcessor((frame) => {
    'worklet'
    myCustomFpPlugin(frame, { outputOrientation: outputOrientation.value })
  })

  return <Camera {...props} onOutputOrientationChanged={(o) => outputOrientation.value = o} />
```

**Note:** In a future version of VisionCamera I might add `outputOrientation` to `Frame` directly, so you don't have to ask the user for it.
Then you can decide whether to use the raw orientation (e.g. for skia plugins), the preview's orientation, or the output orientation.


<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
