### PR TITLE
fix: Fix `Frame.isMirrored`

### DIFF
--- a/package/ios/Core/CameraSession+Orientation.swift
+++ b/package/ios/Core/CameraSession+Orientation.swift
@@ -19,6 +19,10 @@ extension CameraSession: OrientationManagerDelegate {
     return input.device.sensorOrientation
   }
 
+  var isMirrored: Bool {
+    return configuration?.isMirrored == true
+  }
+
   /**
    Get the orientation all outputs should be configured to so they appear up-right.
    This is usually just a counter-rotation to whatever the input camera stream is.

--- a/package/ios/Core/CameraSession+Orientation.swift
+++ b/package/ios/Core/CameraSession+Orientation.swift
@@ -19,10 +19,6 @@ extension CameraSession: OrientationManagerDelegate {
     return input.device.sensorOrientation
   }
 
-  var isMirrored: Bool {
-    return configuration?.isMirrored == true
-  }
-
   /**
    Get the orientation all outputs should be configured to so they appear up-right.
    This is usually just a counter-rotation to whatever the input camera stream is.

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -268,7 +268,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
   public final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
     switch captureOutput {
     case is AVCaptureVideoDataOutput:
-      onVideoFrame(sampleBuffer: sampleBuffer, orientation: connection.orientation)
+      onVideoFrame(sampleBuffer: sampleBuffer, orientation: connection.orientation, isMirrored: connection.isVideoMirrored)
     case is AVCaptureAudioDataOutput:
       onAudioFrame(sampleBuffer: sampleBuffer)
     default:
@@ -276,7 +276,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     }
   }
 
-  private final func onVideoFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation) {
+  private final func onVideoFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool) {
     if let recordingSession {
       do {
         // Write the Video Buffer to the .mov/.mp4 file
@@ -291,7 +291,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     if let delegate {
       // Call Frame Processor (delegate) for every Video Frame
       let relativeBufferOrientation = orientation.relativeTo(orientation: outputOrientation)
-      delegate.onFrame(sampleBuffer: sampleBuffer, orientation: relativeBufferOrientation)
+      delegate.onFrame(sampleBuffer: sampleBuffer, orientation: relativeBufferOrientation, isMirrored: isMirrored)
     }
   }
 

--- a/package/ios/Core/CameraSessionDelegate.swift
+++ b/package/ios/Core/CameraSessionDelegate.swift
@@ -44,7 +44,7 @@ protocol CameraSessionDelegate: AnyObject {
   /**
    Called for every frame (if video or frameProcessor is enabled)
    */
-  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation)
+  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool)
   /**
    Called whenever a QR/Barcode has been scanned. Only if the CodeScanner Output is enabled
    */

--- a/package/ios/FrameProcessors/Frame.h
+++ b/package/ios/FrameProcessors/Frame.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Frame : NSObject
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation;
+- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation isMirrored:(BOOL)isMirrored;
 - (instancetype)init NS_UNAVAILABLE;
 
 - (void)incrementRefCount;

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -63,18 +63,7 @@
 }
 
 - (BOOL)isMirrored {
-  switch (_orientation) {
-    case UIImageOrientationUp:
-    case UIImageOrientationDown:
-    case UIImageOrientationLeft:
-    case UIImageOrientationRight:
-      return false;
-    case UIImageOrientationDownMirrored:
-    case UIImageOrientationUpMirrored:
-    case UIImageOrientationLeftMirrored:
-    case UIImageOrientationRightMirrored:
-      return true;
-  }
+  return _isMirrored;
 }
 
 - (BOOL)isValid {

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -13,13 +13,15 @@
 @implementation Frame {
   CMSampleBufferRef _Nonnull _buffer;
   UIImageOrientation _orientation;
+  BOOL _isMirrored;
 }
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation {
+- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation isMirrored:(BOOL)isMirrored {
   self = [super init];
   if (self) {
     _buffer = buffer;
     _orientation = orientation;
+    _isMirrored = isMirrored;
   }
   return self;
 }

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -370,7 +370,9 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
     #if VISION_CAMERA_ENABLE_FRAME_PROCESSORS
       if let frameProcessor = frameProcessor {
         // Call Frame Processor
-        let frame = Frame(buffer: sampleBuffer, orientation: orientation.imageOrientation)
+        let frame = Frame(buffer: sampleBuffer,
+                          orientation: orientation.imageOrientation,
+                          isMirrored: cameraSession.isMirrored)
         frameProcessor.call(frame)
       }
     #endif

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -360,7 +360,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
     ])
   }
 
-  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation) {
+  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool) {
     // Update latest frame that can be used for snapshot capture
     latestVideoFrame = sampleBuffer
 
@@ -372,7 +372,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
         // Call Frame Processor
         let frame = Frame(buffer: sampleBuffer,
                           orientation: orientation.imageOrientation,
-                          isMirrored: cameraSession.isMirrored)
+                          isMirrored: isMirrored)
         frameProcessor.call(frame)
       }
     #endif


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Previously `Frame.isMirrored` always returned false on iOS.

With this PR, `Frame.isMirrored` now returns the proper value, as we infer it from the current connection.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3075

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
