### PR TITLE
fix: react-native-worklets-core module resolution for pnpm

### DIFF
--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -2,8 +2,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-nodeModules = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
-
 Pod::UI.puts "[VisionCamera] Thank you for using VisionCamera ❤️"
 Pod::UI.puts "[VisionCamera] If you enjoy using VisionCamera, please consider sponsoring this project: https://github.com/sponsors/mrousavy"
 
@@ -23,11 +21,10 @@ else
   Pod::UI.puts "[VisionCamera] $VCEnableFrameProcessors is not set, enabling Frame Processors if Worklets is installed..."
 end
 
-Pod::UI.puts("[VisionCamera] node modules #{Dir.exist?(nodeModules) ? "found at #{nodeModules}" : "not found!"}")
-workletsPath = File.join(nodeModules, "react-native-worklets-core")
+workletsPath = File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-worklets-core/package.json')"`)
 hasWorklets = File.exist?(workletsPath)
 if hasWorklets
-  Pod::UI.puts("[VisionCamera] react-native-worklets-core found, Frame Processors are #{enableFrameProcessors ? "enabled" : "disabled"}!")
+  Pod::UI.puts("[VisionCamera] react-native-worklets-core found at #{workletsPath}, Frame Processors are #{enableFrameProcessors ? "enabled" : "disabled"}!")
 else
   Pod::UI.puts("[VisionCamera] react-native-worklets-core not found - Frame Processors are disabled!")
   enableFrameProcessors = false

--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -22,9 +22,9 @@ else
 end
 
 def Pod::getWorkletsLibraryPath
-  output = `cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-worklets-core/package.json')"`
+  output = `cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "try { require.resolve('react-native-worklets-core/package.json') } catch(e) { /* returning undefined, if package not found */ }"`
   
-  if output.empty?
+  if output.strip == "undefined"
     return nil
   else
     return File.dirname(output)

--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -21,8 +21,18 @@ else
   Pod::UI.puts "[VisionCamera] $VCEnableFrameProcessors is not set, enabling Frame Processors if Worklets is installed..."
 end
 
-workletsPath = File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-worklets-core/package.json')"`)
-hasWorklets = File.exist?(workletsPath)
+def Pod::getWorkletsLibraryPath
+  output = `cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-worklets-core/package.json')"`
+  
+  if output.empty?
+    return nil
+  else
+    return File.dirname(output)
+  end
+end
+
+workletsPath = getWorkletsLibraryPath()
+hasWorklets = workletsPath != nil && File.exist?(workletsPath)
 if hasWorklets
   Pod::UI.puts("[VisionCamera] react-native-worklets-core found at #{workletsPath}, Frame Processors are #{enableFrameProcessors ? "enabled" : "disabled"}!")
 else


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Currently, vision camera uses slightly incorrect logic for detecting `react-native-worklets-core` package. Current algorithm expects that `react-native-worklets-core` package will be next to `react-native` package, which is not the case with `pnpm` package manager - it creates symlinks and may create custom structure for node_modules, that will still be valid. For instance:

```
my-package
`- node_modules
   |- .pnpm
   |  |- react-native@0.73.6
   |  |  `- node_modules
   |  |     `- react-native
   |  `- react-native-worklets-core@1.3.3_react-native@0.73.6
   |     `- node_modules
   |        |- react-native ---> my-package/node_modules/.pnpm/react-native@0.73.6/node_modules/react-native
   |        `- react-native-worklets-core
   |- react-native ---> my-package/node_modules/.pnpm/react-native@0.73.6/node_modules/react-native
   `- react-native-worklets-core ---> my-package/node_modules/.pnpm/react-native-worklets-core@1.3.3_react-native@0.73.6/node_modules/react-native-worklets-core
```
(here `--->` denotes symlink)

So when this library tries to find `node_modules` directory, it runs `node --print "require.resolve('react-native/package.json')"`, which follows symlink and returns `my-package/node_modules/.pnpm/react-native@0.73.6/node_modules/react-native/package.json` path, which is not correct.

## Changes

Replaced `node_modules` directory resolution through `react-native` package, with direct `"require.resolve('react-native-worklets-core')"`. This should not break any projects, because documentation says that [user needs to install `react-native-worklets-core`, in order to use frame processors](https://react-native-vision-camera.com/docs/guides/frame-processors#installation). This means that `react-native-worklets-core` should always be found by nodejs.

## Tested on

* iPhone 12 Pro Max, iOS Version 17.5.1

## Related issues

Fixes #2580