### PR TITLE
fix: Remove `sensorOrientation` hack on iOS, it's always `portrait`

### DIFF
--- a/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+sensorOrientation.swift
@@ -8,67 +8,16 @@
 import AVFoundation
 import Foundation
 
-// On iOS, all built-in Cameras are landscape-left (90deg rotated)
-let DEFAULT_SENSOR_ORIENTATION = Orientation.landscapeLeft
+// On iOS, a camera device's natural sensor orientation is either
+// always portrait, or .videoOrientation already takes natural sensor
+// orientation into account.
+let DEFAULT_SENSOR_ORIENTATION = Orientation.portrait
 
 extension AVCaptureDevice {
   /**
    Get the natural orientation of the camera sensor of this specific device.
    */
   var sensorOrientation: Orientation {
-    // TODO: There is no iOS API to get native sensor orientation.
-    //       - The new `RotationCoordinator` API is a blackbox, and cannot be used statically.
-    //       - Dynamically creating an AVCaptureSession is very hacky and has a runtime overhead.
-    //       Hopefully iOS adds an API to get sensor orientation soon so we can use that!
-
-    // 0. If we don't have Camera permission yet, we cannot create a temporary AVCaptureSession.
-    //    So we just return the default orientation as a workaround...
-    let cameraPermissionStatus = AVCaptureDevice.authorizationStatus(for: .video)
-    if cameraPermissionStatus != .authorized {
-      return DEFAULT_SENSOR_ORIENTATION
-    }
-
-    // 1. Create a capture session
-    let session = AVCaptureSession()
-    if session.canSetSessionPreset(.low) {
-      session.sessionPreset = .low
-    }
-
-    // 2. Add this device as an input
-    guard let input = try? AVCaptureDeviceInput(device: self) else {
-      VisionLogger.log(level: .error, message: "Cannot dynamically determine \(uniqueID)'s sensorOrientation, " +
-        "because the AVCaptureDeviceInput cannot be created. Falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
-      return DEFAULT_SENSOR_ORIENTATION
-    }
-    guard session.canAddInput(input) else {
-      VisionLogger.log(level: .error, message: "Cannot dynamically determine \(uniqueID)'s sensorOrientation, because " +
-        "it cannot be added to the temporary AVCaptureSession. Falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
-      return DEFAULT_SENSOR_ORIENTATION
-    }
-    session.addInput(input)
-
-    // 3. Add an output (e.g. video data output)
-    let output = AVCaptureVideoDataOutput()
-    output.automaticallyConfiguresOutputBufferDimensions = false
-    output.deliversPreviewSizedOutputBuffers = true
-    guard session.canAddOutput(output) else {
-      VisionLogger.log(level: .error, message: "Cannot dynamically determine \(uniqueID)'s sensorOrientation, because " +
-        "the AVCaptureVideoDataOutput cannot be added to the AVCaptureSession. Falling back to \(DEFAULT_SENSOR_ORIENTATION)...")
-      return DEFAULT_SENSOR_ORIENTATION
-    }
-    session.addOutput(output)
-
-    // 4. Inspect the default orientation of the output
-    let defaultOrientation = output.orientation
-
-    // 5. Rotate the default orientation by the default sensor orientation we know of
-    var sensorOrientation = defaultOrientation.rotatedBy(orientation: DEFAULT_SENSOR_ORIENTATION)
-
-    // 6. If we are on the front Camera, AVCaptureVideoDataOutput.orientation is mirrored.
-    if position == .front {
-      sensorOrientation = sensorOrientation.flipped()
-    }
-
-    return sensorOrientation
+    return .portrait
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

So either I was completely drunk when building this initially, or I was way too tired already.

But I just re-visited the orientation implementation on iOS, and it seems like `.sensorOrientation` always returns `.portrait`!

I just tested this on both my iPhone 15 Pro and my iPhone 8 and they work in every orientation - no matter if landscape or portrait, no matter if front or back camera.

---


I revisited the orientation implementation because I wanted to to get rid of the `sensorOrientation` hack I built.
The hack was that everytime I want to know the `sensorOrientation` of an `AVCaptureDevice`, I have to build up an AVCaptureSession and attach a Video Output to it - which was **slow** (~5ms per call, 20 calls on an iPhone 15 Pro at startup), and was insanely hacky.
It also crashed when you don't have camera permission yet, or the device is invalid.

This is the hacky code btw:

https://github.com/mrousavy/react-native-vision-camera/blob/0654898eda207dd425f1957f37997ad2078c2aa7/package/ios/Core/Extensions/AVCaptureDevice%2BsensorOrientation.swift#L18-L73

And now I just return `.portrait` - which works and speeds up the app! :)


<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

So now `sensorOrientation` doesn

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

- iPhone 15 Pro
- iPhone 8

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
