### PR TITLE
feat: Throw an Error if `Frame` is already destroyed

### DIFF
--- a/package/android/src/main/cpp/frameprocessors/FrameHostObject.h
+++ b/package/android/src/main/cpp/frameprocessors/FrameHostObject.h
@@ -27,7 +27,9 @@ public:
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& rt) override;
 
 public:
-  jni::global_ref<JFrame> getFrame();
+  inline jni::global_ref<JFrame> getFrame() const noexcept {
+    return _frame;
+  }
 
 private:
   jni::global_ref<JFrame> _frame;

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -35,7 +35,20 @@
 }
 
 - (CMSampleBufferRef)buffer {
+  if (!self.isValid) {
+    @throw [[NSException alloc] initWithName:@"capture/frame-invalid"
+                                      reason:@"Trying to access an already closed Frame! "
+                                              "Are you trying to access the Image data outside of a Frame Processor's lifetime?\n"
+                                              "- If you want to use `console.log(frame)`, use `console.log(frame.toString())` instead.\n"
+                                              "- If you want to do async processing, use `runAsync(...)` instead.\n"
+                                              "- If you want to use runOnJS, increment it's ref-count: `frame.incrementRefCount()`"
+                                    userInfo:nil];
+  }
   return _buffer;
+}
+
+- (BOOL)isValid {
+  return _buffer != nil && CFGetRetainCount(_buffer) > 0 && CMSampleBufferIsValid(_buffer);
 }
 
 - (UIImageOrientation)orientation {
@@ -43,7 +56,7 @@
 }
 
 - (NSString*)pixelFormat {
-  CMFormatDescriptionRef format = CMSampleBufferGetFormatDescription(_buffer);
+  CMFormatDescriptionRef format = CMSampleBufferGetFormatDescription(self.buffer);
   FourCharCode mediaType = CMFormatDescriptionGetMediaSubType(format);
   switch (mediaType) {
     case kCVPixelFormatType_32BGRA:
@@ -66,32 +79,28 @@
   return _isMirrored;
 }
 
-- (BOOL)isValid {
-  return _buffer != nil && CMSampleBufferIsValid(_buffer);
-}
-
 - (size_t)width {
-  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
+  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(self.buffer);
   return CVPixelBufferGetWidth(imageBuffer);
 }
 
 - (size_t)height {
-  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
+  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(self.buffer);
   return CVPixelBufferGetHeight(imageBuffer);
 }
 
 - (double)timestamp {
-  CMTime timestamp = CMSampleBufferGetPresentationTimeStamp(_buffer);
+  CMTime timestamp = CMSampleBufferGetPresentationTimeStamp(self.buffer);
   return CMTimeGetSeconds(timestamp) * 1000.0;
 }
 
 - (size_t)bytesPerRow {
-  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
+  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(self.buffer);
   return CVPixelBufferGetBytesPerRow(imageBuffer);
 }
 
 - (size_t)planesCount {
-  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_buffer);
+  CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(self.buffer);
   return CVPixelBufferGetPlaneCount(imageBuffer);
 }
 

--- a/package/ios/FrameProcessors/FrameHostObject.h
+++ b/package/ios/FrameProcessors/FrameHostObject.h
@@ -25,7 +25,9 @@ public:
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& rt) override;
 
 public:
-  Frame* getFrame();
+  inline Frame* getFrame() const noexcept {
+    return _frame;
+  }
 
 private:
   Frame* _frame;


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Previously we only checked if `Frame` was already destroyed when trying to access it through JS (through `FrameHostObject`) - but some people/companies (cc @terrysahaidak / @marblemedia / @canfan / @thomas-coldwell) have custom Frame Processor solutions where they access `Frame` directly (the ObjC/Java class), and call `incrementRefCount()`/`decrementRefCount()` there.

In there, we didn't really check if the `Frame` is still valid, and so we didn't throw any nice errors if it wasn't - apps just crashed with SIGBART.

So this PR now changes that and moves all checks to see if a frame is valid inside the actual `Frame` implementation (where it should've belonged in the first place imo).

This is safer, and also more efficient on Java since it's one less JNI call per each prop you access. 🎉 

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
