### PR TITLE
docs: fix options typo in iOS frame processor instructions

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
@@ -53,7 +53,7 @@ For reference see the [CLI's docs](https://github.com/mateusz1913/vision-camera-
 
 - (instancetype) initWithProxy:(VisionCameraProxyHolder*)proxy
                    withOptions:(NSDictionary* _Nullable)options {
-  self = [super initWithProxy:proxy options:options];
+  self = [super initWithProxy:proxy withOptions:options];
   return self;
 }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

-  This PR fixes a typo in an iOS Frame Processor instruction doc.

## Changes

- Change `options` to `withOptions` while initializing proxy.