### PR TITLE
Fix: clear orientation listener on close

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -84,6 +84,7 @@ class CameraSession(internal val context: Context, internal val callback: Callba
   override fun close() {
     Log.i(TAG, "Closing CameraSession...")
     isDestroyed = true
+    orientationManager.clearListeners()
     runOnUiThread {
       lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
     }

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -84,7 +84,7 @@ class CameraSession(internal val context: Context, internal val callback: Callba
   override fun close() {
     Log.i(TAG, "Closing CameraSession...")
     isDestroyed = true
-    orientationManager.clearListeners()
+    orientationManager.stopOrientationUpdates()
     runOnUiThread {
       lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
     }

--- a/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
@@ -67,13 +67,17 @@ class OrientationManager(private val context: Context, private val callback: Cal
     }
   }
 
+  // remove previous listeners if attached
+  fun clearListeners() {
+    displayManager.unregisterDisplayListener(displayListener)
+    orientationListener.disable()
+  }
+
   fun setTargetOutputOrientation(targetOrientation: OutputOrientation) {
     Log.i(TAG, "Target Orientation changed $targetOutputOrientation -> $targetOrientation!")
     targetOutputOrientation = targetOrientation
 
-    // remove previous listeners if attached
-    displayManager.unregisterDisplayListener(displayListener)
-    orientationListener.disable()
+    clearListeners()
 
     when (targetOrientation) {
       OutputOrientation.DEVICE -> {

--- a/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
@@ -67,8 +67,7 @@ class OrientationManager(private val context: Context, private val callback: Cal
     }
   }
 
-  // remove previous listeners if attached
-  fun clearListeners() {
+  fun stopOrientationUpdates() {
     displayManager.unregisterDisplayListener(displayListener)
     orientationListener.disable()
   }
@@ -77,7 +76,8 @@ class OrientationManager(private val context: Context, private val callback: Cal
     Log.i(TAG, "Target Orientation changed $targetOutputOrientation -> $targetOrientation!")
     targetOutputOrientation = targetOrientation
 
-    clearListeners()
+    // remove previous listeners if we have any
+    stopOrientationUpdates()
 
     when (targetOrientation) {
       OutputOrientation.DEVICE -> {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

This PR cleans android orientation listener on camera session close.
If this is not done, the events are still fired and they accumulate until you kill the app.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

Added a `clearListeners` functions in the OrientationManager which is then called when CameraSession.close() is called.

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

Samsung Galaxy tab active4 pro. Android 14.

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
