### PR TITLE
fix: update frame processor plugin reference

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSOR_PLUGINS_COMMUNITY.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_PLUGINS_COMMUNITY.mdx
@@ -47,7 +47,7 @@ Similar to react-native libraries, Frame Processor Plugins are distributed throu
 <br />
 <p align="center">
 <b>
-<a href="https://github.com/mrousavy/react-native-vision-camera/edit/main/docs/docs/guides/FRAME_PROCESSOR_PLUGINS.mdx">Click here</a> to add your Frame Processor Plugin to this list!
+<a href="https://github.com/mrousavy/react-native-vision-camera/edit/main/docs/docs/guides/FRAME_PROCESSOR_PLUGINS_COMMUNITY.mdx">Click here</a> to add your Frame Processor Plugin to this list!
 </b>
 </p>
 <br />


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

This PR fixes a broken link.

## Changes

Commit 4c92e49891bfdd8b7ee8f375cd6f5f536460037d renamed the `FRAME_PROCESSOR_PLUGINS.mdx` to be `FRAME_PROCESSOR_PLUGINS_COMMUNITY.mdx`. This PR adjusts sources to changes. [Relevant page](https://react-native-vision-camera.com/docs/guides/frame-processor-plugins-community).

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
