### PR TITLE
fix: Fix any initialization errors in `getFormats()` (e.g. `IllegalArgumentException - width must be positive`)

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -3,6 +3,7 @@ package com.mrousavy.camera.core
 import android.annotation.SuppressLint
 import android.graphics.ImageFormat
 import android.hardware.camera2.CameraCharacteristics
+import android.util.Log
 import android.util.Range
 import android.util.Size
 import android.util.SizeF
@@ -36,6 +37,10 @@ import kotlin.math.sqrt
 @SuppressLint("RestrictedApi")
 @Suppress("FoldInitializerAndIfToElvis")
 class CameraDeviceDetails(private val cameraInfo: CameraInfo, extensionsManager: ExtensionsManager) {
+  companion object {
+    private const val TAG = "CameraDeviceDetails"
+  }
+
   // Generic props available on all implementations
   private val cameraId = cameraInfo.id ?: throw NoCameraDeviceError()
   private val position = Position.fromLensFacing(cameraInfo.lensFacing)

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -147,7 +147,7 @@ class CameraDeviceDetails(private val cameraInfo: CameraInfo, extensionsManager:
           }
         }
       } catch (error: Throwable) {
-        Log.w(TAG, "Dynamic Range Profile ${dynamicRange} cannot be used as a format!", error)
+        Log.w(TAG, "Dynamic Range Profile $dynamicRange cannot be used as a format!", error)
       }
     }
 


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes any kinds of initialization errors in `getFormats()` that could cause the app to crash when starting up (as constants are evaluated outside of the React Native JS code / error handler).

We just wrap it in a `try`/`catch`, and if for some reason any of those getters throw (which they definitely should not do, according to the Android documentation), then we catch and ignore that specific format.

Those getters can only throw if the host OS (Samsung, Huawei, ..) has implemented the Android spec poorly or missed something. In that case, it's not my fault, but I have to work around those issues anyways.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3180
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
