### PR TITLE
fix: Fix mapping of itf and add new itf-14 type in iOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
    yarn bootstrap
    ```
 
-Read the READMEs in [`android/`](android/README.md) and [`ios/`](ios/README.md) for a quick overview of the native development workflow.
+Read the READMEs in [`android/`](package/android/README.md) and [`ios/`](package/ios/README.md) for a quick overview of the native development workflow.
 
 > You can also open VisionCamera in [a quick online editor (github1s)](https://github1s.com/mrousavy/react-native-vision-camera)
 

--- a/docs/docs/guides/CODE_SCANNING.mdx
+++ b/docs/docs/guides/CODE_SCANNING.mdx
@@ -24,7 +24,7 @@ A Code Scanner is a separate Camera output (just like photo or video) that can d
 - **Data Matrix**: Square Data Matrix codes
 - **Barcode (EAN)**: EAN-13 or EAN-8 Barcodes
 - **Barcode (Code)**: Code-128, Code-39 or Code-93 Barcodes
-- **Barcode (other)**: Codabar, ITF-14, UPC-E or PDF-417 Barcodes
+- **Barcode (other)**: Codabar, Interleaved2of5 (ITF), ITF-14, UPC-E or PDF-417 Barcodes
 
 ## Setup
 
@@ -141,5 +141,11 @@ const codeScanner = useCodeScanner({
 ```
 
 You will need to keep this in mind and do the conversion from EAN-13 to UPC-A yourself. This can be done by removing the front `0` digit from the code to get a UPC-A code.
+
+## Interleaved2of5 (ITF) and ITF-14
+
+Interleaved2of5 (ITF) barcodes are supported by both, Android and iOS, where Android's SDK supports barcodes in ITF format with a minimum length of 6 characters.
+
+ITF-14 is a sub type of interleaved2of5 which always encodes 14 characters. The ITF-14 type is only supported by iOS. If you want to have the restriction to 14 characters in Android as well, you have to handle this in your own code.
 
 #### 🚀 Next section: [Frame Processors](frame-processors)

--- a/package/ios/Core/Parsers/AVMetadataObject.ObjectType+descriptor.swift
+++ b/package/ios/Core/Parsers/AVMetadataObject.ObjectType+descriptor.swift
@@ -35,6 +35,9 @@ extension AVMetadataObject.ObjectType {
       self = .ean8
       return
     case "itf":
+      self = .interleaved2of5
+      return
+    case "itf-14":
       self = .itf14
       return
     case "upc-e":
@@ -78,8 +81,10 @@ extension AVMetadataObject.ObjectType {
       return "ean-13"
     case .ean8:
       return "ean-8"
-    case .itf14:
+    case .interleaved2of5:
       return "itf"
+    case .itf14:
+      return "itf-14"
     case .upce:
       return "upce"
     case .qr:

--- a/package/src/types/CodeScanner.ts
+++ b/package/src/types/CodeScanner.ts
@@ -11,6 +11,7 @@ export type CodeType =
   | 'ean-13'
   | 'ean-8'
   | 'itf'
+  | 'itf-14'
   | 'upc-e'
   | 'upc-a'
   | 'qr'


### PR DESCRIPTION
## What
I can't scan interleaved2of5 (ITF) barcodes in iOS. 

Currently the CodeType `itf` is mapped:
* on android to `Barcode.FORMAT_ITF`, which is the ["barcode format constant for ITF (Interleaved Two-of-Five)"](https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/common/Barcode#FORMAT_ITF)
* on iOS to `AVMetadataObject.ObjectType.itf14`, which is ["a constant that identifies the ITF14 symbology"](https://developer.apple.com/documentation/avfoundation/avmetadataobject/objecttype/1618831-itf14)

ITF-14 is a variant of ITF with a fixed length of 14 characters. The problem is that the iOS [AVMetadataObject.ObjectType.interleaved2of5](https://developer.apple.com/documentation/avfoundation/avmetadataobject/objecttype/1618825-interleaved2of5) type is not mapped at all and therefore interleaved2of5 barcodes with a different length than 14 characters cannot be scanned in iOS.

## Changes
Added and changed the mapping for iOS:
* itf -> interleaved2of5
* new itf-14 -> itf14 (iOS only)

Updated documentation about code types.

If you add now `itf-14` unconditionally (i.e. don't exclude it for android) to the `codeTypes` array of the CodeScanner, in android it will (expectedly) throw the error "The given value for codeType could not be parsed! (Received: itf-14)".

## Tested on
* iPhone 12 mini, iOS 18.1
* Google Pixel 7, Android 15

## Related issues
* fixes #2089
* fixes #2064 
