### PR TITLE
fix: exclude libreactnative.so (rn76 prefab)

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -172,7 +172,8 @@ android {
             "**/libreactnativejni.so",
             "**/libturbomodulejsijni.so",
             "**/libreact_nativemodule_core.so",
-            "**/libjscexecutor.so"
+            "**/libjscexecutor.so",
+            "**/libreactnative.so"
     ]
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Hey.
There are still some problems with the react-native 0.76 prefab, #3270.

```
* What went wrong:
Execution failed for task ':app:mergeDebugNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeNativeLibsTask$MergeNativeLibsTaskWorkAction
   > 2 files found with path 'lib/arm64-v8a/libreactnative.so' from inputs:
      - /Users/torrrrzz/Documents/blesspayments/mobileapp/node_modules/react-native-vision-camera/android/build/intermediates/library_jni/debug/copyDebugJniLibsProjectOnly/jni/arm64-v8a/libreactnative.so
      - /Users/torrrrzz/.gradle/caches/8.10.2/transforms/a86708618e37ae0e0a5c88cb1b2db70c/transformed/react-android-0.76.1-debug/jni/arm64-v8a/libreactnative.so
     If you are using jniLibs and CMake IMPORTED targets, see
     https://developer.android.com/r/tools/jniLibs-vs-imported-targets
```

This PR makes sure that libreactnative.so is excluded in the react-native-vision-camera dependency. 

Cheers.

## Related issues

Fixes #3270
