### PR TITLE
fix: Fix duplicate libraries: `libreactnative.so` error on RN 0.76

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -169,6 +169,7 @@ android {
             "**/libhermes.so",
             "**/libhermes-executor-debug.so",
             "**/libhermes_executor.so",
+            "**/libreactnative.so",
             "**/libreactnativejni.so",
             "**/libturbomodulejsijni.so",
             "**/libreact_nativemodule_core.so",


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes an error in latest RN 0.76 where RN changed their libs to package it into `libreactnative.so`.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3279
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3278
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3270