### PR TITLE
feat/preview-comply-with-photo-resolution-when-video-is-disabled

### DIFF
--- a/docs/docs/guides/PREVIEW.mdx
+++ b/docs/docs/guides/PREVIEW.mdx
@@ -8,8 +8,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 <div class="image-container">
   <svg xmlns="http://www.w3.org/2000/svg" width="283" height="535">
-    <image href={useBaseUrl('img/demo_capture.gif')} x="18" y="33" width="247" height="469" />
-    <image href={useBaseUrl('img/frame.png')} width="283" height="535" />
+    <image href={useBaseUrl("img/demo_capture.gif")} x="18" y="33" width="247" height="469" />
+    <image href={useBaseUrl("img/frame.png")} width="283" height="535" />
   </svg>
 </div>
 
@@ -35,7 +35,11 @@ When starting/stopping the Camera session or when switching Camera devices (e.g.
 To get notified about pauses in the preview view, use the [`onPreviewStarted`](/docs/api/interfaces/CameraProps#onpreviewstarted) and [`onPreviewStopped`](/docs/api/interfaces/CameraProps#onpreviewstopped) events:
 
 ```tsx
-<Camera {...props} onPreviewStarted={() => console.log('Preview started!')} onPreviewStopped={() => console.log('Preview stopped!')} />
+<Camera
+  {...props}
+  onPreviewStarted={() => console.log('Preview started!')}
+  onPreviewStopped={() => console.log('Preview stopped!')}
+/>
 ```
 
 ### Preview Frame Rate (FPS)
@@ -53,11 +57,12 @@ See [FPS](formats#fps) for more information.
 On iOS, the Video resolution also determines the Preview resolution, so if you Camera format has a low Video resolution, your Preview will also be in low resolution:
 
 ```ts
-const lowResolutionFormat = useCameraFormat(device, [{ videoResolution: { width: 640, height: 480 } }])
+const lowResolutionFormat = useCameraFormat(device, [
+  { videoResolution: { width: 640, height: 480 } },
+])
 ```
 
-On Android, the Preview will always be in full HD or the Preview View's size, whichever is smaller. If a format is specified, the preview will comply with the format's resolution based on whether the `photo` or `video` is set.
-E.g if `video` is not set, the preview will be in the photo resolution. If `video` is set, the preview will be in the video resolution.
+On Android, the Preview will always be in full HD or the Preview View's size, whichever is smaller. If a format is specified, the preview will comply with the format's resolution based on whether the `photo` or `video` is set.  E.g., if `video` is not set, the preview will be in the photo resolution. The preview will be in the video resolution if `video` is set.
 
 ```tsx
 <Camera

--- a/docs/docs/guides/PREVIEW.mdx
+++ b/docs/docs/guides/PREVIEW.mdx
@@ -62,7 +62,8 @@ const lowResolutionFormat = useCameraFormat(device, [
 ])
 ```
 
-On Android, the Preview will always be in full HD or the Preview View's size, whichever is smaller. If a format is specified, the preview will comply with the format's resolution based on whether the `photo` or `video` is set.  E.g., if `video` is not set, the preview will be in the photo resolution. The preview will be in the video resolution if `video` is set.
+On Android, the Preview will always be in full HD or the Preview View's size, whichever is smaller.
+If a format is specified, the preview will try to match the `video`'s resolution and aspect ratio if `video` is enabled, and `photo`'s resolution and aspect ratio if `photo` is enabled.
 
 ```tsx
 <Camera

--- a/docs/docs/guides/PREVIEW.mdx
+++ b/docs/docs/guides/PREVIEW.mdx
@@ -8,8 +8,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 <div class="image-container">
   <svg xmlns="http://www.w3.org/2000/svg" width="283" height="535">
-    <image href={useBaseUrl("img/demo_capture.gif")} x="18" y="33" width="247" height="469" />
-    <image href={useBaseUrl("img/frame.png")} width="283" height="535" />
+    <image href={useBaseUrl('img/demo_capture.gif')} x="18" y="33" width="247" height="469" />
+    <image href={useBaseUrl('img/frame.png')} width="283" height="535" />
   </svg>
 </div>
 
@@ -35,11 +35,7 @@ When starting/stopping the Camera session or when switching Camera devices (e.g.
 To get notified about pauses in the preview view, use the [`onPreviewStarted`](/docs/api/interfaces/CameraProps#onpreviewstarted) and [`onPreviewStopped`](/docs/api/interfaces/CameraProps#onpreviewstopped) events:
 
 ```tsx
-<Camera
-  {...props}
-  onPreviewStarted={() => console.log('Preview started!')}
-  onPreviewStopped={() => console.log('Preview stopped!')}
-/>
+<Camera {...props} onPreviewStarted={() => console.log('Preview started!')} onPreviewStopped={() => console.log('Preview stopped!')} />
 ```
 
 ### Preview Frame Rate (FPS)
@@ -57,12 +53,20 @@ See [FPS](formats#fps) for more information.
 On iOS, the Video resolution also determines the Preview resolution, so if you Camera format has a low Video resolution, your Preview will also be in low resolution:
 
 ```ts
-const lowResolutionFormat = useCameraFormat(device, [
-  { videoResolution: { width: 640, height: 480 } },
-])
+const lowResolutionFormat = useCameraFormat(device, [{ videoResolution: { width: 640, height: 480 } }])
 ```
 
 On Android, the Preview will always be in full HD, or the Preview View's size, whichever is smaller.
+If a format is specified the preview will comply with the format's resolution based on if the `photo` or `video` is set.
+E.g if `video` is not set, the preview will be in the photo resolution. If `video` is set, the preview will be in the video resolution.
+
+```tsx
+<Camera
+  {...props}
+  format={bestFormatForPhoto}
+  photo={true} // Preview will be in the photo resolution
+/>
+```
 
 ### Overlays and Masks
 

--- a/docs/docs/guides/PREVIEW.mdx
+++ b/docs/docs/guides/PREVIEW.mdx
@@ -56,8 +56,7 @@ On iOS, the Video resolution also determines the Preview resolution, so if you C
 const lowResolutionFormat = useCameraFormat(device, [{ videoResolution: { width: 640, height: 480 } }])
 ```
 
-On Android, the Preview will always be in full HD, or the Preview View's size, whichever is smaller.
-If a format is specified the preview will comply with the format's resolution based on if the `photo` or `video` is set.
+On Android, the Preview will always be in full HD or the Preview View's size, whichever is smaller. If a format is specified, the preview will comply with the format's resolution based on whether the `photo` or `video` is set.
 E.g if `video` is not set, the preview will be in the photo resolution. If `video` is set, the preview will be in the video resolution.
 
 ```tsx

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -75,8 +75,8 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
       }
 
       if (format != null) {
-        // If video is disable but photo is enabled, use photoSize
-        val targetSize = if (videoConfig == null) format.photoSize else format.videoSize
+        // Preview will follow video size as it's size & aspect ratio, or photo- if video is disabled.
+        val targetSize = if (videoConfig != null) format.videoSize else format.photoSize
 
         val previewResolutionSelector = ResolutionSelector.Builder()
           .forSize(targetSize)

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Configuration.kt
@@ -75,9 +75,11 @@ internal fun CameraSession.configureOutputs(configuration: CameraConfiguration) 
       }
 
       if (format != null) {
-        // Similar to iOS, Preview will follow video size as it's size (and aspect ratio)
+        // If video is disable but photo is enabled, use photoSize
+        val targetSize = if (videoConfig == null) format.photoSize else format.videoSize
+
         val previewResolutionSelector = ResolutionSelector.Builder()
-          .forSize(format.videoSize)
+          .forSize(targetSize)
           .setAllowedResolutionMode(ResolutionSelector.PREFER_CAPTURE_RATE_OVER_HIGHER_RESOLUTION)
           .build()
         preview.setResolutionSelector(previewResolutionSelector)


### PR DESCRIPTION

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR handles the Android preview based on the format and camera configuration, using the proper resolution if the video output is disabled.

### Use case: I want to see exactly what the final photo will look like in the preview.

To achieve this you can use the selected format and calculate the ratio, then you can render your camera view like this:
```js
const aspectRatio = selectedFormat.photoHeight / selectedFormat.photoWidth; // if sensor is rotated

{
  !!device && (
    <View
      style={{
        width: '100%',
        aspectRatio,
      }}>
      <Camera
        ref={cameraRef}
        style={StyleSheet.absoluteFill}
        device={device}
        isActive={true}
        resizeMode="contain"
        format={selectedFormat}
        photo
      />
    </View>
  );
}
```

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

- This PR sets the preview size based on the camera configuration
- This PR updates the documentation of the preview section

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

- iPhone 15 Pro, iOS 17.6.1
- Android Moto G52, android 13

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
