### PR TITLE
fix: Request the current location if lastKnownLocation is null

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/MetadataProvider.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/MetadataProvider.kt
@@ -39,7 +39,7 @@ class MetadataProvider(val context: Context) : LocationListener {
       locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, UPDATE_INTERVAL_MS, UPDATE_DISTANCE_M, this)
       this.location = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
 
-      if (this.location == null){
+      if (this.location == null) {
         // Request the current location if lastKnownLocation is null
         locationManager.requestSingleUpdate(LocationManager.GPS_PROVIDER, this, null)
       }

--- a/package/android/src/main/java/com/mrousavy/camera/core/MetadataProvider.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/MetadataProvider.kt
@@ -38,6 +38,11 @@ class MetadataProvider(val context: Context) : LocationListener {
       Log.i(TAG, "Start updating location...")
       locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, UPDATE_INTERVAL_MS, UPDATE_DISTANCE_M, this)
       this.location = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
+
+      if (this.location == null){
+        // Request the current location if lastKnownLocation is null
+        locationManager.requestSingleUpdate(LocationManager.GPS_PROVIDER, this, null)
+      }
     } else {
       Log.i(TAG, "Stopping location updates...")
       locationManager.removeUpdates(this)


### PR DESCRIPTION
## What
This PR fixes the issue of photos without location metadata because a new location was not reported yet.
## Changes
* Added a check if lastKnownLocation is null a call to requestSingleUpdate should be made

## Tested on
* Google Pixel 7A - Android 15

## Related issues
Resolves issues from: #2713
