### PR TITLE
fix: camera initialization error (#3179)

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -103,7 +103,13 @@ class CameraSession(internal val context: Context, internal val callback: Callba
     }
     Log.i(TAG, "configure { ... }: Waiting for lock...")
 
-    val provider = cameraProvider.await(mainExecutor)
+    val provider = try {
+      cameraProvider.await(mainExecutor)
+    } catch (error: Throwable) {
+      Log.e(TAG, "Failed to get CameraProvider! Error: ${error.message}", error)
+      callback.onError(error)
+      return
+    }
 
     mutex.withLock {
       // Let caller configure a new configuration for the Camera.

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
@@ -64,7 +64,13 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
     cameraManager.registerAvailabilityCallback(callback, null)
     coroutineScope.launch {
       Log.i(TAG, "Initializing ProcessCameraProvider...")
-      cameraProvider = ProcessCameraProvider.getInstance(reactContext).await(executor)
+      cameraProvider = try {
+        ProcessCameraProvider.getInstance(reactContext).await(executor)
+      } catch (error: Throwable) {
+        Log.e(TAG, "Failed to get CameraProvider! Error: ${error.message}", error)
+        sendAvailableDevicesChangedEvent()
+        return@launch
+      }
       Log.i(TAG, "Initializing ExtensionsManager...")
       extensionsManager = ExtensionsManager.getInstanceAsync(reactContext, cameraProvider!!).await(executor)
       Log.i(TAG, "Successfully initialized!")


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR prevents crashes caused by Android camera initialization exceptions, on devices without cameras.

## Changes

This PR ensures calls to `ProcessCameraProvider.getInstance(reactContext).await(executor)` are safely wrapped in a try-catch statement and logs resulting errors.

Please feel free to make changes to my edits and do with this what you will - really appreciate your work 🙏

## Tested on

### Android simulated device setup to have no cameras

#### Before 🐛

Catastrophic failure, resulting in a crash of the application.

https://github.com/user-attachments/assets/6e906c57-a377-4983-9b56-42c4f69726f2

#### After 🦋

Errors, but the app does not crash.

https://github.com/user-attachments/assets/447696f6-b626-46c9-b9d5-42bcf892b996

### Samsung SM-X110 (has a camera, to test the happy case).

#### Before 🐛

No initialisation issues.

#### After 🦋

Still no initialisation issues.

https://github.com/user-attachments/assets/25079f14-7824-4a89-ab71-501a4b5b623c

## Related issues

Fixes #3179