### PR TITLE
Enhance photo size retrieval by combining high-resolution and standard resolutions

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -121,7 +121,7 @@ class CameraDeviceDetails(private val cameraInfo: CameraInfo, extensionsManager:
       try {
         val qualities = videoCapabilities.getSupportedQualities(dynamicRange)
         val videoSizes = qualities.map { it as ConstantQuality }.flatMap { it.typicalSizes }
-        val photoSizes = cameraInfoInternal.getSupportedResolutions(ImageFormat.JPEG)
+        val photoSizes = (cameraInfoInternal.getSupportedHighResolutions(ImageFormat.JPEG) union cameraInfoInternal.getSupportedResolutions(ImageFormat.JPEG)).toList()
         val fpsRanges = cameraInfo.supportedFrameRateRanges
         val minFps = fpsRanges.minOf { it.lower }
         val maxFps = fpsRanges.maxOf { it.upper }


### PR DESCRIPTION


<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR exposes all possible photo resolutions for Android devices. Some Android devices do not expose all resolutions 
  
When we check the sizes coming only from `getSupportedResolutions` the highest resolution ("4080x3072") is not there

- Example:

| cameraInfoInternal.getSupportedResolutions(ImageFormat.JPEG) |
|--------|
| <img width="845" alt="Screenshot 2025-01-31 at 14 32 53" src="https://github.com/user-attachments/assets/def08454-0513-4530-b912-e06ca808f502" /> | 

 <br>  <br>  

But when we use the `getSupportedHighResolutions` we can get it

- Example:

| cameraInfoInternal.getSupportedHighResolutions(ImageFormat.JPEG) |
|--------|
| <img width="839" alt="Screenshot 2025-01-31 at 14 32 33" src="https://github.com/user-attachments/assets/a57df2de-e057-49b4-a4b1-f3f2dbcf8e2d" /> |

 <br>  <br>   

So if we combine and remove the duplicates we can the all sizes possible

- Example:

| combined |
|--------|
| <img width="1496" alt="Screenshot 2025-01-31 at 14 31 49" src="https://github.com/user-attachments/assets/8334058b-af09-42a6-ae85-6a4aa60c9909" /> |


<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

This PR combines the highest and standard photo resolutions

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

Moto G52, Android 13

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

