### PR TITLE
fix: React Native 77 Android build failure (#3380)

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -191,6 +191,9 @@ dependencies {
   implementation "androidx.camera:camera-view:${camerax_version}"
   implementation "androidx.camera:camera-extensions:${camerax_version}"
 
+  // Lifecycle dependency
+  implementation "androidx.lifecycle:lifecycle-common:2.8.7"
+
   // Some Coroutines extension functions
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -90,7 +90,8 @@ class CameraSession(internal val context: Context, internal val callback: Callba
     }
   }
 
-  override fun getLifecycle(): Lifecycle = lifecycleRegistry
+  override val lifecycle: Lifecycle
+    get() = lifecycleRegistry
 
   /**
    * Configures the [CameraSession] with new values in one batch.


### PR DESCRIPTION
## What

This PR fixes an Android build failure that occurs when using `react-native-vision-camera@4.6.3` (latest) in a React Native 77 project
- React Native 77 bumped the `compileSdkVersion` from 34 to 35, which includes breaking changes to `androidx.lifecycle`, which caused the build failure

## Changes

- Update `lifecycle` override in [`CameraSession`](https://github.com/mrousavy/react-native-vision-camera/blob/b687014a1477fb9b9ebbea1c905a220c2f2bc944/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt#L93) from `fun` to `val`
    - The `androidx.lifecycle` [`2.6.0-beta01` release notes](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.0-beta01) discuss the breaking change from `fun` to `val`
        > `LifecycleOwner` is now written in Kotlin. This is a **source incompatible change** for classes written in Kotlin - they must now override the `lifecycle` property rather than implementing the previous `getLifecycle()` function.
- Add a `build.gradle` dependency on `androidx.lifecycle:lifecycle-common:2.8.7`, so that the change remains backwards compatible with RN <77
    - [`2.8.7`](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7) is the latest stable `androidx.lifecycle` release
    - [`2.6.0`](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.0) is the first release that handles the breaking change
    - So theoretically I could have used `androidx.lifecycle:lifecycle-common:2.6.0` instead of `2.8.7`
        - If you'd prefer to use `2.6.0` instead of `2.8.7`, I'm happy to update this PR

## Tested on

- Android emulator

## Related issues

- Based on the work in https://github.com/mrousavy/react-native-vision-camera/pull/3376
- Based on the work in https://github.com/mrousavy/react-native-vision-camera/pull/3382
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3380