### PR TITLE
fix: Fix orientation updating to `portrait` when phone is flat

### DIFF
--- a/package/ios/Core/Extensions/CMAccelerometerData+deviceOrientation.swift
+++ b/package/ios/Core/Extensions/CMAccelerometerData+deviceOrientation.swift
@@ -10,9 +10,10 @@ import Foundation
 
 extension CMAccelerometerData {
   /**
-   Get the current device orientation from the given acceleration/gyro data.
+   Get the current device orientation from the given acceleration/gyro data, or `nil` if it is unknown.
+   The orientation can only be unknown if the phone is flat, in which case it is not clear which orientation the phone is held in.
    */
-  var deviceOrientation: Orientation {
+  var deviceOrientation: Orientation? {
     let acceleration = acceleration
     let xNorm = abs(acceleration.x)
     let yNorm = abs(acceleration.y)

--- a/package/ios/Core/OrientationManager.swift
+++ b/package/ios/Core/OrientationManager.swift
@@ -161,7 +161,8 @@ final class OrientationManager {
     stopDeviceOrientationListener()
     if motionManager.isAccelerometerAvailable {
       motionManager.accelerometerUpdateInterval = 0.2
-      motionManager.startAccelerometerUpdates(to: operationQueue) { accelerometerData, error in
+      motionManager.startAccelerometerUpdates(to: operationQueue) { [weak self] accelerometerData, error in
+        guard let self else { return }
         if let error {
           VisionLogger.log(level: .error, message: "Failed to get Accelerometer data! \(error)")
         }

--- a/package/ios/Core/OrientationManager.swift
+++ b/package/ios/Core/OrientationManager.swift
@@ -166,7 +166,11 @@ final class OrientationManager {
           VisionLogger.log(level: .error, message: "Failed to get Accelerometer data! \(error)")
         }
         if let accelerometerData {
-          self.deviceOrientation = accelerometerData.deviceOrientation
+          // There  is accelerometer data available
+          if let deviceOrientation = accelerometerData.deviceOrientation {
+            // The orientation can actually be determined - it is not `nil` (flat)! Update it
+            self.deviceOrientation = deviceOrientation
+          }
         }
       }
     }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Previously, when the phone is flat, `outputOrientation` would be updated to `'portrait'` - which is not correct since it can also be landscape before the phone is being laid flat.

Instead, we now return `nil` if the orientation is flat, since it is not known how the user is holding the phone. In other words, we skip an orientation update for flat now.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
