### PR TITLE
fix: Don't send `onOrientationChanged` event if phone is flat on Android

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/OrientationManager.kt
@@ -36,6 +36,10 @@ class OrientationManager(private val context: Context, private val callback: Cal
   private val orientationListener = object : OrientationEventListener(context) {
     override fun onOrientationChanged(rotationDegrees: Int) {
       // Phone rotated!
+      if (rotationDegrees == OrientationEventListener.ORIENTATION_UNKNOWN) {
+        // phone is laying flat - orientation is unknown! Avoid sending out event.
+        return
+      }
       deviceRotation = degreesToSurfaceRotation(rotationDegrees)
       maybeNotifyOrientationChanged()
     }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Same as https://github.com/mrousavy/react-native-vision-camera/pull/3423, but for Android.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
