### PR TITLE
fix(android): crash due to focus management

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+Focus.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+Focus.kt
@@ -15,5 +15,7 @@ suspend fun CameraView.focus(pointMap: ReadableMap) {
     val dp = Resources.getSystem().displayMetrics.density
     previewView.meteringPointFactory.createPoint(x.toFloat() * dp, y.toFloat() * dp)
   }
-  cameraSession.focus(point)
+  try {
+    cameraSession.focus(point)
+  } catch (e: Exception) {}
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md

Trying not to be an asshole 😆 

-->

## What
This PR fixes random crash found on pixel 8a while using qrcode scanner and modifying focus in parallel.
Unfortunatly, I don't have clear scenario to reproduce it, but a code review clearly hightlight an uncatched exception.

## Changes

This PR just catch the exception to avoid application crash.
If you think a better solution is possible (catching the error somewhere else, throwing a message to client or adding a log), just let me know

## Tested on
Issue hasn't been reproduced on pixel 8a (no other issue found)

## Related issues

fix: https://github.com/mrousavy/react-native-vision-camera/issues/3475

