### PR TITLE
fix: Error building assembleDebug assembleAndroidTest: '2 files found…

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -173,7 +173,8 @@ android {
             "**/libreactnativejni.so",
             "**/libturbomodulejsijni.so",
             "**/libreact_nativemodule_core.so",
-            "**/libjscexecutor.so"
+            "**/libjscexecutor.so",
+            "**/libhermestooling.so"
     ]
   }
 }


### PR DESCRIPTION
… with path 'lib/arm64-v8a/libhermestooling.so' from inputs'

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR Fixes the followinfg Error

Error building assembleDebug assembleAndroidTest: "2 files found with path 'lib/arm64-v8a/libhermestooling.so' from inputs #3540
<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes
This PR changes the **`packagingOptions`** in _`android/build.gradle`_ adding `"**/libhermestooling.so"` in **`excludes`** array.
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

    
    
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
Fixes #3540 
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
