### PR TITLE
feat: Enable 16 KB page size on Android

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -133,7 +133,8 @@ android {
         cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
         arguments "-DANDROID_STL=c++_shared",
                 "-DNODE_MODULES_DIR=${nodeModules}",
-                "-DENABLE_FRAME_PROCESSORS=${enableFrameProcessors ? "ON" : "OFF"}"
+                "-DENABLE_FRAME_PROCESSORS=${enableFrameProcessors ? "ON" : "OFF"}",
+                "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
       }
     }


### PR DESCRIPTION
Enables support for 16 KB page sizes on Android.

See [Support 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes) for more information.