### PR TITLE
fix(android): no camera devices on app start

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
@@ -59,9 +59,8 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
 
   override fun getName(): String = TAG
 
-  override fun initialize() {
-    super.initialize()
-    cameraManager.registerAvailabilityCallback(callback, null)
+  // Init cameraProvider + manager as early as possible
+  init {
     coroutineScope.launch {
       try {
         Log.i(TAG, "Initializing ProcessCameraProvider...")
@@ -74,6 +73,12 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
       }
       sendAvailableDevicesChangedEvent()
     }
+  }
+
+  // Note: initialize() will be called after getConstants on new arch!
+  override fun initialize() {
+    super.initialize()
+    cameraManager.registerAvailabilityCallback(callback, null)
   }
 
   override fun invalidate() {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

I was looking at a bug where no camera devices were returned, however, getting them later I was getting values:

<img width="1684" height="260" alt="CleanShot_2025-07-14_at_11 53 482x" src="https://github.com/user-attachments/assets/ba1c83c2-47b4-4a03-a27b-e69eb26024f5" />

<img width="553" height="209" alt="CleanShot_2025-07-14_at_11 53 45" src="https://github.com/user-attachments/assets/c3b4b282-fe89-44de-a30b-d27bcae40252" />

This resulted in the camera never displaying


## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->
**Problem:**

- Before we init the `cameraProvider` in `onInitialize()`
- In our app code however we request the camera devices through the native module's constants
- `getConstants()` will be called _before_ `onInitialize()` so we just return an empty camera list
- As the camera devices never changed no new event would be emitted that would refresh the devices list

**Solution:**

- Move the `cameraProvider` + `manager` to the init which will be called earlier, react context should be present at this point as its a constructor arg 
- This way when `getConstants` gets called we can get the devices, which fixes the. problem
- I kept `cameraManager.registerAvailabilityCallback` in `onInitialize()` as this needs to the looper, which we don't have available in `init` (at least on new arch as its init from a bg thread) 

**Note:** I am wondering if this is a performance improvement as well, as before I assume something as:

- getCameraDevices: []
- event emitted which camera devices changed emitted
- getCameraDevices: [...]

So first frame time might be faster? 🤷 


## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

- Samsung S23

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

Not sure, haven't checked
