### PR TITLE
fix:- Fix build for RN 0.81

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraViewManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraViewManager.kt
@@ -27,7 +27,7 @@ class CameraViewManager : ViewGroupManager<CameraView>() {
     view.update()
   }
 
-  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? =
+  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? =
     MapBuilder.builder<String, Any>()
       .put(CameraViewReadyEvent.EVENT_NAME, MapBuilder.of("registrationName", "onViewReady"))
       .put(CameraInitializedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onInitialized"))

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraViewModule.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraViewModule.kt
@@ -189,7 +189,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
   }
 
   private fun canRequestPermission(permission: String): Boolean {
-    val activity = currentActivity as? PermissionAwareActivity
+    val activity = reactApplicationContext.currentActivity as? PermissionAwareActivity
     return activity?.shouldShowRequestPermissionRationale(permission) ?: false
   }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
Fixes build issue on RN 0.81.0
<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes
This PR changes Mutable Map to Map . I think the type has been changed when this was migrated to Kotlin (https://github.com/facebook/react-native/pull/51626)

Also changes `currentActivity` to `reactApplicationContext.currentActivity` to fix build
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->
This is build issue
## Related issues
N/A
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
